### PR TITLE
[OC-1400] Add WidgetSetting unit and slice tests

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WidgetSettingServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WidgetSettingServiceImp.java
@@ -19,11 +19,11 @@ public class WidgetSettingServiceImp implements WidgetSettingService {
     private WidgetSettingRepository widgetSettingRepository;
 
     @Autowired
-    private WidgetServiceImp widgetServiceImp;
+    private WidgetService widgetServiceImp;
 
     @Autowired
     @Lazy
-    private UserServiceImpl userService;
+    private UserService userService;
 
     @Override
     public void create(WidgetSetting widgetSetting) {

--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/WidgetSettingRepositoryTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/WidgetSettingRepositoryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.slice.database.mysql.repository;
+
+import com.becon.opencelium.backend.database.mysql.entity.User;
+import com.becon.opencelium.backend.database.mysql.entity.Widget;
+import com.becon.opencelium.backend.database.mysql.entity.WidgetSetting;
+import com.becon.opencelium.backend.database.mysql.repository.WidgetSettingRepository;
+import com.becon.opencelium.backend.testutil.annotation.SliceTest;
+import com.becon.opencelium.backend.testutil.fixture.UserFixture;
+import com.becon.opencelium.backend.testutil.fixture.WidgetFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * JPA slice test for {@link WidgetSettingRepository#findByUserId(int)}.
+ *
+ * Validates that Spring Data correctly resolves the derived query against
+ * the H2 schema. A unit test cannot catch a typo or schema drift here
+ * because Spring Data only validates derived-query method names at runtime.
+ *
+ * Run with: ./gradlew test --tests "*.WidgetSettingRepositoryTest"
+ */
+@SliceTest
+@DisplayName("WidgetSettingRepository — JPA slice")
+class WidgetSettingRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private WidgetSettingRepository widgetSettingRepository;
+
+    // ── findByUserId ──────────────────────────────────────────────────────────
+
+    @Test
+    void findByUserIdReturnsSettingsWhenUserHasSavedSettings() {
+        Widget widget = WidgetFixture.aTransientWidget();
+        em.persist(widget);
+
+        User user = UserFixture.anEmptyUser();
+        em.persist(user);
+
+        em.persist(WidgetFixture.aTransientWidgetSetting(widget, user));
+        em.flush();
+
+        List<WidgetSetting> result = widgetSettingRepository.findByUserId(user.getId());
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getWidget().getName()).isEqualTo("system-metrics");
+    }
+
+    @Test
+    void findByUserIdReturnsEmptyListWhenUserHasNoSettings() {
+        User user = UserFixture.anEmptyUser();
+        em.persist(user);
+        em.flush();
+
+        List<WidgetSetting> result = widgetSettingRepository.findByUserId(user.getId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findByUserIdExcludesSettingsOwnedByOtherUsersWhenQueried() {
+        Widget widget = WidgetFixture.aTransientWidget();
+        em.persist(widget);
+
+        User user1 = UserFixture.anEmptyUser();
+        em.persist(user1);
+
+        User user2 = UserFixture.anEmptyUser();
+        em.persist(user2);
+
+        em.persist(WidgetFixture.aTransientWidgetSetting(widget, user1));
+        em.flush();
+
+        List<WidgetSetting> result = widgetSettingRepository.findByUserId(user2.getId());
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/annotation/SliceTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/annotation/SliceTest.java
@@ -8,6 +8,7 @@
 
 package com.becon.opencelium.backend.testutil.annotation;
 
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -24,7 +25,12 @@ import java.lang.annotation.Target;
  *
  * Equivalent to:
  *   @DataJpaTest
+ *   @AutoConfigureTestDatabase(replace = Replace.NONE)
  *   @ActiveProfiles("test")
+ *
+ * Replace.NONE tells Spring to use the datasource from application-test.yml
+ * rather than auto-generating one, so the custom H2 URL (including NON_KEYWORDS)
+ * is honored.
  *
  * Usage:
  *   @SliceTest
@@ -33,6 +39,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 public @interface SliceTest {
 }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/WidgetFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/WidgetFixture.java
@@ -8,9 +8,11 @@
 
 package com.becon.opencelium.backend.testutil.fixture;
 
+import com.becon.opencelium.backend.database.mysql.entity.User;
 import com.becon.opencelium.backend.database.mysql.entity.Widget;
 import com.becon.opencelium.backend.database.mysql.entity.WidgetSetting;
 import com.becon.opencelium.backend.resource.user.WidgetResource;
+import com.becon.opencelium.backend.resource.user.WidgetSettingResource;
 
 /**
  * Object mother for {@link Widget}, {@link WidgetSetting}, and their resource counterparts.
@@ -67,6 +69,57 @@ public final class WidgetFixture {
         resource.setI("system-metrics");
         resource.setIcon("metrics-icon.png");
         resource.setTooltipTranslationKey("widget.system_metrics");
+        return resource;
+    }
+
+    // ── WidgetSetting entity factories ────────────────────────────────────────
+
+    /**
+     * WidgetSetting with a pre-set id — suitable for unit tests where JPA is not involved.
+     */
+    public static WidgetSetting aWidgetSetting(Widget widget) {
+        return aWidgetSetting(widget, UserFixture.anEmptyUser());
+    }
+
+    /**
+     * WidgetSetting with a pre-set id and an explicit user — use when the test needs to control
+     * which user the setting belongs to.
+     */
+    public static WidgetSetting aWidgetSetting(Widget widget, User user) {
+        WidgetSetting ws = aTransientWidgetSetting(widget, user);
+        ws.setId(10);
+        return ws;
+    }
+
+    /**
+     * WidgetSetting with id left at 0 — suitable for JPA slice tests where
+     * {@code TestEntityManager.persist()} must let the database assign the id.
+     */
+    public static WidgetSetting aTransientWidgetSetting(Widget widget, User user) {
+        WidgetSetting ws = new WidgetSetting();
+        ws.setAxisX(0);
+        ws.setAxisY(0);
+        ws.setWidth(4);
+        ws.setHeight(3);
+        ws.setMinWidth(2);
+        ws.setMinHeight(2);
+        ws.setWidget(widget);
+        ws.setUser(user);
+        return ws;
+    }
+
+    // ── WidgetSettingResource factories ───────────────────────────────────────
+
+    public static WidgetSettingResource aWidgetSettingResource() {
+        WidgetSettingResource resource = new WidgetSettingResource();
+        resource.setWidgetSettingId(0);
+        resource.setWidgetId(1);
+        resource.setX(0);
+        resource.setY(0);
+        resource.setW(4);
+        resource.setH(3);
+        resource.setMinW(2);
+        resource.setMinH(2);
         return resource;
     }
 }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/WidgetSettingServiceImplTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/WidgetSettingServiceImplTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.User;
+import com.becon.opencelium.backend.database.mysql.entity.Widget;
+import com.becon.opencelium.backend.database.mysql.entity.WidgetSetting;
+import com.becon.opencelium.backend.database.mysql.repository.WidgetSettingRepository;
+import com.becon.opencelium.backend.database.mysql.service.UserService;
+import com.becon.opencelium.backend.database.mysql.service.WidgetService;
+import com.becon.opencelium.backend.database.mysql.service.WidgetSettingServiceImp;
+import com.becon.opencelium.backend.resource.user.WidgetSettingResource;
+import com.becon.opencelium.backend.testutil.fixture.UserFixture;
+import com.becon.opencelium.backend.testutil.fixture.WidgetFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link WidgetSettingServiceImp}.
+ *
+ * No Spring context is loaded. All collaborators are mocked with Mockito.
+ * Run with: ./gradlew test --tests "*.WidgetSettingServiceImplTest"
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WidgetSettingServiceImp — unit")
+class WidgetSettingServiceImplTest {
+
+    @Mock
+    private WidgetSettingRepository widgetSettingRepository;
+
+    @Mock
+    private WidgetService widgetServiceImp;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private WidgetSettingServiceImp widgetSettingService;
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    @Test
+    void createPersistsWidgetSettingWhenCalled() {
+        WidgetSetting ws = WidgetFixture.aWidgetSetting(WidgetFixture.aWidget());
+
+        widgetSettingService.create(ws);
+
+        verify(widgetSettingRepository).save(ws);
+    }
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    @Test
+    void updatePersistsWidgetSettingWhenCalled() {
+        WidgetSetting ws = WidgetFixture.aWidgetSetting(WidgetFixture.aWidget());
+
+        widgetSettingService.update(ws);
+
+        verify(widgetSettingRepository).save(ws);
+    }
+
+    // ── findById ──────────────────────────────────────────────────────────────
+
+    @Test
+    void findByIdReturnsWidgetSettingWhenIdExists() {
+        WidgetSetting ws = WidgetFixture.aWidgetSetting(WidgetFixture.aWidget());
+        when(widgetSettingRepository.findById(10)).thenReturn(Optional.of(ws));
+
+        WidgetSetting result = widgetSettingService.findById(10);
+
+        assertThat(result.getId()).isEqualTo(10);
+        assertThat(result.getWidth()).isEqualTo(4);
+    }
+
+    @Test
+    void findByIdThrowsRuntimeExceptionWhenIdDoesNotExist() {
+        when(widgetSettingRepository.findById(99)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> widgetSettingService.findById(99))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("WidgetNotFound");
+    }
+
+    // ── deleteById ────────────────────────────────────────────────────────────
+
+    @Test
+    void deleteByIdRemovesWidgetSettingWhenIdProvided() {
+        widgetSettingService.deleteById(10);
+
+        verify(widgetSettingRepository).deleteById(10);
+    }
+
+    // ── saveAll ───────────────────────────────────────────────────────────────
+
+    @Test
+    void saveAllPersistsAllWidgetSettingsWhenCalled() {
+        List<WidgetSetting> widgetSettings = List.of(
+                WidgetFixture.aWidgetSetting(WidgetFixture.aWidget()));
+
+        widgetSettingService.saveAll(widgetSettings);
+
+        verify(widgetSettingRepository).saveAll(widgetSettings);
+    }
+
+    // ── deleteAll ─────────────────────────────────────────────────────────────
+
+    @Test
+    void deleteAllRemovesAllWidgetSettingsWhenCalled() {
+        widgetSettingService.deleteAll();
+
+        verify(widgetSettingRepository).deleteAll();
+    }
+
+    // ── findAllByUserId / findByUserId ────────────────────────────────────────
+
+    @Test
+    void findAllByUserIdReturnsSettingsWhenUserHasWidgetSettings() {
+        User user = UserFixture.anEmptyUser();
+        user.setId(5);
+        WidgetSetting ws = WidgetFixture.aWidgetSetting(WidgetFixture.aWidget(), user);
+        when(widgetSettingRepository.findByUserId(5)).thenReturn(List.of(ws));
+
+        List<WidgetSetting> result = widgetSettingService.findAllByUserId(5);
+
+        assertThat(result).hasSize(1);
+        verify(widgetSettingRepository).findByUserId(5);
+    }
+
+    @Test
+    void findByUserIdReturnsSettingsWhenUserHasWidgetSettings() {
+        User user = UserFixture.anEmptyUser();
+        user.setId(5);
+        WidgetSetting ws = WidgetFixture.aWidgetSetting(WidgetFixture.aWidget(), user);
+        when(widgetSettingRepository.findByUserId(5)).thenReturn(List.of(ws));
+
+        List<WidgetSetting> result = widgetSettingService.findByUserId(5);
+
+        assertThat(result).hasSize(1);
+        verify(widgetSettingRepository).findByUserId(5);
+    }
+
+    // ── toResource ────────────────────────────────────────────────────────────
+
+    @Test
+    void toResourceConvertsEntityToResourceWhenEntityIsValid() {
+        Widget widget = WidgetFixture.aWidget();
+        WidgetSetting ws = WidgetFixture.aWidgetSetting(widget);
+
+        WidgetSettingResource resource = widgetSettingService.toResource(ws);
+
+        assertThat(resource.getWidgetId()).isEqualTo(widget.getId());
+        assertThat(resource.getI()).isEqualTo(widget.getName());
+        assertThat(resource.getX()).isEqualTo(ws.getAxisX());
+        assertThat(resource.getY()).isEqualTo(ws.getAxisY());
+        assertThat(resource.getW()).isEqualTo(ws.getWidth());
+        assertThat(resource.getH()).isEqualTo(ws.getHeight());
+        assertThat(resource.getMinW()).isEqualTo(ws.getMinWidth());
+        assertThat(resource.getMinH()).isEqualTo(ws.getMinHeight());
+    }
+
+    // ── toEntity ──────────────────────────────────────────────────────────────
+
+    @Test
+    void toEntityReturnsWidgetSettingWhenBothWidgetAndUserExist() {
+        WidgetSettingResource resource = WidgetFixture.aWidgetSettingResource();
+        Widget widget = WidgetFixture.aWidget();
+        User user = UserFixture.anEmptyUser();
+        user.setId(5);
+        when(widgetServiceImp.findById(resource.getWidgetId())).thenReturn(Optional.of(widget));
+        when(userService.findById(5)).thenReturn(Optional.of(user));
+
+        WidgetSetting result = widgetSettingService.toEntity(resource, 5);
+
+        assertThat(result.getWidget()).isEqualTo(widget);
+        assertThat(result.getUser()).isEqualTo(user);
+        assertThat(result.getWidth()).isEqualTo(resource.getW());
+        assertThat(result.getHeight()).isEqualTo(resource.getH());
+    }
+
+    @Test
+    void toEntityThrowsRuntimeExceptionWhenWidgetNotFound() {
+        WidgetSettingResource resource = WidgetFixture.aWidgetSettingResource();
+        when(widgetServiceImp.findById(resource.getWidgetId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> widgetSettingService.toEntity(resource, 5))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Widget not found");
+    }
+
+    @Test
+    void toEntityThrowsRuntimeExceptionWhenUserNotFound() {
+        WidgetSettingResource resource = WidgetFixture.aWidgetSettingResource();
+        Widget widget = WidgetFixture.aWidget();
+        when(widgetServiceImp.findById(resource.getWidgetId())).thenReturn(Optional.of(widget));
+        when(userService.findById(5)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> widgetSettingService.toEntity(resource, 5))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("User not found");
+    }
+}

--- a/src/backend/src/test/resources/application-test.yml
+++ b/src/backend/src/test/resources/application-test.yml
@@ -17,7 +17,9 @@ spring:
   #  DB_CLOSE_DELAY=-1 keeps the database alive for the full JVM lifetime —
   #  without it H2 closes between test method executions.
   datasource:
-    url: jdbc:h2:mem:opencelium_test;DB_CLOSE_DELAY=-1;MODE=MySQL
+    # NON_KEYWORDS stops H2 treating USER and VALUE as reserved words.
+    # H2 2.x rejects "create table user" and "column value varchar" without this.
+    url: jdbc:h2:mem:opencelium_test;DB_CLOSE_DELAY=-1;MODE=MySQL;NON_KEYWORDS=USER,VALUE
     driver-class-name: org.h2.Driver
     username: sa
     password:


### PR DESCRIPTION
## What
- Add `WidgetSettingServiceImplTest` (13 unit tests) and `WidgetSettingRepositoryTest` (3 JPA slice tests).
- Fix `WidgetSettingServiceImp` to inject `WidgetService` / `UserService` interfaces instead of the concrete implementation classes.
- Fix `@SliceTest` to add `@AutoConfigureTestDatabase(replace = Replace.NONE)` so the custom H2 datasource URL from `application-test.yml` is used.
- Add `NON_KEYWORDS=USER,VALUE` to the H2 JDBC URL so H2 2.x does not reject `create table user` and column names that clash with its reserved words.

## Why
Part of OC-1400.

## How to test
```bash
# Unit tests — no Docker needed
./gradlew test --tests "*.WidgetSettingServiceImplTest"

# JPA slice tests — no Docker needed
./gradlew test --tests "*.WidgetSettingRepositoryTest"

# Full fast suite
./gradlew test
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added — `WidgetSettingServiceImplTest` (13 tests), `WidgetSettingRepositoryTest` (3 tests)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
