### PR TITLE
[Fixed] OC-1406 Fixed a problem with setting pagination

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/ConnectorExMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/ConnectorExMapper.java
@@ -67,8 +67,8 @@ public class ConnectorExMapper {
             connectorEx.setInvoker(connector.getInvoker());
             connectorEx.setRequiredData(map);
 
-            setPagination(connectorEx, invoker);
             connectorEx.setMethods(operationExMapper.toOperationAll(dto.getMethods(), connector.getInvoker()));
+            setPagination(connectorEx, invoker);
         } else {
             connectorEx.setMethods(operationExMapper.toOperationAll(dto.getMethods(), null));
         }


### PR DESCRIPTION
## What
There is a bug with setting pagination to old connections.

## Why
Cause is setting pagination is called before setting operations on connector. That is why NPE occurs on using connector's operations

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed