### PR TITLE
Fixed updating multiple references in endpoint: enhanced regex

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/base/Version43Utils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/version_manager/base/Version43Utils.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 
 public class Version43Utils {
 
-    private static final Pattern REFERENCE_REGEX = Pattern.compile("#[a-zA-Z0-9]{6}\\.(\\(response\\)|\\(request\\))\\.[^;]*");
+    private static final Pattern REFERENCE_REGEX = Pattern.compile("#[a-zA-Z0-9]{6}\\.(\\(response\\)|\\(request\\))\\..*?(?=;|%}|$)");
     private static final Pattern REQUEST_PATTERN = Pattern.compile("^(#\\w+)\\.(\\(request\\))\\.(?!body\\.\\$|header\\.\\$)(.+)$");
     private static final Pattern RESPONSE_PATTERN = Pattern.compile("^(#\\w+)\\.(\\(response\\))\\.(success|fail)\\.(.+)$");
 


### PR DESCRIPTION
Bug: In the reference regex, there is a seperator for determining the ending of a reference in case of severeal references in one string. This seperator plays key role because of a reference hasn't any specific identifier that indicates the ending of a reference and we need to know the ending of references to seperate references in one string. So far, I used only `;` seperator because multiple references in body, enhancement are seperated by `;`. But it don't work with multiple direct references in endpoint.

Fix: Since direct references in endpoint will be wrapped by `{%%}` we can use `%` seperator.