### PR TITLE
Fix TransactionRequiredException on widget-setting creation & Fix NPE on getting total failed executions duration

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/repository/ExecutionRepository.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/repository/ExecutionRepository.java
@@ -30,7 +30,7 @@ public interface ExecutionRepository extends JpaRepository<Execution, Long> {
 
     @Query(nativeQuery = true, value = """
             SELECT COUNT(*) AS totalExecs,
-                SUM(CASE WHEN status = 'F' THEN 1 ELSE 0 END) AS totalFailed,
+                COALESCE(SUM(CASE WHEN status = 'F' THEN 1 ELSE 0 END), 0) AS totalFailed,
                 COALESCE(SUM(CASE WHEN start_time IS NOT NULL AND end_time IS NOT NULL
                     THEN TIMESTAMPDIFF(MICROSECOND, start_time, end_time) / 1000.0 ELSE 0 END), 0) AS totalRuntime,
                 COALESCE(AVG(CASE WHEN status = 'S' AND start_time IS NOT NULL AND end_time IS NOT NULL

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/repository/UserRepository.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/repository/UserRepository.java
@@ -32,7 +32,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 //    @Query(value = "SELECT * FROM user WHERE email=?1", nativeQuery = true)
     Optional<User> findByEmail(String email);
     Optional<User> findByUsernameAndAuthMethod(String username, AuthMethod authMethod);
-    Optional<User> findOneById(int id);
     @Transactional
     void deleteOneById(int id);
     boolean existsByEmail(String email);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/UserServiceImpl.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/UserServiceImpl.java
@@ -74,7 +74,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public Optional<User> findById(int id) {
-        return userRepository.findOneById(id);
+        return userRepository.findById(id);
     }
 
     @Override


### PR DESCRIPTION
Replaced the custom-derived query method findOneById (not covered by SimpleJpaRepository's @Transactional in Hibernate 6) with the standard findById, which is already transactional via SimpleJpaRepository. Also removed the now-unused findOneById from UserRepository. 