### PR TITLE
Fixed issue with parsing numbers larger than 32-bit integers

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ValueUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ValueUtils.java
@@ -4,7 +4,8 @@ import java.math.BigDecimal;
 
 public class ValueUtils {
 
-    private ValueUtils() {}
+    private ValueUtils() {
+    }
 
     public static double compareTo(Number n1, Number n2) {
         if (n1 == null || n2 == null) return n1 == null ? -n2.doubleValue() : n1.doubleValue();
@@ -45,10 +46,18 @@ public class ValueUtils {
         } else if (o instanceof Double d) {
             return d;
         } else if (o instanceof String number) {
-            if (number.contains(".")) {
-                return Double.parseDouble(number);
+            BigDecimal bd;
+            try {
+                bd = new BigDecimal(number.trim());
+
+                if (bd.abs().compareTo(BigDecimal.valueOf(Double.MAX_VALUE)) > 0) {
+                    throw new RuntimeException("Value exceeds : " + number);
+                }
+
+                return bd;
+            } catch (Exception e) {
+                throw new RuntimeException("Cannot convert " + o + " to a number");
             }
-            return Integer.parseInt(number);
         }
         throw new RuntimeException("Cannot convert " + o + " to a number");
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ValueUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ValueUtils.java
@@ -19,6 +19,15 @@ public class ValueUtils {
     }
 
     public static boolean isNumberStr(String element) {
+        if (element == null || element.trim().isEmpty()) {
+            return false;
+        }
+
+        // Reject numbers with leading zeros (except "0" or decimal formats like "0.5")
+        if (element.matches("^-?0[0-9]+.*")) {
+            return false;
+        }
+
         BigDecimal bigDecimal;
         try {
             bigDecimal = new BigDecimal(element);


### PR DESCRIPTION
Bug: `ValueUtils.isNumber()` considers any string number in the range from `Double.MIN_VALUE` to `Double.MAX_VALUE` as a valid number. However, `ValueUtils.compareTo()` only supports non-floating-point numbers within the `Integer.MIN_VALUE` to `Integer.MAX_VALUE` range.

Fix: `ValueUtils.compareTo()` has been updated to strictly handle only those inputs for which `ValueUtils.isNumber()` returns `true`
<img width="812" height="295" alt="image" src="https://github.com/user-attachments/assets/a341bf81-b028-42bf-a240-460830a9c94c" />

