### PR TITLE
[Fixed] OC-1406 NPE on updating operation usage

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ConnectionConstants.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ConnectionConstants.java
@@ -2,5 +2,6 @@ package com.becon.opencelium.backend.constant;
 
 public interface ConnectionConstants {
     String DEFAULT_CONNECTOR_NAME = "DEFAULT";
+    String DEFAULT_INVOKER_NAME = "DEFAULT";
     Integer DEFAULT_CONNECTOR_ID = -1;
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/OperationUsageHistory.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/OperationUsageHistory.java
@@ -40,7 +40,7 @@ public class OperationUsageHistory {
     @Column(name = "from_invoker", nullable = false, length = 255)
     private String fromInvoker;
 
-    @Column(name = "to_invoker", nullable = false, length = 255)
+    @Column(name = "to_invoker", nullable = true, length = 255)
     private String toInvoker;
 
     @OneToMany(mappedBy = "operationUsageHistory", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionServiceImpl.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionServiceImpl.java
@@ -286,7 +286,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .orElseGet(() -> {
                     // If no history exists, create a new one
                     return operationUsageHistoryService.createNewEntity(sub, connectionEx.getConnectionName(),
-                            opsUsage, startTime, connectionEx.getSource().getInvoker(), connectionEx.getTarget().getInvoker());
+                            opsUsage, startTime, connectionEx.getSource().getInvoker(), connectionEx.getTarget() == null ? null : connectionEx.getTarget().getInvoker());
                 });
         operationUsageHistoryService.save(operationUsageHistory);
         if (!isCurrentUsageIsValid(sub)) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/ConnectorExMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/ConnectorExMapper.java
@@ -71,6 +71,7 @@ public class ConnectorExMapper {
             setPagination(connectorEx, invoker);
         } else {
             connectorEx.setMethods(operationExMapper.toOperationAll(dto.getMethods(), null));
+            connectorEx.setInvoker(ConnectionConstants.DEFAULT_INVOKER_NAME);
         }
 
         connectorEx.setName(dto.getTitle());

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -725,3 +725,5 @@ ALTER TABLE `enhancement` DROP FOREIGN KEY `fk_enhancement_connection1`;
 ALTER TABLE `enhancement` ADD CONSTRAINT `fk_enhancement_connection1` FOREIGN KEY (`connection_id`) REFERENCES `connection` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
 --changeset 5.0:1 stripComments:true splitStatements:true endDelimiter:;
 ALTER TABLE `connection` MODIFY COLUMN `to_connector` INT NULL;
+--changeset 5.0:2 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `operation_usage_history` MODIFY COLUMN `to_invoker` VARCHAR(255) NULL;


### PR DESCRIPTION
## What
- Made `operation_usage_history` table's `to_invoker` column nullable
- Avoided NPEs on setting toInvoker while creating operation-usage
- set `DEFAULT` value to `fromInvoker` field of operation-usage

## Why
Part of OC-1406

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed