### PR TITLE
OC-1204 Fixed a bug with '%' and '\n' on DenyList

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/DenyList.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/DenyList.java
@@ -6,24 +6,34 @@ import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
 
 import java.util.List;
-import java.util.Objects;
 
 public class DenyList implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
         if (o2 instanceof String) {
-            String[] split = ((String) o2).split(",");
-            for (String s : split) {
-                if (Objects.equals(s, o1.toString()))
+            String[] split = ((String) o2).replaceAll("\n", ",").split(",");
+            Like like = new Like();
+
+            for (String value : split) {
+                Object result = like.apply(o1.toString(), value);
+                if (Boolean.TRUE.equals(result)) {
                     return false;
+                }
             }
+
             return true;
         }
-        if (o1 instanceof String val && o2 instanceof List<?> list) {
-            for (Object o : list) {
-                if (Objects.equals(o, val))
+
+        if (o1 instanceof String && o2 instanceof List<?> list) {
+            Like like = new Like();
+
+            for (Object value : list) {
+                Object result = like.apply(o1.toString(), value);
+                if (Boolean.TRUE.equals(result)) {
                     return false;
+                }
             }
+
             return true;
         }
         throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/MatchesInList.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/MatchesInList.java
@@ -1,12 +1,10 @@
 package com.becon.opencelium.backend.ocel.operator.operators;
 
-import com.becon.opencelium.backend.execution.operator.Like;
 import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
 import com.becon.opencelium.backend.ocel.operator.BinaryOperator;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class MatchesInList implements BinaryOperator {
@@ -15,11 +13,27 @@ public class MatchesInList implements BinaryOperator {
         if (o2 instanceof String) {
             String[] values = o2.toString().replace("\n", ",").split(",");
             Like like = new Like();
-            return Arrays.stream(values).anyMatch(v -> like.apply(o1.toString(), v));
+
+            for (String value : values) {
+                Object result = like.apply(o1.toString(), value);
+                if (Boolean.TRUE.equals(result)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
+
         if (o1 instanceof String && o2 instanceof List<?> list) {
             Like like = new Like();
-            return list.stream().anyMatch(v -> like.apply(o1, v));
+            for (Object value : list) {
+                Object result = like.apply(o1.toString(), value);
+                if (Boolean.TRUE.equals(result)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
         throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
     }


### PR DESCRIPTION
1. DenyList: Added support for '%' and '\n' signs on DenyList
2. MatchesInList: there was wrong import path of Like operator.