### PR TITLE
[OC-1212]  Delete old log files by executionId (in case of dropping DB)

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/OcLogger.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/OcLogger.java
@@ -47,6 +47,9 @@ public class OcLogger<T extends LogMessage> {
         this.connectionId = connectionId;
         this.logEntity = logEntity;
 
+        // delete existing log files with the same 'executionId'
+        LogFileUtility.deleteByExecutionId(executionId);
+
         // set up the logger to create temporary log file in base log directory: type = u (uncategorized), not s (success) or f (fail):
         String loggerId = String.format("%d-%d", executionId, connectionId);
         String filename = LogFileUtility.toFilename(timestamp, connectionId, "u", executionId, "log");

--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/LogFileUtility.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/LogFileUtility.java
@@ -12,7 +12,13 @@ import org.springframework.http.MediaType;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.*;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -98,6 +104,33 @@ public class LogFileUtility {
                     return FileVisitResult.CONTINUE;
                 }
             });
+        }
+    }
+
+    public static void deleteByExecutionId(long executionId) {
+        Path logFolder = toPath(LOG_LOCATION);
+
+        try (Stream<Path> stream = Files.walk(logFolder)) {
+            stream
+                    .filter(Files::isRegularFile)
+                    .filter(p -> {
+                        String filename = p.getFileName().toString();
+
+                        if (!filename.matches(LOG_FILE_NAME_RGX)) return false;
+
+                        int start = filename.lastIndexOf('_');
+                        int end = filename.lastIndexOf('.');
+                        long fileExecutionId = Long.parseLong(filename.substring(start + 1, end));
+
+                        return fileExecutionId == executionId;
+                    })
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {}
+                    });
+        } catch (IOException e) {
+            log.warn("Failed to delete old log files by executionId", e);
         }
     }
 


### PR DESCRIPTION
Resolves: [[OC-1212]  Delete old log files by executionId (in case of dropping DB)](https://becon.atlassian.net/browse/OC-1212)