### PR TITLE
[OC-1400] Add WidgetService unit tests and shared test fixtures

### DIFF
--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/assertion/WidgetAssertions.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/assertion/WidgetAssertions.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.testutil.assertion;
+
+import com.becon.opencelium.backend.database.mysql.entity.Widget;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Custom AssertJ assertions for {@link Widget}.
+ *
+ * Wraps repeated field-level checks into readable, chainable one-liners so
+ * test classes express intent rather than field comparisons.
+ *
+ * Usage:
+ *   WidgetAssertions.assertThat(widget)
+ *                   .isSystemMetricsWidget()
+ *                   .hasId(1);
+ *
+ * Add a new method here when the same field check appears in two or more
+ * test classes. Do not add methods speculatively — let duplication drive it.
+ */
+public class WidgetAssertions extends AbstractAssert<WidgetAssertions, Widget> {
+
+    private WidgetAssertions(Widget actual) {
+        super(actual, WidgetAssertions.class);
+    }
+
+    /**
+     * Entry point — mirrors AssertJ's assertThat() style.
+     *
+     * WidgetAssertions.assertThat(widget).isSystemMetricsWidget().hasId(1);
+     */
+    public static WidgetAssertions assertThat(Widget actual) {
+        return new WidgetAssertions(actual);
+    }
+
+    // ── Named-scenario checks ─────────────────────────────────────────────────
+
+    /**
+     * Verifies the widget matches the "system-metrics" fixture scenario
+     * produced by {@link com.becon.opencelium.backend.testutil.fixture.WidgetFixture#aWidget()}.
+     */
+    public WidgetAssertions isSystemMetricsWidget() {
+        hasName("system-metrics");
+        hasIcon("metrics-icon.png");
+        hasTooltipKey("widget.system_metrics");
+        return this;
+    }
+
+    // ── Field checks ──────────────────────────────────────────────────────────
+
+    public WidgetAssertions hasId(int expected) {
+        isNotNull();
+        if (actual.getId() != expected) {
+            failWithMessage("Expected widget id to be <%d> but was <%d>", expected, actual.getId());
+        }
+        return this;
+    }
+
+    public WidgetAssertions hasName(String expected) {
+        isNotNull();
+        if (!expected.equals(actual.getName())) {
+            failWithMessage("Expected widget name to be <%s> but was <%s>", expected, actual.getName());
+        }
+        return this;
+    }
+
+    public WidgetAssertions hasIcon(String expected) {
+        isNotNull();
+        if (!expected.equals(actual.getIcon())) {
+            failWithMessage("Expected widget icon to be <%s> but was <%s>", expected, actual.getIcon());
+        }
+        return this;
+    }
+
+    public WidgetAssertions hasTooltipKey(String expected) {
+        isNotNull();
+        if (!expected.equals(actual.getTooltipTranslationKey())) {
+            failWithMessage(
+                "Expected widget tooltip key to be <%s> but was <%s>",
+                expected, actual.getTooltipTranslationKey()
+            );
+        }
+        return this;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/UserFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/UserFixture.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.database.mysql.entity.User;
+
+/**
+ * Object mother for {@link User} test data.
+ *
+ * Use the named factory methods in test classes — never construct
+ * User objects inline. Add new named scenarios here rather than
+ * duplicating setup across test classes.
+ */
+public final class UserFixture {
+
+    private UserFixture() {}
+
+    /**
+     * User with no fields set beyond JVM defaults (id = 0, authMethod = BASIC).
+     * Use when a test only needs a valid FK target and no User fields are under test.
+     */
+    public static User anEmptyUser() {
+        return new User();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/WidgetFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/WidgetFixture.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.database.mysql.entity.Widget;
+import com.becon.opencelium.backend.database.mysql.entity.WidgetSetting;
+import com.becon.opencelium.backend.resource.user.WidgetResource;
+
+/**
+ * Object mother for {@link Widget}, {@link WidgetSetting}, and their resource counterparts.
+ *
+ * Use the named factory methods in test classes — never construct these objects inline.
+ * Add new named scenarios here rather than duplicating setup across test classes.
+ */
+public final class WidgetFixture {
+
+    private WidgetFixture() {}
+
+    // ── Widget entity factories ───────────────────────────────────────────────
+
+    /**
+     * Widget with id left at 0 — suitable for JPA slice tests where
+     * {@code TestEntityManager.persist()} must let the database assign the id.
+     */
+    public static Widget aTransientWidget() {
+        Widget widget = new Widget();
+        widget.setName("system-metrics");
+        widget.setIcon("metrics-icon.png");
+        widget.setTooltipTranslationKey("widget.system_metrics");
+        return widget;
+    }
+
+    /**
+     * Widget with a pre-set id — suitable for unit tests where JPA is not involved.
+     */
+    public static Widget aWidget() {
+        Widget widget = aTransientWidget();
+        widget.setId(1);
+        return widget;
+    }
+
+    /**
+     * Widget with a pre-set id and a custom name — use when a test needs a widget
+     * distinct from the default "system-metrics" scenario (e.g. testing a list
+     * with two different widgets).
+     */
+    public static Widget aWidgetNamed(String name) {
+        Widget widget = new Widget();
+        widget.setId(1);
+        widget.setName(name);
+        widget.setIcon(name + "-icon.png");
+        widget.setTooltipTranslationKey("widget." + name.replace("-", "_"));
+        return widget;
+    }
+
+    // ── WidgetResource factories ──────────────────────────────────────────────
+
+    public static WidgetResource aWidgetResource() {
+        WidgetResource resource = new WidgetResource();
+        resource.setWidgetId(1);
+        resource.setI("system-metrics");
+        resource.setIcon("metrics-icon.png");
+        resource.setTooltipTranslationKey("widget.system_metrics");
+        return resource;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/WidgetServiceImplTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/WidgetServiceImplTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.Widget;
+import com.becon.opencelium.backend.database.mysql.repository.WidgetRepository;
+import com.becon.opencelium.backend.database.mysql.service.ExecutionService;
+import com.becon.opencelium.backend.database.mysql.service.WidgetServiceImp;
+import com.becon.opencelium.backend.resource.application.ExecutionStatsDTO;
+import com.becon.opencelium.backend.resource.application.SystemMetricsDTO;
+import com.becon.opencelium.backend.resource.user.WidgetResource;
+import com.becon.opencelium.backend.testutil.assertion.WidgetAssertions;
+import com.becon.opencelium.backend.testutil.fixture.WidgetFixture;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link WidgetServiceImp}.
+ *
+ * No Spring context is loaded. The repository and execution service are mocked with Mockito.
+ * MeterRegistry uses a real SimpleMeterRegistry — see setUp() for the reasoning.
+ * MeterRegistry uses SimpleMeterRegistry (a real no-op implementation) to avoid
+ * ByteBuddy instrumentation issues with abstract JDK classes on newer JDK versions.
+ * Run with: ./gradlew test --tests "*.WidgetServiceImplTest"
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WidgetServiceImp — unit")
+class WidgetServiceImplTest {
+
+    @Mock
+    private WidgetRepository widgetRepository;
+
+    @Mock
+    private ExecutionService executionService;
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    private WidgetServiceImp widgetService;
+
+    @BeforeEach
+    void setUp() {
+        widgetService = new WidgetServiceImp(widgetRepository, executionService, meterRegistry);
+    }
+
+    // ── save ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void savePersistsWidgetWhenCalled() {
+        Widget widget = WidgetFixture.aWidget();
+
+        widgetService.save(widget);
+
+        verify(widgetRepository).save(widget);
+    }
+
+    // ── findById ──────────────────────────────────────────────────────────────
+
+    @Test
+    void findByIdReturnsWidgetWhenIdExists() {
+        Widget widget = WidgetFixture.aWidget();
+        when(widgetRepository.findById(1)).thenReturn(Optional.of(widget));
+
+        Optional<Widget> result = widgetService.findById(1);
+
+        assertThat(result).isPresent();
+        WidgetAssertions.assertThat(result.get()).isSystemMetricsWidget();
+    }
+
+    @Test
+    void findByIdReturnsEmptyWhenIdDoesNotExist() {
+        when(widgetRepository.findById(99)).thenReturn(Optional.empty());
+
+        assertThat(widgetService.findById(99)).isEmpty();
+    }
+
+    // ── deleteById ────────────────────────────────────────────────────────────
+
+    @Test
+    void deleteByIdRemovesWidgetWhenIdProvided() {
+        widgetService.deleteById(1);
+
+        verify(widgetRepository).deleteById(1);
+    }
+
+    // ── findAll ───────────────────────────────────────────────────────────────
+
+    @Test
+    void findAllReturnsAllWidgetsWhenRepositoryHasEntries() {
+        Widget widget = WidgetFixture.aWidget();
+        when(widgetRepository.findAll()).thenReturn(List.of(widget));
+
+        List<Widget> result = widgetService.findAll();
+
+        assertThat(result).hasSize(1);
+        WidgetAssertions.assertThat(result.get(0)).isSystemMetricsWidget();
+    }
+
+    // ── toEntity / toResource ─────────────────────────────────────────────────
+
+    @Test
+    void toEntityConvertsResourceToWidgetWhenResourceIsValid() {
+        WidgetResource resource = WidgetFixture.aWidgetResource();
+
+        Widget entity = widgetService.toEntity(resource);
+
+        WidgetAssertions.assertThat(entity).isSystemMetricsWidget();
+    }
+
+    @Test
+    void toResourceConvertsWidgetToResourceWhenWidgetIsValid() {
+        Widget widget = WidgetFixture.aWidget();
+
+        WidgetResource resource = widgetService.toResource(widget);
+
+        assertThat(resource.getWidgetId()).isEqualTo(1);
+        assertThat(resource.getI()).isEqualTo("system-metrics");
+        assertThat(resource.getIcon()).isEqualTo("metrics-icon.png");
+        assertThat(resource.getTooltipTranslationKey()).isEqualTo("widget.system_metrics");
+    }
+
+    // ── getSystemMetrics ──────────────────────────────────────────────────────
+
+    @Test
+    void getSystemMetricsReturnsExecutionStatsWhenServiceReturnsData() {
+        when(executionService.getStats())
+                .thenReturn(new ExecutionStatsDTO(10, 2, 5000L, 500L));
+        Gauge.builder("process.cpu.usage", () -> 0.0).register(meterRegistry);
+
+        SystemMetricsDTO dto = widgetService.getSystemMetrics();
+
+        assertThat(dto.getTotalExecs()).isEqualTo(10);
+        assertThat(dto.getTotalFailedExecs()).isEqualTo(2);
+        assertThat(dto.getTotalRuntime()).isEqualTo(5000L);
+        assertThat(dto.getAverageRuntimeS()).isEqualTo(500L);
+    }
+
+    @Test
+    @DisplayName("getSystemMetrics scales the gauge ratio (0.0–1.0) to a percentage (0–100)")
+    void getSystemMetricsReturnsCpuUsagePercentageWhenGaugeIsRegistered() {
+        when(executionService.getStats())
+                .thenReturn(new ExecutionStatsDTO(0, 0, 0L, 0L));
+        Gauge.builder("process.cpu.usage", () -> 0.50).register(meterRegistry);
+
+        SystemMetricsDTO dto = widgetService.getSystemMetrics();
+
+        assertThat(dto.getCpuUsage()).isEqualTo(50.0);
+    }
+
+    @Test
+    void getSystemMetricsReturnsCpuUsageNullWhenGaugeIsNotRegistered() {
+        when(executionService.getStats())
+                .thenReturn(new ExecutionStatsDTO(0, 0, 0L, 0L));
+        // No gauge registered — MeterNotFoundException is caught and logged at ERROR; that is expected here.
+
+        SystemMetricsDTO dto = widgetService.getSystemMetrics();
+
+        assertThat(dto.getCpuUsage()).isNull();
+    }
+
+    @Test
+    @DisplayName("getSystemMetrics swallows execution-service exceptions and continues populating independent metrics")
+    void getSystemMetricsReturnsPartialDtoWithNullStatsWhenExecutionServiceThrows() {
+        when(executionService.getStats()).thenThrow(new RuntimeException("db error"));
+        Gauge.builder("process.cpu.usage", () -> 0.75).register(meterRegistry);
+
+        SystemMetricsDTO dto = widgetService.getSystemMetrics();
+
+        // exception is swallowed — execution-stat fields remain null
+        assertThat(dto.getTotalExecs()).isNull();
+        assertThat(dto.getTotalFailedExecs()).isNull();
+        assertThat(dto.getTotalRuntime()).isNull();
+        assertThat(dto.getAverageRuntimeS()).isNull();
+        // independent metrics are unaffected by the execution-service failure
+        assertThat(dto.getCpuUsage()).isEqualTo(75.0);
+    }
+}


### PR DESCRIPTION
## What
Add `WidgetServiceImplTest` (10 unit tests) and the shared object-mother fixtures
`UserFixture` / `WidgetFixture` that all widget-domain tests will use.

## Why
`WidgetServiceImp` had no test coverage. The fixtures establish a single source of truth for test data so individual test classes do not construct entities inline.
Part of OC-1400.

## How to test
```bash
./gradlew test --tests "*.WidgetServiceImplTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added — `WidgetServiceImplTest` (10 tests)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed

---