### PR TITLE
[OC-1394] ReferenceExtractor legacy unit tests migration

### DIFF
--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.execution.oc721.Operation;
+import com.becon.opencelium.backend.testutil.fake.FakeReferenceExtractor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+/**
+ * Object mother for {@link Operation} test data.
+ */
+public final class OperationFixture {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String RESOURCE = "/fake/response-entity-body-reference-extractor.json";
+    private static final Map<String, Object> body;
+
+    static {
+        try (InputStream is = FakeReferenceExtractor.class.getResourceAsStream(RESOURCE)) {
+            body = MAPPER.readValue(is, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load test fixture: " + RESOURCE, e);
+        }
+    }
+
+    private OperationFixture() {
+    }
+
+    public static Operation anOperationWithResponseBody() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE);
+
+        ResponseEntity<?> response = new ResponseEntity<>(body, headers, HttpStatus.OK);
+
+        Operation operation = new Operation();
+        operation.setColor("#ababab");
+        operation.setLoopDepth(0);
+
+        operation.getResponses().put("#", response);
+
+        return operation;
+    }
+
+    public static Operation anOperationInDoubleLoop() {
+        String body = "{\"index\": \"%s\"}";
+
+        ResponseEntity<?> res00 = response(200, header("index", "0_0"), body.formatted("0_0"));
+        ResponseEntity<?> res01 = response(201, header("index", "0_1"), body.formatted("0_1"));
+        ResponseEntity<?> res02 = response(202, header("index", "0_2"), body.formatted("0_2"));
+        ResponseEntity<?> res10 = response(300, header("index", "1_0"), body.formatted("1_0"));
+        ResponseEntity<?> res11 = response(301, header("index", "1_1"), body.formatted("1_1"));
+        ResponseEntity<?> res12 = response(302, header("index", "1_2"), body.formatted("1_2"));
+
+        Map<String, ResponseEntity<?>> responses = Map.of(
+                "0, 0", res00, "1, 1", res11, "1, 0", res10,
+                "0, 2", res02, "0, 1", res01, "1, 2", res12
+        );
+
+        return operation("#ababab", 2, responses);
+    }
+
+
+    private static HttpHeaders header(String key, String value) {
+        var headers = new HttpHeaders();
+        headers.add(key, value);
+
+        return headers;
+    }
+
+    private static ResponseEntity<?> response(int status, HttpHeaders headers, Object body) {
+        return new ResponseEntity<>(body, headers, HttpStatus.valueOf(status));
+    }
+
+    private static Operation operation(String color, int loopDepth, Map<String, ResponseEntity<?>> responses) {
+        Operation operation = new Operation();
+        operation.setColor(color);
+        operation.setLoopDepth(loopDepth);
+
+        operation.getResponses().putAll(responses);
+
+        return operation;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
@@ -1,0 +1,591 @@
+package com.becon.opencelium.backend.unit.execution.oc721;
+
+import com.becon.opencelium.backend.execution.ExecutionManager;
+import com.becon.opencelium.backend.execution.oc721.Loop;
+import com.becon.opencelium.backend.execution.oc721.Operation;
+import com.becon.opencelium.backend.execution.oc721.ReferenceExtractor;
+import com.becon.opencelium.backend.resource.execution.OperatorEx;
+import com.becon.opencelium.backend.testutil.fixture.OperationFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ReferenceExtractor}.
+ * <p>
+ * No Spring context is loaded.
+ */
+@DisplayName("ReferenceExtractor — unit")
+@ExtendWith(MockitoExtension.class)
+public class ReferenceExtractorTest {
+    @Mock
+    ExecutionManager executionManager;
+
+    @InjectMocks
+    ReferenceExtractor extractor;
+
+    /*
+     * Test-only delegate for ReferenceExtractor.extractValue(..).
+     * Used to reduce noise in "find usages" results from test code.
+     */
+    private Object extractValue(String rawReference) {
+        return extractor.extractValue(rawReference);
+    }
+
+
+    //-----------------------------------------------------------
+    //                    DIRECT_REFERENCE
+    //-----------------------------------------------------------
+
+    @Test
+    void extractValueReturnsAllResponseEntities() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationInDoubleLoop();
+
+        when(executionManager.findOperationByColor(operation.getColor()))
+                .thenReturn(Optional.of(operation));
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).[*]");
+
+        // THEN
+        assertInstanceOf(TreeMap.class, result);
+        assertEquals(6, ((Map) result).size());
+    }
+
+    @Test
+    void extractValueReturnsAllResponseEntityStatuses() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationInDoubleLoop();
+
+        when(executionManager.findOperationByColor(operation.getColor()))
+                .thenReturn(Optional.of(operation));
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).[*].status");
+
+        // THEN
+        assertInstanceOf(TreeMap.class, result);
+        var statuses = (TreeMap<String, Integer>) result;
+
+        assertEquals(
+                List.of(200, 201, 202, 300, 301, 302),
+                statuses.values().stream().toList()
+        );
+    }
+
+    @Test
+    void extractValueReturnsAllResponseEntityHeaders() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationInDoubleLoop();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).[*].header");
+
+        // THEN
+        assertInstanceOf(TreeMap.class, result);
+        var headers = (TreeMap<String, Map<String, List<String>>>) result;
+
+        headers.forEach((key, values) -> {
+            assertTrue(values.get("index").contains(key.replace(", ", "_")));
+        });
+    }
+
+    @Test
+    void extractValueReturnsAllResponseEntityBodies() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationInDoubleLoop();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).[*].body");
+
+        // THEN
+        assertInstanceOf(TreeMap.class, result);
+        var bodies = (TreeMap<String, Object>) result;
+
+        var expected = List.of(
+                "{\"index\": \"0_0\"}", "{\"index\": \"0_1\"}", "{\"index\": \"0_2\"}",
+                "{\"index\": \"1_0\"}", "{\"index\": \"1_1\"}", "{\"index\": \"1_2\"}"
+        );
+        assertEquals(expected, new ArrayList<>(bodies.values()));
+    }
+
+    @Test
+    void extractValueReturnsAllResponseEntityStatusWhenCalledInALoop() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationInDoubleLoop();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("1, 1");
+
+        // WHEN
+        Object status = extractValue("#ababab.(response).status");
+
+        // THEN
+        assertEquals(301, status);
+    }
+
+    @Test
+    @DisplayName("obj['i']~ - field name on ith index (indexing starts from 0)")
+    void extractValueReturnsFieldNameOnIthIndex() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop = loop("forin", "i", "forin {%#ababab.(response).body.$.meta%}");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN
+        loop.setIndex(1);
+        loop.setValue("version");
+
+        Object val = extractValue("#ababab.(response).body.$.meta['i']~");
+
+        // THEN
+        assertEquals("version", val);
+    }
+
+    @Test
+    @DisplayName("obj['*']~ - all field names")
+    void extractValueReturnsAllFieldNames() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$.meta['*']~");
+
+        // THEN
+        assertEquals(List.of("response-id", "version"), val);
+    }
+
+    @Test
+    @DisplayName("obj['field_name']~ - field_name itself")
+    void extractValueReturnsFieldNameItself() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val1 = extractValue("#ababab.(response).body.$.meta['response-id']~");
+
+        // THEN
+        assertEquals("response-id", val1);
+    }
+
+    @Test
+    @DisplayName("obj['i'] - value of the field on ith index (indexing starts from 0)")
+    void extractValueReturnsFieldValueOnIthIndex() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        // loop extracts targeted objects field names
+        Loop loop = loop("forin", "i", "forin {%#ababab.(response).body.$.data.items[0]%}");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN-THEN
+        loop.setIndex(1);
+        loop.setValue("name");
+
+        Object val1 = extractValue("#ababab.(response).body.$.data.items[0]['i']"); // primitive
+        assertEquals("first", val1);
+
+        loop.setIndex(3);
+        loop.setValue("metrics");
+        Object val2 = extractValue("#ababab.(response).body.$.data.items[0]['i']"); // object
+        assertInstanceOf(Map.class, val2);
+        var metrics = (Map<String, Object>) val2;
+        assertEquals(10, metrics.get("count"));
+        assertEquals(0.5, metrics.get("ratio"));
+    }
+
+    @Test
+    @DisplayName("obj['field_name'] - value of the field by its name")
+    void extractValueReturnsFieldValueByFieldName() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$.data['key_with_underscore']");
+
+        // THEN
+        assertInstanceOf(Map.class, val);
+        Map keyWithUnderscore = (Map) val;
+        assertTrue(keyWithUnderscore.containsKey("key.with.dot"));
+
+        assertInstanceOf(Map.class, keyWithUnderscore.get("key.with.dot"));
+        Map keyWithDot = (Map) keyWithUnderscore.get("key.with.dot");
+        assertTrue(keyWithDot.containsKey("inner-value"));
+        assertEquals(1, keyWithDot.size());
+        assertEquals(42, keyWithDot.get("inner-value"));
+    }
+
+    @Test
+    @DisplayName("field[i]~ - string on the ith index (indexing starts from 0)")
+    void extractValueReturnsStringValueOnIthIndexAfterSplitting() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop = loop("SplitString", "i", "{%#ababab.(response).body.$.string_with_delimiter[*]~%} SplitString ';'");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN-THEN
+        loop.setValue("d");
+        loop.setIndex(3);
+        Object val2 = extractValue("#ababab.(response).body.$.string_with_delimiter[i]~");
+        assertEquals("d", val2);
+    }
+
+    @Test
+    @DisplayName("field[*]~- all strings (after splitting)")
+    void extractValueReturnsAllStringValuesAfterSplitting() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop = loop("SplitString", "i", "{%#ababab.(response).body.$.string_with_delimiter[*]~%} SplitString ';'");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$.string_with_delimiter[*]~");
+
+        // THEN
+        assertInstanceOf(List.class, val);
+        assertEquals(List.of("a", "b", "c", "d"), val);
+    }
+
+    @Test
+    @DisplayName("field[2]~ - string on the 2nd index (indexing starts from 0)")
+    void extractValueReturnsStringValueOnSpecifiedIndexAfterSplitting() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop = loop("SplitString", "i", "{%#ababab.(response).body.$.string_with_delimiter[*]~%} SplitString ';'");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN-THEN
+        loop.setIndex(0);
+        loop.setValue("a");
+        Object val1 = extractValue("#ababab.(response).body.$.string_with_delimiter[0]~");
+        assertEquals("a", val1);
+
+        loop.setIndex(2);
+        loop.setValue("c");
+        Object val2 = extractValue("#ababab.(response).body.$.string_with_delimiter[2]~");
+        assertEquals("c", val2);
+    }
+
+    @Test
+    @DisplayName("array[i] - value on the ith index (indexing starts from 0)")
+    void extractValueReturnsArrayElementOnIthIndex() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop = loop("for", "i", "for {%#ababab.(response).body.$.list[*]%}");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN-THEN
+        loop.setIndex(0);
+        loop.setValue("0");
+        Object val1 = extractValue("#ababab.(response).body.$.list[i]");
+        assertEquals("L1", val1); // string
+
+        loop.setIndex(2);
+        loop.setValue("2");
+        Object val2 = extractValue("#ababab.(response).body.$.list[i]");
+        assertEquals("L3", val2); // string
+    }
+
+    @Test
+    @DisplayName("array[i].field - field value of object on the ith index (indexing starts from 0)")
+    void extractValueReturnsArrayElementFieldValuesOnIthIndex() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop = loop("for", "i", "for {%#ababab.(response).body.$.data.items[*]%}");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop));
+
+        // WHEN-THEN
+        loop.setIndex(1);
+        loop.setValue("1");
+
+        Object val1 = extractValue("#ababab.(response).body.$.data.items[i].id");
+        assertEquals(2, val1); // primitive
+
+        Object val2 = extractValue("#ababab.(response).body.$.data.items[i].name");
+        assertEquals("second", val2); // string
+
+        Object val3 = extractValue("#ababab.(response).body.$.data.items[i].tags");
+        assertInstanceOf(List.class, val3);
+        assertEquals(List.of("x", "y"), val3); // collection
+    }
+
+    @Test
+    @DisplayName("array[3] - value on the 3rd index (indexing starts from 0)")
+    void extractValueReturnsArrayElementOnSpecifiedIndex() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$.list[1]");
+
+        // THEN
+        assertEquals("L2", val);
+    }
+
+    @Test
+    @DisplayName("array[*] - all values")
+    void extractValueReturnsAllArrayElements() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$.list[*]");
+
+        // THEN
+        assertInstanceOf(List.class, val);
+        assertEquals(List.of("L1", "L2", "L3"), val);
+    }
+
+    @Test
+    void extractValueReturnsFieldValueWhenPathIsSimple() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN - THEN
+        Object val1 = extractValue("#ababab.(response).body.$.status");
+        assertEquals("ok", val1); // string
+
+        Object val2 = extractValue("#ababab.(response).body.$.meta.version");
+        assertEquals(3, val2);  // primitive
+    }
+
+    @Test
+    void extractValueReturnsFieldValueWhenPathContainsSpecialSymbols() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN - THEN
+        Object val1 = extractValue("#ababab.(response).body.$.data.key_with_underscore");
+        assertInstanceOf(Map.class, val1);
+        assertTrue(((Map) val1).containsKey("key.with.dot"));
+
+        Object val2 = extractValue("#ababab.(response).body.$.data.key_with_underscore.['key.with.dot']");
+        assertInstanceOf(Map.class, val2);
+        assertTrue(((Map) val2).containsKey("inner-value"));
+
+        Object val3 = extractValue("#ababab.(response).body.$.data.key_with_underscore.['key.with.dot'].inner-value");
+        assertEquals(42, val3);
+    }
+
+    @Test
+    void extractValueReturnsCollectionWhenPathContainsForForInForInLoopOperators() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop1 = loop("for", "i", "for {%#ababab.(response).body.$.data.items[*]%}");
+        Loop loop2 = loop("forin", "j", "forin {%#ababab.(response).body.$.data.items[i]%}");
+        Loop loop3 = loop("forin", "k", "forin {%#ababab.(response).body.$.data.items[i]['j']%}");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop1, loop2, loop3));
+
+        // WHEN - THEN
+        // verify FOR loop creation (1st loop)
+        Object val1 = extractValue("#ababab.(response).body.$.data.items[*]"); // loop1.getRef()
+        assertInstanceOf(List.class, val1);
+        assertEquals(2, ((List) val1).size());
+
+        // verify FOR_IN keys loop creation (2nd loop)
+        // it will be created in 1st loop, so we need to initialize its control values
+        loop1.setIndex(1);
+        loop1.setValue("1");
+        Object val2 = extractValue("#ababab.(response).body.$.data.items[i]['*']~"); // loop2.getRef()
+        assertInstanceOf(List.class, val2);
+        assertEquals(List.of("id", "name", "tags", "metrics"), val2);
+
+        // verify FOR_IN keys loop creation (3rd loop)
+        // it will be created in 1st loop adn 2nd loop, so we need to initialize second loops control values
+        loop2.setIndex(3);
+        loop2.setValue("metrics");
+        Object val3 = extractValue("#ababab.(response).body.$.data.items[i]['j']['*']~"); // loop3.getRef()
+        assertInstanceOf(List.class, val3);
+        assertEquals(List.of("count", "ratio"), val3);
+    }
+
+    @Test
+    void extractValueReturnsCollectionWhenPathContainsForForInSplitStringLoopOperators() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        Loop loop1 = loop("for", "i", "for {%#ababab.(response).body.$.items[*]%}");
+        Loop loop2 = loop("forin", "j", "forin {%#ababab.(response).body.$.items[i]%}");
+        Loop loop3 = loop("SplitString", "k", "{%#ababab.(response).body.$.items[i]['j'][*]~%} SplitString '-'");
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        when(executionManager.getLoops())
+                .thenReturn(List.of(loop1, loop2, loop3));
+
+        // WHEN - THEN
+        // verify FOR loop creation (1st loop)
+        Object val1 = extractValue("#ababab.(response).body.$.items[*]"); // loop1.getRef()
+        assertInstanceOf(List.class, val1);
+        assertEquals(1, ((List) val1).size());
+
+        // verify FOR_IN keys loop creation (2nd loop)
+        // it will be created in 1st loop, so we need to initialize its control values
+        loop1.setIndex(0);
+        loop1.setValue("0");
+        Object val2 = extractValue("#ababab.(response).body.$.items[i]['*']~"); // loop2.getRef()
+        assertInstanceOf(List.class, val2);
+        assertEquals(List.of("name", "string"), val2);
+
+        // verify FOR_IN keys loop creation (3rd loop)
+        // it will be created in 1st loop adn 2nd loop, so we need to initialize second loops control values
+        loop2.setIndex(1);
+        loop2.setValue("string");
+        Object val3 = extractValue("#ababab.(response).body.$.items[i]['j'][*]~"); // loop3.getRef()
+        assertInstanceOf(List.class, val3);
+        assertEquals(List.of("x", "y", "z"), val3);
+    }
+
+
+    private Loop loop(String type, String iterator, String expression) {
+        OperatorEx operator = new OperatorEx();
+        operator.setId("23123");
+        operator.setIndex("1");
+        operator.setType(type);
+        operator.setIterator(iterator);
+        operator.setExpression(expression);
+
+        return Loop.fromOperator(operator);
+    }
+}

--- a/src/backend/src/test/resources/fake/response-entity-body-reference-extractor.json
+++ b/src/backend/src/test/resources/fake/response-entity-body-reference-extractor.json
@@ -1,0 +1,55 @@
+{
+  "status": "ok",
+  "meta": {
+    "response-id": "142",
+    "version": 3
+  },
+  "items": [
+    {
+      "name": "complex Split String",
+      "string": "x-y-z"
+    }
+  ],
+  "data": {
+    "items": [
+      {
+        "id": 1,
+        "name": "first",
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ],
+        "metrics": {
+          "count": 10,
+          "ratio": 0.5
+        }
+      },
+      {
+        "id": 2,
+        "name": "second",
+        "tags": [
+          "x",
+          "y"
+        ],
+        "metrics": {
+          "count": 20,
+          "ratio": 1.5
+        }
+      }
+    ],
+    "key_with_underscore": {
+      "key.with.dot": {
+        "inner-value": 42
+      }
+    }
+  },
+  "list": [
+    "L1",
+    "L2",
+    "L3"
+  ],
+  "string_with_delimiter": "a;b;c;d",
+  "string_array": "[\"a\", \"b\", \"c\"]",
+  "last": true
+}


### PR DESCRIPTION
## What
- Migrated existing tests
- Add coverage for mixed loops in single path

## Why
Resolves: [[OC-1394] ReferenceExtractor legacy unit tests migration](https://becon.atlassian.net/browse/OC-1394)

Covers: [[OC 1375] Investigate and optimize performance degradation when processing large arrays with references](https://becon.atlassian.net/browse/OC-1375)

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code