### PR TITLE
[OC-1244] Fixed a bug with double-action-operations(rename, move)

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/migrate/YAMLMigrator.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/migrate/YAMLMigrator.java
@@ -176,24 +176,9 @@ public class YAMLMigrator {
                 patched = PATCH_HELPER.patch(singleJsonPatch, patched, Object.class);
                 changeSet.setSuccess(true);
             } catch (RuntimeException e) {
-                if (e.getCause() != null && (e.getCause().getMessage().equals("parent of node to add does not exist") || e.getCause().getMessage().equals("parent of path to add to is not a container"))) {
-                    if (PATCH_HELPER.size(singleJsonPatch) == 2) {
-                        JsonPatch firstOp = PATCH_HELPER.delete(singleJsonPatch, 1, 2);
-                        patched = fillUp(changeSet.getPath().replaceAll("\\.", "/"), firstOp, patched);
-                    } else {
-                        patched = fillUp(changeSet.getPath().replaceAll("\\.", "/"), singleJsonPatch, patched);
-                    }
-                    i--;
-                } else if (e.getCause() != null && e.getCause().getMessage().equals("value cannot be null")
-                        || changeSet.getOperation() == OperationType.DELETE && e.getCause() != null && e.getCause().getMessage().equals("no such path in target JSON document")) {
-                    log.warn("An error occurred while applying {} - changeset : {}", changeSet.getVersion(), e.getCause() == null ? e.getMessage() : e.getCause().getMessage());
+                log.warn("An error occurred while applying {} - changeset : {}", changeSet.getVersion(), e.getCause() == null ? e.getMessage() : e.getCause().getMessage());
 
-                    changeSet.setSuccess(false);
-                } else {
-                    log.warn("Unexpected error occurred while applying {} - changeset : {}", changeSet.getVersion(), e.getCause() == null ? e.getMessage() : e.getCause().getMessage());
-
-                    changeSet.setSuccess(false);
-                }
+                changeSet.setSuccess(false);
             }
         }
         finish(patched, newChangeSets);


### PR DESCRIPTION
**Bug**: The code contained special handling for the `move` operation that attempted to automatically fill in missing intermediate paths when users provided shortened target paths. This functionality became problematic after migrating from a fail-fast strategy to a skip-on-fail policy, as the path reconstruction logic would trigger unexpected retry behavior and mask legitimate errors.

**Fix**: Removed the automatic path-filling functionality entirely. Users are now required to provide the full target path for move operations, which aligns with our current error handling policy and makes the behavior more predictable and explicit.

**Changes**:
- Removed complex exception handling that attempted to reconstruct paths using `fillUp()`
- Simplified error handling to use consistent skip-on-fail behavior