### PR TITLE
[Modified] OC-1406 Modified API layer to support new structure. Fixed NPEs for connectors

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/application/assistant/AssistantServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/application/assistant/AssistantServiceImp.java
@@ -471,7 +471,9 @@ public class AssistantServiceImp implements ApplicationService {
         Invoker toInvoker = invokerService.findByName(toInvokerStr);
 
         addHeaderFromInvokerHelper(connectionMng.getFromConnector().getMethods(), fromInvoker);
-        addHeaderFromInvokerHelper(connectionMng.getToConnector().getMethods(), toInvoker);
+        if (connectionMng.getToConnector() != null) {
+            addHeaderFromInvokerHelper(connectionMng.getToConnector().getMethods(), toInvoker);
+        }
     }
 
     private void addHeaderFromInvokerHelper(List<MethodMng> methods, Invoker invoker) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ConnectionConstants.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ConnectionConstants.java
@@ -1,0 +1,6 @@
+package com.becon.opencelium.backend.constant;
+
+public interface ConnectionConstants {
+    String DEFAULT_CONNECTOR_NAME = "DEFAULT";
+    Integer DEFAULT_CONNECTOR_ID = -1;
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
@@ -15,4 +15,5 @@ public interface ExceptionMessages {
     String CANT_REMOVE_LAST_VERSION_CONNECTION = "Can't remove last version connection";
     String ONLY_OWNER_CAN_PERFORM_ACTION = "Only owner can perform this action";
     String ONLY_OWNER_OR_ADMIN_CAN_PERFORM_ACTION = "Only owner or admin can perform this action";
+    String FROM_CONNECTOR_IS_NULL = "fromConnector is null";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -210,9 +210,11 @@ public class ConnectionController {
             c.getFromConnector().getInvoker().setOperations(null);
             c.getFromConnector().getInvoker().setRequiredData(null);
 
-            c.getToConnector().setRequestData(null);
-            c.getToConnector().getInvoker().setOperations(null);
-            c.getToConnector().getInvoker().setRequiredData(null);
+            if (c.getToConnector() != null) {
+                c.getToConnector().setRequestData(null);
+                c.getToConnector().getInvoker().setOperations(null);
+                c.getToConnector().getInvoker().setRequiredData(null);
+            }
         });
         return ResponseEntity.ok(connectionResources);
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connection.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connection.java
@@ -46,10 +46,17 @@ public class Connection {
     private String description;
 
     @Column(name = "from_connector")
-    private int fromConnector;
+    private Integer fromConnector;
 
+    /**
+     * ID of the target connector in legacy (two-connector) connections.
+     * <p>
+     * <b>Null for multi-connector connections</b> — in that mode each method on
+     * {@code fromConnector} carries its own connector reference via
+     * {@code MethodMng.connector.connectorId}.
+     */
     @Column(name = "to_connector")
-    private int toConnector;
+    private Integer toConnector;
 
     @CreatedBy
     @Column(name = "created_by", updatable = false)
@@ -119,19 +126,19 @@ public class Connection {
         this.description = description;
     }
 
-    public int getFromConnector() {
+    public Integer getFromConnector() {
         return fromConnector;
     }
 
-    public void setFromConnector(int fromConnector) {
+    public void setFromConnector(Integer fromConnector) {
         this.fromConnector = fromConnector;
     }
 
-    public int getToConnector() {
+    public Integer getToConnector() {
         return toConnector;
     }
 
-    public void setToConnector(int toConnector) {
+    public void setToConnector(Integer toConnector) {
         this.toConnector = toConnector;
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -134,15 +134,24 @@ public class ConnectionServiceImp implements ConnectionService {
             throw new RuntimeException("TITLE_HAS_ALREADY_TAKEN");
         }
 
-        //checking existence of connectors
-        Connector from = connectorService.getById(connection.getToConnector());
-        Connector to = connectorService.getById(connection.getFromConnector());
-
-        connectionMng.getFromConnector().setTitle(from.getTitle());
-        connectionMng.getToConnector().setTitle(to.getTitle());
+        if (connection.getFromConnector() == null) {
+            throw new GeneralServiceException(ExceptionConstant.CONNECTOR_NOT_FOUND, ExceptionMessages.FROM_CONNECTOR_IS_NULL);
+        }
 
         connectionMng.getFromConnector().setFlowId(UUID.randomUUID().toString());
-        connectionMng.getToConnector().setFlowId(UUID.randomUUID().toString());
+
+        if (Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)) {
+            connectionMng.getFromConnector().setTitle(ConnectionConstants.DEFAULT_CONNECTOR_NAME);
+        } else {
+            Connector from = connectorService.getById(connection.getFromConnector());
+            connectionMng.getFromConnector().setTitle(from.getTitle());
+        }
+
+        if (connection.getToConnector() != null) {
+            Connector to = connectorService.getById(connection.getToConnector());
+            connectionMng.getToConnector().setTitle(to.getTitle());
+            connectionMng.getToConnector().setFlowId(UUID.randomUUID().toString());
+        }
 
         //checking existence of category
         if (connection.getCategoryId() != null) {
@@ -175,15 +184,24 @@ public class ConnectionServiceImp implements ConnectionService {
 
         ConnectionMng oldMng = connectionMngService.getById(sCon.getSnapshotId());
 
-        //checking existence of connectors
-        Connector from = connectorService.getById(connection.getToConnector());
-        Connector to = connectorService.getById(connection.getFromConnector());
-
-        connectionMng.getFromConnector().setTitle(from.getTitle());
-        connectionMng.getToConnector().setTitle(to.getTitle());
+        if (connection.getFromConnector() == null) {
+            throw new GeneralServiceException(ExceptionConstant.CONNECTOR_NOT_FOUND, ExceptionMessages.FROM_CONNECTOR_IS_NULL);
+        }
 
         connectionMng.getFromConnector().setFlowId(oldMng.getFromConnector().getFlowId());
-        connectionMng.getToConnector().setFlowId(oldMng.getToConnector().getFlowId());
+
+        if (Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)) {
+            connectionMng.getFromConnector().setTitle(ConnectionConstants.DEFAULT_CONNECTOR_NAME);
+        } else {
+            Connector from = connectorService.getById(connection.getFromConnector());
+            connectionMng.getFromConnector().setTitle(from.getTitle());
+        }
+
+        if (connection.getToConnector() != null) {
+            Connector to = connectorService.getById(connection.getToConnector());
+            connectionMng.getToConnector().setTitle(to.getTitle());
+            connectionMng.getToConnector().setFlowId(oldMng.getToConnector().getFlowId());
+        }
 
         //checking existence of category
         if (connection.getCategoryId() != null && !connection.getCategoryId().equals(sCon.getCategoryId())) {
@@ -340,13 +358,15 @@ public class ConnectionServiceImp implements ConnectionService {
         connectionDTOMng.setCategoryId(connectionDTO.getCategoryId());
 
         if (connectionDTOMng.getFromConnector() != null) {
-            ConnectorDTO temp = connectionDTOMng.getFromConnector();
-            connectionDTOMng.setFromConnector(connectorMapper.toDTO(connectorService.getById(connection.getFromConnector())));
-            connectionDTOMng.getFromConnector().setOperators(temp.getOperators() == null ? new ArrayList<>() : temp.getOperators());
-            connectionDTOMng.getFromConnector().setMethods(temp.getMethods() == null ? new ArrayList<>() : temp.getMethods());
+            if(!Objects.equals(ConnectionConstants.DEFAULT_CONNECTOR_ID, connectionDTOMng.getFromConnector().getConnectorId())) {
+                ConnectorDTO temp = connectionDTOMng.getFromConnector();
+                connectionDTOMng.setFromConnector(connectorMapper.toDTO(connectorService.getById(connection.getFromConnector())));
+                connectionDTOMng.getFromConnector().setOperators(temp.getOperators() == null ? new ArrayList<>() : temp.getOperators());
+                connectionDTOMng.getFromConnector().setMethods(temp.getMethods() == null ? new ArrayList<>() : temp.getMethods());
+            }
         }
 
-        if (connectionDTOMng.getToConnector() != null) {
+        if (connection.getToConnector() != null) {
             ConnectorDTO temp = connectionDTOMng.getToConnector();
             connectionDTOMng.setToConnector(connectorMapper.toDTO(connectorService.getById(connection.getToConnector())));
             connectionDTOMng.getToConnector().setOperators(temp.getOperators() == null ? new ArrayList<>() : temp.getOperators());

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
@@ -16,6 +16,7 @@
 
 package com.becon.opencelium.backend.database.mysql.service;
 
+import com.becon.opencelium.backend.constant.ConnectionConstants;
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.entity.EventNotification;
@@ -299,10 +300,14 @@ public class SchedulerServiceImp implements SchedulerService {
             jobsResource.setAvgDuration(avg);
 
             Connection connection = connectionService.getById(connId);
-            Connector fromCotr = connectorService.getById(connection.getFromConnector());
-            Connector toCtor = connectorService.getById(connection.getToConnector());
-            jobsResource.setToConnector(toCtor.getTitle());
-            jobsResource.setFromConnector(fromCotr.getTitle());
+            if(!Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)){
+                Connector fromCotr = connectorService.getById(connection.getFromConnector());
+                jobsResource.setFromConnector(fromCotr.getTitle());
+            }
+            if (connection.getToConnector() != null) {
+                Connector toCtor = connectorService.getById(connection.getToConnector());
+                jobsResource.setToConnector(toCtor.getTitle());
+            }
 
             runningJobsResources.add(jobsResource);
         });
@@ -325,10 +330,16 @@ public class SchedulerServiceImp implements SchedulerService {
                 jobsResource.setAvgDuration(avg);
 
                 Connection connection = connectionService.getById(connId);
-                Connector fromCotr = connectorService.getById(connection.getFromConnector());
-                Connector toCtor = connectorService.getById(connection.getToConnector());
-                jobsResource.setToConnector(toCtor.getTitle());
-                jobsResource.setFromConnector(fromCotr.getTitle());
+                if (!Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)) {
+                    Connector fromCotr = connectorService.getById(connection.getFromConnector());
+                    jobsResource.setFromConnector(fromCotr.getTitle());
+                } else {
+                    jobsResource.setFromConnector(ConnectionConstants.DEFAULT_CONNECTOR_NAME);
+                }
+                if (connection.getToConnector() != null) {
+                    Connector toCtor = connectorService.getById(connection.getToConnector());
+                    jobsResource.setToConnector(toCtor.getTitle());
+                }
 
                 runningJobsResources.add(jobsResource);
             }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/supportfile/SupportFileServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/supportfile/SupportFileServiceImp.java
@@ -1,6 +1,7 @@
 package com.becon.opencelium.backend.execution.supportfile;
 
 import com.becon.opencelium.backend.constant.AppYamlPath;
+import com.becon.opencelium.backend.constant.ConnectionConstants;
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
@@ -30,6 +31,7 @@ import java.nio.file.Path;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -218,16 +220,20 @@ public class SupportFileServiceImp implements SupportFileService {
             addToZip(zipOutputStream, template, "connection_template.json");
 
             // Add invoker files:
-            int fromConnectorId = dto.getFromConnector().getConnectorId();
-            Connector fromConnector = connectorSqlService.getById(fromConnectorId);
-            File fromInvoker = invokerService.findFileByInvokerName(fromConnector.getInvoker());
-            addToZip(zipOutputStream, fromInvoker, fromConnector.getInvoker() + ".xml");
+            Integer fromConnectorId = dto.getFromConnector().getConnectorId();
+            if(!Objects.equals(fromConnectorId, ConnectionConstants.DEFAULT_CONNECTOR_ID)){
+                Connector fromConnector = connectorSqlService.getById(fromConnectorId);
+                File fromInvoker = invokerService.findFileByInvokerName(fromConnector.getInvoker());
+                addToZip(zipOutputStream, fromInvoker, fromConnector.getInvoker() + ".xml");
+            }
 
-            int toConnectorId = dto.getToConnector().getConnectorId();
-            if (fromConnectorId != toConnectorId) {
-                Connector toConnector = connectorSqlService.getById(toConnectorId);
-                File toInvoker = invokerService.findFileByInvokerName(toConnector.getInvoker());
-                addToZip(zipOutputStream, toInvoker, toConnector.getInvoker() + ".xml");
+            if (dto.getToConnector() != null) {
+                int toConnectorId = dto.getToConnector().getConnectorId();
+                if (fromConnectorId != toConnectorId) {
+                    Connector toConnector = connectorSqlService.getById(toConnectorId);
+                    File toInvoker = invokerService.findFileByInvokerName(toConnector.getInvoker());
+                    addToZip(zipOutputStream, toInvoker, toConnector.getInvoker() + ".xml");
+                }
             }
 
             // copy temporary uncategorized log file into zip, then delete it:

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mongo/MethodConnectorMngMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mongo/MethodConnectorMngMapper.java
@@ -1,0 +1,22 @@
+package com.becon.opencelium.backend.mapper.mongo;
+
+import com.becon.opencelium.backend.database.mongodb.entity.MethodConnectorMng;
+import com.becon.opencelium.backend.mapper.base.Mapper;
+import com.becon.opencelium.backend.resource.connection.MethodConnectorDTO;
+import org.mapstruct.Named;
+import org.mapstruct.ReportingPolicy;
+
+@org.mapstruct.Mapper(
+        componentModel = "spring",
+        unmappedSourcePolicy = ReportingPolicy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+@Named("methodConnectorMngMapper")
+public interface MethodConnectorMngMapper extends Mapper<MethodConnectorMng, MethodConnectorDTO> {
+
+    @Named("toEntity")
+    MethodConnectorMng toEntity(MethodConnectorDTO dto);
+
+    @Named("toDTO")
+    MethodConnectorDTO toDTO(MethodConnectorMng entity);
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mongo/MethodMngMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mongo/MethodMngMapper.java
@@ -16,7 +16,8 @@ import java.util.List;
         componentModel = "spring",
         uses = {
                 RequestMngMapper.class,
-                ResponseMngMapper.class
+                ResponseMngMapper.class,
+                MethodConnectorMngMapper.class
         }
 )
 @Named("methodMngMapper")

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/MethodConnectorDTO.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/MethodConnectorDTO.java
@@ -1,0 +1,26 @@
+package com.becon.opencelium.backend.resource.connection;
+
+import jakarta.annotation.Resource;
+
+@Resource
+public class MethodConnectorDTO {
+
+    private Integer connectorId;
+    private String title;
+
+    public Integer getConnectorId() {
+        return connectorId;
+    }
+
+    public void setConnectorId(Integer connectorId) {
+        this.connectorId = connectorId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/MethodDTO.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/MethodDTO.java
@@ -31,6 +31,7 @@ public class MethodDTO {
     private Integer dataAggregator;
     private RequestDTO request;
     private ResponseDTO response;
+    private MethodConnectorDTO connector;
 
     public String getId() {
         return id;
@@ -94,6 +95,14 @@ public class MethodDTO {
 
     public void setDataAggregator(Integer dataAggregator) {
         this.dataAggregator = dataAggregator;
+    }
+
+    public MethodConnectorDTO getConnector() {
+        return connector;
+    }
+
+    public void setConnector(MethodConnectorDTO connector) {
+        this.connector = connector;
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/old/MethodOldDTO.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/old/MethodOldDTO.java
@@ -16,6 +16,7 @@
 
 package com.becon.opencelium.backend.resource.connection.old;
 
+import com.becon.opencelium.backend.resource.connection.MethodConnectorDTO;
 import com.becon.opencelium.backend.resource.connector.RequestDTO;
 import com.becon.opencelium.backend.resource.connector.ResponseDTO;
 import jakarta.annotation.Resource;
@@ -31,6 +32,7 @@ public class MethodOldDTO {
     private Integer dataAggregator;
     private RequestDTO request;
     private ResponseDTO response;
+    private MethodConnectorDTO connector;
 
     public String getNodeId() {
         return nodeId;
@@ -99,5 +101,13 @@ public class MethodOldDTO {
     @Override
     public boolean equals(Object obj) {
         return this == obj;
+    }
+
+    public MethodConnectorDTO getConnector() {
+        return connector;
+    }
+
+    public void setConnector(MethodConnectorDTO connector) {
+        this.connector = connector;
     }
 }

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -723,3 +723,5 @@ INSERT IGNORE INTO widget_setting (
 --changeset 4.8.1:1 stripComments:true splitStatements:true endDelimiter:;
 ALTER TABLE `enhancement` DROP FOREIGN KEY `fk_enhancement_connection1`;
 ALTER TABLE `enhancement` ADD CONSTRAINT `fk_enhancement_connection1` FOREIGN KEY (`connection_id`) REFERENCES `connection` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+--changeset 5.0:1 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `connection` MODIFY COLUMN `to_connector` INT NULL;


### PR DESCRIPTION
## What
- Modified API layer of connection lifecycle: on create, update, get requests used new structure
- Avoided NPEs on the places called connection's `fromConnector` and `toConnector`

## Why
Part of OC-1406

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed