### PR TITLE
Fixed a bug related to updating already updated connection

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/base/Version43Utils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/base/Version43Utils.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 public class Version43Utils {
 
     private static final Pattern REFERENCE_REGEX = Pattern.compile("#[a-zA-Z0-9]{6}\\.(\\(response\\)|\\(request\\))\\.[^;]*");
-    private static final Pattern REQUEST_PATTERN = Pattern.compile("^(#\\w+)\\.(\\(request\\))\\.(.+)$");
+    private static final Pattern REQUEST_PATTERN = Pattern.compile("^(#\\w+)\\.(\\(request\\))\\.(?!body\\.\\$|header\\.\\$)(.+)$");
     private static final Pattern RESPONSE_PATTERN = Pattern.compile("^(#\\w+)\\.(\\(response\\))\\.(success|fail)\\.(.+)$");
 
     public static String updateRef(String rawStr) {


### PR DESCRIPTION
Bug: When your connection's version is actually greater than or equal to 4.3(Introducing new reference structure) but it's version field is null or accidently set a value less than 4.3 then the updater tries to update it again including references in it.

Fix: Used more strict regex for distinguish between new and old references so that even your connection or template's version is old but it has some reference in new format then they won't be updated