### PR TITLE
Fixed handling direct body in old templates

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/Template40Updater.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/Template40Updater.java
@@ -1,38 +1,41 @@
 package com.becon.opencelium.backend.version_manager.template;
 
-import com.becon.opencelium.backend.mapper.others.FieldBindingOldDTOMapper;
-import com.becon.opencelium.backend.mapper.others.MethodOldDTOMapper;
 import com.becon.opencelium.backend.mapper.others.OperatorOldDTOMapper;
-import com.becon.opencelium.backend.resource.connection.old.MethodOldDTO;
+import com.becon.opencelium.backend.resource.connection.MethodDTO;
 import com.becon.opencelium.backend.resource.connection.old.OperatorOldDTO;
+import com.becon.opencelium.backend.resource.connector.BodyDTO;
+import com.becon.opencelium.backend.resource.connector.RequestDTO;
+import com.becon.opencelium.backend.resource.connector.ResponseDTO;
+import com.becon.opencelium.backend.resource.connector.ResultDTO;
 import com.becon.opencelium.backend.resource.template.CtionTemplateResource;
 import com.becon.opencelium.backend.template.entity.Template;
 import com.becon.opencelium.backend.version_manager.EntityUpdater;
 import com.becon.opencelium.backend.version_manager.Wrapper;
 import com.becon.opencelium.backend.version_manager.base.UpdaterVersion;
 import com.becon.opencelium.backend.version_manager.base.Utils;
+import com.becon.opencelium.backend.version_manager.template.domains.MethodWithDirectBody;
+import com.becon.opencelium.backend.version_manager.template.domains.RequestWithDirectBody;
+import com.becon.opencelium.backend.version_manager.template.domains.ResponseWithDirectBody;
+import com.becon.opencelium.backend.version_manager.template.domains.ResultWithDirectBody;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Component
 public class Template40Updater implements EntityUpdater<Template> {
 
     private final ObjectMapper objectMapper;
-    private final MethodOldDTOMapper methodOldDTOMapper;
     private final OperatorOldDTOMapper operatorOldDTOMapper;
-    private final FieldBindingOldDTOMapper fieldBindingOldDTOMapper;
 
     private final UpdaterVersion updaterVersion = UpdaterVersion.VERSION_4_0;
 
-    public Template40Updater(ObjectMapper objectMapper, MethodOldDTOMapper methodOldDTOMapper, OperatorOldDTOMapper operatorOldDTOMapper, FieldBindingOldDTOMapper fieldBindingOldDTOMapper) {
+    public Template40Updater(ObjectMapper objectMapper, OperatorOldDTOMapper operatorOldDTOMapper) {
         this.objectMapper = objectMapper;
-        this.methodOldDTOMapper = methodOldDTOMapper;
         this.operatorOldDTOMapper = operatorOldDTOMapper;
-        this.fieldBindingOldDTOMapper = fieldBindingOldDTOMapper;
     }
 
     @Override
@@ -49,9 +52,10 @@ public class Template40Updater implements EntityUpdater<Template> {
         CtionTemplateResource connection = template.getConnection();
 
         if (Objects.nonNull(connection.getFromConnector().getMethods())) {
-            List<MethodOldDTO> fromMethods = objectMapper.convertValue(connection.getFromConnector().getMethods(), new TypeReference<>() {
+            List<MethodWithDirectBody> fromMethods = objectMapper.convertValue(connection.getFromConnector().getMethods(), new TypeReference<>() {
             });
-            connection.getFromConnector().setMethods(methodOldDTOMapper.toEntityAll(fromMethods));
+
+            connection.getFromConnector().setMethods(resolveMethods(fromMethods));
         }
         if (Objects.nonNull(connection.getFromConnector().getOperators())) {
             List<OperatorOldDTO> fromOperators = objectMapper.convertValue(connection.getFromConnector().getOperators(), new TypeReference<>() {
@@ -59,9 +63,10 @@ public class Template40Updater implements EntityUpdater<Template> {
             connection.getFromConnector().setOperators(operatorOldDTOMapper.toEntityAll(fromOperators));
         }
         if (Objects.nonNull(connection.getToConnector().getMethods())) {
-            List<MethodOldDTO> toMethods = objectMapper.convertValue(connection.getToConnector().getMethods(), new TypeReference<>() {
+            List<MethodWithDirectBody> toMethods = objectMapper.convertValue(connection.getToConnector().getMethods(), new TypeReference<>() {
             });
-            connection.getToConnector().setMethods(methodOldDTOMapper.toEntityAll(toMethods));
+
+            connection.getToConnector().setMethods(resolveMethods(toMethods));
         }
         if (Objects.nonNull(connection.getToConnector().getOperators())) {
             List<OperatorOldDTO> toOperators = objectMapper.convertValue(connection.getToConnector().getOperators(), new TypeReference<>() {
@@ -73,5 +78,87 @@ public class Template40Updater implements EntityUpdater<Template> {
                 .changed(true)
                 .withOldVersion(oldVersion)
                 .withNewVersion(updaterVersion.getVersion());
+    }
+
+    private Object resolveMethods(List<MethodWithDirectBody> methods) {
+        if (methods == null || methods.isEmpty())
+            return methods;
+
+        return methods.stream()
+                .map(method -> {
+                    MethodDTO methodDTO = new MethodDTO();
+
+                    methodDTO.setId(method.getNodeId());
+                    methodDTO.setName(method.getName());
+                    methodDTO.setColor(method.getColor());
+                    methodDTO.setLabel(method.getLabel());
+                    methodDTO.setIndex(method.getIndex());
+                    methodDTO.setDataAggregator(method.getDataAggregator());
+                    methodDTO.setRequest(resolveRequest(method.getRequest()));
+                    methodDTO.setResponse(resolveResponse(method.getResponse()));
+
+                    return methodDTO;
+                })
+                .toList();
+    }
+
+    private ResponseDTO resolveResponse(ResponseWithDirectBody response) {
+        ResponseDTO responseDTO = new ResponseDTO();
+
+        responseDTO.setFail(resolveResult(response.getFail()));
+        responseDTO.setSuccess(resolveResult(response.getSuccess()));
+
+        return responseDTO;
+    }
+
+    private RequestDTO resolveRequest(RequestWithDirectBody request) {
+        RequestDTO requestDTO = new RequestDTO();
+
+        requestDTO.setEndpoint(request.getEndpoint());
+        requestDTO.setMethod(request.getMethod());
+        requestDTO.setHeader(request.getHeader());
+        requestDTO.setBody(resolveBody(request.getBody()));
+
+        return requestDTO;
+    }
+
+    private ResultDTO resolveResult(ResultWithDirectBody result) {
+        ResultDTO resultDTO = new ResultDTO();
+
+        resultDTO.setStatus(result.getStatus());
+        resultDTO.setHeader(result.getHeader());
+        resultDTO.setBody(resolveBody(result.getBody()));
+
+        return resultDTO;
+    }
+
+    private BodyDTO resolveBody(Map<String, Object> body) {
+        if (body == null) {
+            return null;
+        }
+
+        BodyDTO bodyDTO = new BodyDTO();
+        if (body.containsKey("type")
+                && body.containsKey("format")
+                && body.containsKey("data") &&
+                body.containsKey("fields")) {
+            // normal body
+
+            bodyDTO.setType(body.get("type").toString());
+            bodyDTO.setFormat(body.get("format").toString());
+            bodyDTO.setData(body.get("data").toString());
+
+            bodyDTO.setFields((Map<String, Object>) body.get("fields"));
+        } else {
+            // direct body, without 'type', 'format', 'raw' and 'fields' fields
+
+            // set default values
+            bodyDTO.setType("object");
+            bodyDTO.setFormat("json");
+            bodyDTO.setData("raw");
+
+            bodyDTO.setFields(body);
+        }
+        return bodyDTO;
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/MethodWithDirectBody.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/MethodWithDirectBody.java
@@ -1,0 +1,76 @@
+package com.becon.opencelium.backend.version_manager.template.domains;
+
+public class MethodWithDirectBody {
+    private String nodeId;
+    private String index;
+    private String name;
+    private String color;
+    private String label;
+    private Integer dataAggregator;
+    private RequestWithDirectBody request;
+    private ResponseWithDirectBody response;
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public void setIndex(String index) {
+        this.index = index;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public RequestWithDirectBody getRequest() {
+        return request;
+    }
+
+    public void setRequest(RequestWithDirectBody request) {
+        this.request = request;
+    }
+
+    public ResponseWithDirectBody getResponse() {
+        return response;
+    }
+
+    public void setResponse(ResponseWithDirectBody response) {
+        this.response = response;
+    }
+
+    public Integer getDataAggregator() {
+        return dataAggregator;
+    }
+
+    public void setDataAggregator(Integer dataAggregator) {
+        this.dataAggregator = dataAggregator;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/RequestWithDirectBody.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/RequestWithDirectBody.java
@@ -1,0 +1,43 @@
+package com.becon.opencelium.backend.version_manager.template.domains;
+
+import java.util.Map;
+
+public class RequestWithDirectBody {
+
+    private String endpoint;
+    private String method;
+    private Map<String, String> header;
+    private Map<String, Object> body;
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public Map<String, String> getHeader() {
+        return header;
+    }
+
+    public void setHeader(Map<String, String> header) {
+        this.header = header;
+    }
+
+    public Map<String, Object> getBody() {
+        return body;
+    }
+
+    public void setBody(Map<String, Object> body) {
+        this.body = body;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/ResponseWithDirectBody.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/ResponseWithDirectBody.java
@@ -1,0 +1,27 @@
+package com.becon.opencelium.backend.version_manager.template.domains;
+
+public class ResponseWithDirectBody {
+    private String name = "response";
+    private ResultWithDirectBody success;
+    private ResultWithDirectBody fail;
+
+    public String getName() {
+        return name;
+    }
+
+    public ResultWithDirectBody getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(ResultWithDirectBody success) {
+        this.success = success;
+    }
+
+    public ResultWithDirectBody getFail() {
+        return fail;
+    }
+
+    public void setFail(ResultWithDirectBody fail) {
+        this.fail = fail;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/ResultWithDirectBody.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/template/domains/ResultWithDirectBody.java
@@ -1,0 +1,34 @@
+package com.becon.opencelium.backend.version_manager.template.domains;
+
+import java.util.Map;
+
+public class ResultWithDirectBody {
+
+    private String status;
+    private Map<String, String> header;
+    private Map<String, Object> body;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Map<String, String> getHeader() {
+        return header;
+    }
+
+    public void setHeader(Map<String, String> header) {
+        this.header = header;
+    }
+
+    public Map<String, Object> getBody() {
+        return body;
+    }
+
+    public void setBody(Map<String, Object> body) {
+        this.body = body;
+    }
+}


### PR DESCRIPTION
Bug: In old templates, there are two types of body : 
1. with `type`, `format`, `data`, `fields` fields on body
2. without them - direct
Even there are two templates with one  - 2.0 version having different body format:
<img width="595" height="262" alt="image" src="https://github.com/user-attachments/assets/f023b682-3d0c-466e-a8ca-d4f8286d7e89" />
<img width="689" height="256" alt="image" src="https://github.com/user-attachments/assets/a59cd1d5-9a61-4401-a26a-7b41123764f8" />

Fix: set default values for `type = object`, `format = json`, `data = raw` for those templates