### PR TITLE
Subscription active status returns true after end date expires

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionService.java
@@ -23,6 +23,7 @@ public interface SubscriptionService {
     void updateUsage(String subId, ConnectionEx connectionEx, long requestSize, long startTime);
     void createFreeLicenseFileIfNotExists();
     void resetMonthlyUsageForLicense(String subId);
+    void deactivateExpiredSubscription(String subId);
 
     Subscription findByLicenseId(String licenseId);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionServiceImpl.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionServiceImpl.java
@@ -11,6 +11,8 @@ import com.becon.opencelium.backend.database.mysql.repository.SubscriptionReposi
 import com.becon.opencelium.backend.enums.ActivReqStatus;
 import com.becon.opencelium.backend.execution.socket.SocketConstant;
 import com.becon.opencelium.backend.execution.socket.WebSocketNotificationQueue;
+import com.becon.opencelium.backend.quartz.DeactivateExpiredSubscriptionJob;
+import com.becon.opencelium.backend.quartz.QuartzJobScheduler;
 import com.becon.opencelium.backend.quartz.ResetLimitsJob;
 import com.becon.opencelium.backend.resource.execution.ConnectionEx;
 import com.becon.opencelium.backend.resource.subs.SubsDTO;
@@ -41,6 +43,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     private final SubscriptionRepository subscriptionRepository;
     private final Scheduler scheduler;
+    private final QuartzJobScheduler quartzJobScheduler;
     private final OperationUsageHistoryService operationUsageHistoryService;
     private final OperationUsageHistoryDetailService operationUsageHistoryDetailService;
     private final ActivationRequestService activationRequestService;
@@ -59,6 +62,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                                    WebSocketNotificationQueue notificationQueue) {
         this.subscriptionRepository = subscriptionRepository;
         this.scheduler = scheduler;
+        this.quartzJobScheduler = new QuartzJobScheduler(scheduler);
         this.operationUsageHistoryService = operationUsageHistoryService;
         this.operationUsageHistoryDetailService = operationUsageHistoryDetailService;
         this.activationRequestService = activationRequestService;
@@ -148,6 +152,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         subscription.setCurrentUsageHmac(HmacUtility
                 .encode(subscription.getId() + subscription.getCurrentUsage()));
         initUsageResetJob(subscription);
+        initExpiryJob(subscription);
         subscriptionRepository.save(subscription);
     }
 
@@ -274,7 +279,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                     newDetail.setStartDate(Instant.ofEpochMilli(startTime).atZone(ZoneId.of("UTC")).toLocalDateTime());
                     newDetail.setOperationUsageHistory(history);  // Set the bidirectional relationship
                     operationUsageHistoryDetailService.save(newDetail);
-                         // Add the new detail to the existing list
+                        // Add the new detail to the existing list
 //                    history.getDetails().add(newDetail);
                     return history;
                 })
@@ -395,11 +400,45 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         }
     }
 
+    @Override
+    public void deactivateExpiredSubscription(String subId) {
+        Optional<Subscription> optional = subscriptionRepository.findById(subId);
+        if (optional.isEmpty()) {
+            logger.warn("Subscription not found when trying to deactivate expired: {}", subId);
+            return;
+        }
+        Subscription subscription = optional.get();
+        LicenseKey licenseKey = LicenseKeyUtility.decrypt(subscription.getLicenseKey());
+        if (licenseKey.getEndDate() < System.currentTimeMillis()) {
+            subscription.setActive(false);
+            subscriptionRepository.save(subscription);
+            logger.info("Subscription {} deactivated — license expired at {}", subId,
+                    Instant.ofEpochMilli(licenseKey.getEndDate()));
+            sendNotification();
+        }
+    }
+
+    private void initExpiryJob(Subscription subscription) {
+        LicenseKey lk = LicenseKeyUtility.decrypt(subscription.getLicenseKey());
+        if (lk.getEndDate() == SubscriptionConstant.freeLicenseEndDate) {
+            return;
+        }
+        quartzJobScheduler.scheduleOnce(
+                DeactivateExpiredSubscriptionJob.class,
+                "LicenseExpiryJob-" + subscription.getId(),
+                "LicenseExpiryJobs",
+                "localSubId",
+                subscription.getId(),
+                Date.from(Instant.ofEpochMilli(lk.getEndDate()))
+        );
+    }
+
     private void killAllTasks() {
         try {
-            Set<JobKey> jobKeys = scheduler.getJobKeys(GroupMatcher.jobGroupEquals("LicenseJobs"));
-            for (JobKey jobKey : jobKeys) {
-                scheduler.deleteJob(jobKey);
+            for (String group : List.of("LicenseJobs", "LicenseExpiryJobs")) {
+                for (JobKey jobKey : scheduler.getJobKeys(GroupMatcher.jobGroupEquals(group))) {
+                    scheduler.deleteJob(jobKey);
+                }
             }
         } catch (SchedulerException e) {
             e.printStackTrace();

--- a/src/backend/src/main/java/com/becon/opencelium/backend/quartz/DeactivateExpiredSubscriptionJob.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/quartz/DeactivateExpiredSubscriptionJob.java
@@ -1,0 +1,21 @@
+package com.becon.opencelium.backend.quartz;
+
+import com.becon.opencelium.backend.database.mysql.service.SubscriptionService;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+public class DeactivateExpiredSubscriptionJob extends QuartzJobBean {
+
+    private final SubscriptionService subscriptionService;
+
+    public DeactivateExpiredSubscriptionJob(@Qualifier("subscriptionServiceImpl") SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
+    }
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) {
+        String subId = context.getJobDetail().getJobDataMap().getString("localSubId");
+        subscriptionService.deactivateExpiredSubscription(subId);
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/quartz/QuartzJobScheduler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/quartz/QuartzJobScheduler.java
@@ -9,6 +9,7 @@ import com.becon.opencelium.backend.exception.SchedulerNotFoundException;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
+import org.quartz.Job;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -16,6 +17,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
 import org.quartz.JobPersistenceException;
 import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
@@ -24,6 +26,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -303,6 +306,40 @@ public class QuartzJobScheduler implements SchedulingStrategy {
             }
 
             quartzScheduler.interrupt(jobKey);
+        } catch (SchedulerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void scheduleOnce(Class<? extends Job> jobClass, String jobKey, String group,
+                             String dataKey, String dataValue, Date fireAt) {
+        JobKey jobIdentity = new JobKey(jobKey, group);
+        TriggerKey triggerKey = new TriggerKey(jobKey, group);
+
+        // If the app was down when fireAt passed, fire immediately on the next startup.
+        SimpleScheduleBuilder schedule = SimpleScheduleBuilder.simpleSchedule()
+                .withRepeatCount(0)
+                .withMisfireHandlingInstructionFireNow();
+        try {
+            if (quartzScheduler.checkExists(jobIdentity)) {
+                Trigger newTrigger = TriggerBuilder.newTrigger()
+                        .withIdentity(triggerKey)
+                        .startAt(fireAt)
+                        .withSchedule(schedule)
+                        .build();
+                quartzScheduler.rescheduleJob(triggerKey, newTrigger);
+            } else {
+                JobDetail job = JobBuilder.newJob(jobClass)
+                        .withIdentity(jobKey, group)
+                        .usingJobData(dataKey, dataValue)
+                        .build();
+                Trigger trigger = TriggerBuilder.newTrigger()
+                        .withIdentity(triggerKey)
+                        .startAt(fireAt)
+                        .withSchedule(schedule)
+                        .build();
+                quartzScheduler.scheduleJob(job, trigger);
+            }
         } catch (SchedulerException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What
Fix subscription `active` status remaining `true` after the license end date passes.

A one-shot Quartz job (`DeactivateExpiredSubscriptionJob`) is scheduled at activation time and fires exactly at `endDate`, flipping `active = false` in the database and pushing a WebSocket notification to the frontend.

`QuartzJobScheduler.scheduleOnce()` encapsulates the one-shot scheduling pattern so it can be reused outside the subscription domain.

## Why
The `active` column is only set to `false` when a new license is activated or deleted — no job ever cleared it on expiry, so `GET /subs/active` returned `"active": true` even months after the license end date had passed.

If the application is down when `endDate` passes, `withMisfireHandlingInstructionFireNow()` causes the job to fire immediately on the next startup.

The free license (`endDate` normalised to year 2100 by the `LicenseKey` getter) is excluded from job scheduling.

## How to test

Manual verification:
1. Activate a license whose `endDate` is set to a timestamp a few seconds in the future.
2. Wait for the Quartz job to fire.
3. Call `GET /subs/active` and verify `"active": false`.
4. Restart the application with an already-expired license and verify `"active": false` is returned immediately (misfire fires on startup).

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
