### PR TITLE
[Modified] opencelium.service

### DIFF
--- a/conf/opencelium.service
+++ b/conf/opencelium.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=OpenCelium API Hub
 After=syslog.target network.target
+StartLimitIntervalSec=30
+StartLimitBurst=3
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
Improve systemd service to prevent restart loops on failure.

When OpenCelium fails to start for some reason, the service enters a bootloop. The bootloop prevents monitoring systems, like checkmk for example, to register the stopped service. This results in undetected service failures.

Example:


`journalctl -u opencelium.service -f`

```
Feb 18 11:36:32 hnopencelium systemd[1]: opencelium.service: Main process exited, code=exited, status=1/FAILURE
Feb 18 11:36:32 hnopencelium systemd[1]: opencelium.service: Failed with result 'exit-code'.
Feb 18 11:36:32 hnopencelium systemd[1]: opencelium.service: Consumed 17.927s CPU time.
Feb 18 11:36:37 hnopencelium systemd[1]: opencelium.service: Scheduled restart job, restart counter is at 7.
Feb 18 11:36:37 hnopencelium systemd[1]: Stopped opencelium.service - OpenCelium API Hub.
Feb 18 11:36:37 hnopencelium systemd[1]: opencelium.service: Consumed 17.927s CPU time.
Feb 18 11:36:37 hnopencelium systemd[1]: Started opencelium.service - OpenCelium API Hub.
```

`systemctl show opencelium.service -p NRestarts`

```
NRestarts=58
```
By setting a limit to the restarts, this bootloop doesn't happen and checkmk can register the stopped service.
(This solution is based on the example in the redhead blog-post: https://www.redhat.com/en/blog/systemd-automate-recovery)

Example:

`systemctl list-units --state failed`

```
  UNIT               LOAD   ACTIVE SUB    DESCRIPTION       
● opencelium.service loaded failed failed OpenCelium API Hub

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.
```
![Checkmk](https://github.com/user-attachments/assets/b2a4a310-f762-473d-959e-598ee301443e)
