### PR TITLE
Prepared for 4.8.1 version

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -478,34 +478,33 @@ public class ConnectionServiceImp implements ConnectionService {
             if (Utils.compare(ocProps.getVersion(), connection.getOcVersion()) > 0 && !isTestConnection(connection.getTitle())) {
 
                 List<ConnectionMng> connections = connectionMngService.getAllByConnectionId(connection.getId());
-                ConnectionMng connectionMng;
                 if (connections.isEmpty()) {
                     log.error("Failed to find Connection[id={}, name={}] on MongoDB. Skipped updating", connection.getId(), connection.getTitle());
                     continue;
-                } else if (connections.size() > 1) {
-                    log.error("{} instances found for Connection[id={}, name={}] on MongoDB. Skipped updating", connections.size(), connection.getId(), connection.getTitle());
-                    continue;
-                } else {
-                    connectionMng = connections.get(0);
                 }
 
                 try {
-                    connectionMngEntityUpdater.updateToCurrentVersion(connectionMng);
+                    for (ConnectionMng connectionMng : connections) {
+                        connectionMngEntityUpdater.updateToCurrentVersion(connectionMng);
+                        connectionMng.setVersion(ocProps.getVersion());
 
-                    log.info("Connection[id={}, name={}, version={}] successfully updated to {} version", connection.getId(), connection.getTitle(), connection.getOcVersion(), connectionMng.getVersion());
+                        if (connectionMng.getCreatedBy() == null) {
+                            connectionMng.setCreatedBy(connection.getCreatedBy());
+                        }
+                        connectionMngService.save(connectionMng);
+                    }
+
+                    log.info("Connection[id={}, name={}, version={}] successfully updated to {} version", connection.getId(), connection.getTitle(), connection.getOcVersion(), ocProps.getVersion());
                 } catch (Exception e) {
                     log.error("Failed to update Connection[id={}, name={}, version={}]", connection.getId(), connection.getTitle(), connection.getOcVersion(), e);
                     continue;
                 }
 
-                if (connectionMng.getCreatedBy() == null) {
-                    connectionMng.setCreatedBy(connection.getCreatedBy());
-                }
-                connectionMngService.save(connectionMng);
-
                 if (connection.getSnapshotId() == null) {
-                    connection.setSnapshotId(connectionMng.getId());
+                    ConnectionMng lastConnection = connections.stream().max(Comparator.comparing(ConnectionMng::getCreatedAt)).get();
+                    connection.setSnapshotId(lastConnection.getId());
                 }
+
                 connection.setOcVersion(ocProps.getVersion());
                 connectionRepository.save(connection);
             }

--- a/src/backend/src/main/resources/application_default.yml
+++ b/src/backend/src/main/resources/application_default.yml
@@ -194,7 +194,7 @@ management:
           UP: 200
 
 opencelium:
-  version: 4.8
+  version: 4.8.1
   ###########################################################################
   #                                                                         #
   #   Is customizable                                                       #

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -719,3 +719,7 @@ INSERT IGNORE INTO widget_setting (
 (0, 2, 6, 4, 6, 4, 4, 1),
 (0, 0, 12, 2, 12, 2, 5, 1),
 (6, 2, 6, 4, 6, 4, 2, 1);
+
+--changeset 4.8.1:1 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `enhancement` DROP FOREIGN KEY `fk_enhancement_connection1`;
+ALTER TABLE `enhancement` ADD CONSTRAINT `fk_enhancement_connection1` FOREIGN KEY (`connection_id`) REFERENCES `connection` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
+++ b/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
@@ -202,3 +202,9 @@ versions:
         operation: add
         value: native
         path: server.forward-headers-strategy
+  - version: 4.8.1
+    changes:
+      - changeset: 1
+        operation: add
+        value: 4.8.1
+        path: opencelium.version


### PR DESCRIPTION
1. From 4.8 version, connections can have multiple versions on mongodb. So that we need to update all versions. Before 4.8, all connections had only one instance on mongodb, that is why this concern is not needed before 4.8.


2. Updated application's version to 4.8.1 on application.yml and application_default.yml


3. Fixed connection deletion failing to remove associated enhancements                                             
   
  Prior to 4.8, the Connection entity held a list of enhancements annotated with CascadeType.ALL, so deleting a   
  connection automatically cascaded to its enhancements via JPA. When the enhancements list was removed from    
  Connection in 4.8, that cascade was lost — leaving orphaned enhancement rows and causing deletion to fail.

  Fixed by adding an ON DELETE CASCADE clause to the enhancement table's foreign key, delegating the cascade
  responsibility to the database layer.