### PR TITLE
[OC-1378] fix GET /user/check and GET /role/exists always returning the same response

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/RoleController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/RoleController.java
@@ -38,7 +38,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
+import com.becon.opencelium.backend.resource.application.ResultDTO;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 
 import java.io.IOException;
@@ -217,11 +217,11 @@ public class RoleController {
         return ResponseEntity.created(uri).body(resource);
     }
 
-    @Operation(summary = "Checks existence of role in OC")
+    @Operation(summary = "Checks whether a role with the given name exists in the system")
     @ApiResponses(value = {
         @ApiResponse( responseCode = "200",
-                description = "Returns EXISTS or NOT_EXISTS",
-                content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+                description = "Returns true if the role exists, false otherwise",
+                content = @Content(schema = @Schema(implementation = ResultDTO.class))),
         @ApiResponse( responseCode = "401",
                 description = "Unauthorized",
                 content = @Content(schema = @Schema(implementation = ErrorResource.class))),
@@ -230,12 +230,8 @@ public class RoleController {
                 content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping("/exists/{role}")
-    public ResponseEntity<?> roleExists(@PathVariable("role") String role) throws IOException{
-        if (userRoleService.existsByRole(role)){
-            throw new ResponseStatusException(HttpStatus.OK, "EXISTS");
-        } else {
-            throw new ResponseStatusException(HttpStatus.OK, "NOT_EXISTS");
-        }
+    public ResponseEntity<ResultDTO<Boolean>> roleExists(@PathVariable("role") String role) {
+        return ResponseEntity.ok(ResultDTO.of(userRoleService.existsByRole(role)));
     }
 
     @Operation(summary = "Deletes an User Role from system by provided role ID")

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/UserController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/UserController.java
@@ -56,7 +56,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -105,11 +104,11 @@ public class UserController {
                 ResponseEntity.ok(new UserResource(p))).orElseThrow(() -> new UserNotFoundException(id));
     }
 
-    @Operation(summary = "Checks the existence of an user email in the system")
+    @Operation(summary = "Checks whether a user with the given email exists in the system")
     @ApiResponses(value = {
         @ApiResponse( responseCode = "200",
-                description = "The email address exists in the system.",
-                content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+                description = "Returns true if the email is registered, false otherwise",
+                content = @Content(schema = @Schema(implementation = ResultDTO.class))),
         @ApiResponse( responseCode = "401",
                 description = "Unauthorized",
                 content = @Content(schema = @Schema(implementation = ErrorResource.class))),
@@ -118,12 +117,8 @@ public class UserController {
                 content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping("/check/{email}")
-    public ResponseEntity<?> emailExists(@PathVariable("email") String email) {
-        if (userService.existsByEmail(email)) {
-            throw new ResponseStatusException(HttpStatus.OK, "EXISTS");
-        } else {
-            throw new ResponseStatusException(HttpStatus.OK, "NOT_EXISTS");
-        }
+    public ResponseEntity<ResultDTO<Boolean>> emailExists(@PathVariable("email") String email) {
+        return ResponseEntity.ok(ResultDTO.of(userService.existsByEmail(email)));
     }
 
     @Operation(summary = "Retrieves a list of all users in the application")


### PR DESCRIPTION
## What
Fix `GET /user/check/{email}` and `GET /role/exists/{role}` always returning an identical response regardless of whether the entity exists.

## Why
Both endpoints were using `throw new ResponseStatusException(HttpStatus.OK, ...)` in both branches. Because the exception is thrown on both paths with the same HTTP status (200), Spring's error resolver produced the same error response regardless of the actual lookup result — making existence checks unreliable.
Closes OC-1378.

## How to test
```bash
# Manual verification
curl -s http://localhost:9090/user/check/existing@email.com   # → {"result":true}
curl -s http://localhost:9090/user/check/unknown@email.com    # → {"result":false}
curl -s http://localhost:9090/role/exists/ROLE_ADMIN          # → {"result":true}
curl -s http://localhost:9090/role/exists/ROLE_GHOST          # → {"result":false}
```

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated