### PR TITLE
Fixed a bug with setting current version when uploading templates

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/FileController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/FileController.java
@@ -111,7 +111,7 @@ public class FileController {
         this.invokerServiceImp = invokerServiceImp;
         this.storageService = storageService;
         this.connectorMapper = connectorMapper;
-        templateUpdater = versionManager.getUpdater(Template.class);
+        this.templateUpdater = versionManager.getUpdater(Template.class);
         this.ocProps = ocProps;
     }
 
@@ -564,9 +564,11 @@ public class FileController {
 
     private void updateTemplate(Template template){
         try {
-            Wrapper<Template> updated = templateUpdater.updateToCurrentVersion(template);
-            template.setVersion(updated.getNewVersion());
-            log.info("Template[id={}, name={}] is successfully updated to {} version", template.getTemplateId(), template.getName(), ocProps.getVersion());
+            templateUpdater.updateToCurrentVersion(template)
+                    .ifUpdated(temp -> {
+                        log.info("Template[id={}, name={}] is successfully updated to {} version", template.getTemplateId(), template.getName(), ocProps.getVersion());
+                    });
+            template.setVersion(ocProps.getVersion());
         } catch (Exception e) {
             log.error("Failed to update Template[id={}, name={}]", template.getTemplateId(), template.getName(), e);
             throw new RuntimeException("INVALID_TEMPLATE");


### PR DESCRIPTION
Bug: after updating template, I had set `template.setVersion(updated.getNewVersion())` which can be less that current actual version. Because we don't create updater class for each version(e.g. currently we use 4.4 version's updater for 4.5+ versions as well), so updated.getNewVersion() is not equal to current version always. We need to set `ocProps.getVersion()`