### PR TITLE
[Added] Implemented read-only in-memory migration to 5.0 version

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngService.java
@@ -16,6 +16,8 @@ public interface ConnectionMngService {
 
     List<ConnectionMng> getAllByConnectionId(Long id);
 
+    List<ConnectionMng> getAllByConnectionIdRaw(Long id);
+
     long deleteByConnectionIdIn(List<Long> chunk);
 
     void deleteAllByConnectionId(Long id);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
@@ -11,8 +11,12 @@ import com.becon.opencelium.backend.database.mongodb.repository.ConnectionMngRep
 import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.mapper.mongo.ConnectionMngMapper;
 import com.becon.opencelium.backend.resource.connection.ConnectionVersionUpdateRequest;
+import com.becon.opencelium.backend.versionmanager.EntityUpdater;
+import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -21,20 +25,25 @@ import java.util.Objects;
 
 @Service
 public class ConnectionMngServiceImp implements ConnectionMngService {
+    private static final Logger log = LoggerFactory.getLogger(ConnectionMngServiceImp.class);
+
     private final ConnectionMngRepository connectionMngRepository;
     private final FieldBindingMngService fieldBindingMngService;
     private final OpenceliumProps ocProps;
     private final ConnectionMngMapper connectionMngMapper;
+    private final EntityUpdater<ConnectionMng> connectionMngEntityUpdater;
 
     public ConnectionMngServiceImp(
             ConnectionMngRepository connectionMngRepository,
             @Qualifier("fieldBindingMngServiceImp") FieldBindingMngService fieldBindingMngService,
-            OpenceliumProps ocProps, ConnectionMngMapper connectionMngMapper
+            OpenceliumProps ocProps, ConnectionMngMapper connectionMngMapper,
+            EntityVersionManager entityVersionManager
     ) {
         this.connectionMngRepository = connectionMngRepository;
         this.fieldBindingMngService = fieldBindingMngService;
         this.ocProps = ocProps;
         this.connectionMngMapper = connectionMngMapper;
+        this.connectionMngEntityUpdater = entityVersionManager.getUpdater(ConnectionMng.class);
     }
 
     @Override
@@ -62,7 +71,9 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
 
     @Override
     public List<ConnectionMng> getAll() {
-        return connectionMngRepository.findAll();
+        List<ConnectionMng> all = connectionMngRepository.findAll();
+        all.forEach(this::applyVersionUpdater);
+        return all;
     }
 
     @Override
@@ -84,13 +95,36 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
 
     @Override
     public ConnectionMng getById(String id) {
-        return connectionMngRepository.findById(id)
+        ConnectionMng connectionMng = connectionMngRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("CONNECTION_NOT_FOUND"));
+        applyVersionUpdater(connectionMng);
+        return connectionMng;
     }
 
     @Override
     public List<ConnectionMng> getAllByConnectionId(Long id) {
+        List<ConnectionMng> all = connectionMngRepository.findAllByConnectionIdOrderByConnectionIdDesc(id);
+        all.forEach(this::applyVersionUpdater);
+        return all;
+    }
+
+    @Override
+    public List<ConnectionMng> getAllByConnectionIdRaw(Long id) {
         return connectionMngRepository.findAllByConnectionIdOrderByConnectionIdDesc(id);
+    }
+
+    /**
+     * Migrates the in-memory ConnectionMng to the running OpenCelium version without persisting the change.
+     * The DB document stays at its original version; conversion happens only on the read path.
+     */
+    private void applyVersionUpdater(ConnectionMng connectionMng) {
+        if (connectionMng == null) return;
+        try {
+            connectionMngEntityUpdater.updateToCurrentVersion(connectionMng);
+        } catch (Exception e) {
+            log.error("Failed to convert ConnectionMng[id={}, version={}] to current version on read",
+                    connectionMng.getId(), connectionMng.getVersion(), e);
+        }
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -44,6 +44,7 @@ import com.becon.opencelium.backend.utility.LogFileUtility;
 import com.becon.opencelium.backend.utility.patch.PatchHelper;
 import com.becon.opencelium.backend.versionmanager.EntityUpdater;
 import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
+import com.becon.opencelium.backend.versionmanager.base.UpdaterVersion;
 import com.becon.opencelium.backend.versionmanager.base.Utils;
 import com.github.fge.jsonpatch.JsonPatch;
 import jakarta.persistence.EntityNotFoundException;
@@ -83,7 +84,7 @@ public class ConnectionServiceImp implements ConnectionService {
     private final PatchHelper patchHelper;
     private final WebhookService webhookService;
     private final OpenceliumProps ocProps;
-    private final EntityUpdater<ConnectionMng> connectionMngEntityUpdater;
+    private final EntityUpdater<ConnectionMng> connectionMngStartupUpdater;
     private final OwnershipSecurity ownershipSecurity;
 
     public ConnectionServiceImp(
@@ -120,7 +121,7 @@ public class ConnectionServiceImp implements ConnectionService {
         this.webhookService = webhookService;
         this.ruleRepository = ruleRepository;
         this.ocProps = ocProps;
-        this.connectionMngEntityUpdater = entityVersionManager.getUpdater(ConnectionMng.class);
+        this.connectionMngStartupUpdater = entityVersionManager.getUpdater(ConnectionMng.class, UpdaterVersion.VERSION_4_8);
         this.ownershipSecurity = ownershipSecurity;
     }
 
@@ -160,11 +161,13 @@ public class ConnectionServiceImp implements ConnectionService {
 
         ConnectionMng savedMng = connectionMngService.create(connectionMng);
 
-        connection.setOcVersion(ocProps.getVersion());
+        String version = resolveVersion(connection);
+        connection.setOcVersion(version);
         connection.setSnapshotId(savedMng.getId());
         Connection savedConnection = connectionRepository.save(connection);
 
         savedMng.setConnectionId(savedConnection.getId());
+        savedMng.setVersion(version);
         connectionMngService.save(savedMng);
 
         connectionHistoryService.makeHistoryAndSave(savedConnection, null, Action.CREATE);
@@ -212,7 +215,11 @@ public class ConnectionServiceImp implements ConnectionService {
         connectionMng.setConnectionId(connection.getId());
         ConnectionMng savedMng = connectionMngService.create(connectionMng);
 
-        connection.setOcVersion(ocProps.getVersion());
+        String version = resolveVersion(connection);
+        savedMng.setVersion(version);
+        connectionMngService.save(savedMng);
+
+        connection.setOcVersion(version);
         connection.setSnapshotId(savedMng.getId());
         connection.setRevision(sCon.getRevision());
         connectionRepository.save(connection);
@@ -368,9 +375,11 @@ public class ConnectionServiceImp implements ConnectionService {
 
         if (connection.getToConnector() != null) {
             ConnectorDTO temp = connectionDTOMng.getToConnector();
-            connectionDTOMng.setToConnector(connectorMapper.toDTO(connectorService.getById(connection.getToConnector())));
-            connectionDTOMng.getToConnector().setOperators(temp.getOperators() == null ? new ArrayList<>() : temp.getOperators());
-            connectionDTOMng.getToConnector().setMethods(temp.getMethods() == null ? new ArrayList<>() : temp.getMethods());
+            if (temp != null) {
+                connectionDTOMng.setToConnector(connectorMapper.toDTO(connectorService.getById(connection.getToConnector())));
+                connectionDTOMng.getToConnector().setOperators(temp.getOperators() == null ? new ArrayList<>() : temp.getOperators());
+                connectionDTOMng.getToConnector().setMethods(temp.getMethods() == null ? new ArrayList<>() : temp.getMethods());
+            }
         }
 
         if (connectionDTOMng.getFieldBinding() == null) {
@@ -491,13 +500,15 @@ public class ConnectionServiceImp implements ConnectionService {
 
     @Override
     public void updateConnectionsToCurrentVersion() {
+        // Startup migration stops at 4.8; the 5.0 transform is applied on the read path only.
+        String targetVersion = UpdaterVersion.VERSION_4_8.getVersion();
         List<Long> ids = connectionRepository.findIds();
 
         for (Long id : ids) {
             Connection connection = getById(id);
-            if (Utils.compare(ocProps.getVersion(), connection.getOcVersion()) > 0 && !isTestConnection(connection.getTitle())) {
+            if (Utils.compare(targetVersion, connection.getOcVersion()) > 0 && !isTestConnection(connection.getTitle())) {
 
-                List<ConnectionMng> connections = connectionMngService.getAllByConnectionId(connection.getId());
+                List<ConnectionMng> connections = connectionMngService.getAllByConnectionIdRaw(connection.getId());
                 if (connections.isEmpty()) {
                     log.error("Failed to find Connection[id={}, name={}] on MongoDB. Skipped updating", connection.getId(), connection.getTitle());
                     continue;
@@ -505,8 +516,7 @@ public class ConnectionServiceImp implements ConnectionService {
 
                 try {
                     for (ConnectionMng connectionMng : connections) {
-                        connectionMngEntityUpdater.updateToCurrentVersion(connectionMng);
-                        connectionMng.setVersion(ocProps.getVersion());
+                        connectionMngStartupUpdater.updateToCurrentVersion(connectionMng);
 
                         if (connectionMng.getCreatedBy() == null) {
                             connectionMng.setCreatedBy(connection.getCreatedBy());
@@ -514,7 +524,7 @@ public class ConnectionServiceImp implements ConnectionService {
                         connectionMngService.save(connectionMng);
                     }
 
-                    log.info("Connection[id={}, name={}, version={}] successfully updated to {} version", connection.getId(), connection.getTitle(), connection.getOcVersion(), ocProps.getVersion());
+                    log.info("Connection[id={}, name={}, version={}] successfully updated to {} version", connection.getId(), connection.getTitle(), connection.getOcVersion(), targetVersion);
                 } catch (Exception e) {
                     log.error("Failed to update Connection[id={}, name={}, version={}]", connection.getId(), connection.getTitle(), connection.getOcVersion(), e);
                     continue;
@@ -525,7 +535,7 @@ public class ConnectionServiceImp implements ConnectionService {
                     connection.setSnapshotId(lastConnection.getId());
                 }
 
-                connection.setOcVersion(ocProps.getVersion());
+                connection.setOcVersion(targetVersion);
                 connectionRepository.save(connection);
             }
         }
@@ -663,6 +673,12 @@ public class ConnectionServiceImp implements ConnectionService {
 
     private boolean isTestConnection(String title) {
         return title != null && title.matches(RegExpression.TEST_CONNECTION_REGEX);
+    }
+
+    private String resolveVersion(Connection connection) {
+        return connection.getToConnector() == null
+                ? ocProps.getVersion()
+                : UpdaterVersion.VERSION_4_8.getVersion();
     }
 
     private void extractVars(Object json, List<String> varList) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateServiceImp.java
@@ -30,6 +30,7 @@ import com.becon.opencelium.backend.utility.FileNameUtils;
 import com.becon.opencelium.backend.versionmanager.EntityUpdater;
 import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
 import com.becon.opencelium.backend.versionmanager.backup.FileBackupManager;
+import com.becon.opencelium.backend.versionmanager.base.UpdaterVersion;
 import com.becon.opencelium.backend.versionmanager.base.Utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -59,6 +60,7 @@ public class TemplateServiceImp implements TemplateService {
     private final Mapper<ConnectionDTO, ConnectionOldDTO> oldDTOMapper;
     private final OpenceliumProps ocProps;
     private final EntityUpdater<Template> templateEntityUpdater;
+    private final EntityUpdater<Template> templateStartupUpdater;
     private final ObjectMapper objectMapper;
 
     public TemplateServiceImp(
@@ -73,6 +75,7 @@ public class TemplateServiceImp implements TemplateService {
         this.oldDTOMapper = oldDTOMapper;
         this.ocProps = ocProps;
         this.templateEntityUpdater = entityVersionManager.getUpdater(Template.class);
+        this.templateStartupUpdater = entityVersionManager.getUpdater(Template.class, UpdaterVersion.VERSION_4_4);
         this.objectMapper = objectMapper;
     }
 
@@ -158,6 +161,9 @@ public class TemplateServiceImp implements TemplateService {
         moveTemplatesToNewLocation();
 
         Map<String, Template> templateMap = getAllAsMap();
+
+        // Startup migration stops at 4.4; the 5.0 transform is applied on the read path only.
+        String targetVersion = UpdaterVersion.VERSION_4_4.getVersion();
         for (Map.Entry<String, Template> entry : templateMap.entrySet()) {
             String fileName = entry.getKey();
             Template template = entry.getValue();
@@ -169,15 +175,15 @@ public class TemplateServiceImp implements TemplateService {
                 continue;
             }
 
-            if (Utils.compare(ocProps.getVersion(), template.getVersion()) > 0) {
+            if (Utils.compare(targetVersion, template.getVersion()) > 0) {
                 try {
                     String oldVersion = template.getVersion();
-                    templateEntityUpdater.updateToCurrentVersion(template)
+                    templateStartupUpdater.updateToCurrentVersion(template)
                             .ifUpdated(x -> {
-                                template.setVersion(ocProps.getVersion());
-                                FileBackupManager.doBackup(backup, oldVersion, ocProps.getVersion());
+                                template.setVersion(targetVersion);
+                                FileBackupManager.doBackup(backup, oldVersion, targetVersion);
                                 save(template, fileName);
-                                log.info("Template[id={}, name={}] is successfully updated to {} version", template.getTemplateId(), template.getName(), ocProps.getVersion());
+                                log.info("Template[id={}, name={}] is successfully updated to {} version", template.getTemplateId(), template.getName(), targetVersion);
                             });
                 } catch (Exception e) {
                     log.error("Failed to update Template[id={}, name={}]", template.getTemplateId(), template.getName(), e);
@@ -239,9 +245,24 @@ public class TemplateServiceImp implements TemplateService {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
             Template template = objectMapper.readValue(contentBuilder.toString(), Template.class);
+            applyVersionUpdater(template);
             return Optional.of(template);
         } catch (Exception e) {
             throw new RuntimeException("ERROR while converting from json to Template object");
+        }
+    }
+
+    /**
+     * Migrates the in-memory Template to the running version without persisting the change.
+     * The stored JSON file stays at its original version; conversion happens only on the read path.
+     */
+    private void applyVersionUpdater(Template template) {
+        if (template == null) return;
+        try {
+            templateEntityUpdater.updateToCurrentVersion(template);
+        } catch (Exception e) {
+            log.error("Failed to convert Template[id={}, name={}, version={}] to current version on read",
+                    template.getTemplateId(), template.getName(), template.getVersion(), e);
         }
     }
 
@@ -274,7 +295,9 @@ public class TemplateServiceImp implements TemplateService {
                         try (Stream<String> stream = Files.lines(Paths.get(path.toString()), StandardCharsets.UTF_8)) {
                             stream.forEach(s -> contentBuilder.append(s).append("\n"));
 //                            System.out.println(Paths.get(path.toString()).getFileName().toString());
-                            return objectMapper.readValue(contentBuilder.toString(), Template.class);
+                            Template template = objectMapper.readValue(contentBuilder.toString(), Template.class);
+                            applyVersionUpdater(template);
+                            return template;
                         } catch (Exception e) {
                             e.printStackTrace();
                             throw new WrongEncode("UTF8");
@@ -296,7 +319,9 @@ public class TemplateServiceImp implements TemplateService {
                             path -> {
                                 try {
                                     String json = Files.readString(path, StandardCharsets.UTF_8);
-                                    return objectMapper.readValue(json, Template.class);
+                                    Template template = objectMapper.readValue(json, Template.class);
+                                    applyVersionUpdater(template);
+                                    return template;
                                 } catch (IOException e) {
                                     throw new RuntimeException("Failed to read template: " + path, e);
                                 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/EntityVersionManager.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/EntityVersionManager.java
@@ -28,4 +28,12 @@ public class EntityVersionManager {
             case TEMPLATE -> (EntityUpdater<T>) templateUpdaterProvider.getUpdater(currentVersion);
         };
     }
+
+    @SuppressWarnings("unchecked")
+    public <T> EntityUpdater<T> getUpdater(Class<T> clazz, UpdaterVersion maxVersion) {
+        return switch (UpdaterType.getByClass(clazz)) {
+            case CONNECTION_MNG -> (EntityUpdater<T>) connectionMngUpdaterProvider.getUpdater(maxVersion);
+            case TEMPLATE -> (EntityUpdater<T>) templateUpdaterProvider.getUpdater(maxVersion);
+        };
+    }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/base/UpdaterVersion.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/base/UpdaterVersion.java
@@ -11,7 +11,8 @@ public enum UpdaterVersion {
     VERSION_4_4("4.4"),
     VERSION_4_5("4.5"),
     VERSION_4_6("4.6"),
-    VERSION_4_8("4.8");
+    VERSION_4_8("4.8"),
+    VERSION_5_0("5.0");
 
     private final String version;
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/connectionmng/Connection50MngUpdater.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/connectionmng/Connection50MngUpdater.java
@@ -1,0 +1,133 @@
+package com.becon.opencelium.backend.versionmanager.connectionmng;
+
+import com.becon.opencelium.backend.constant.ConnectionConstants;
+import com.becon.opencelium.backend.database.mongodb.entity.ConnectionMng;
+import com.becon.opencelium.backend.database.mongodb.entity.ConnectorMng;
+import com.becon.opencelium.backend.database.mongodb.entity.MethodConnectorMng;
+import com.becon.opencelium.backend.database.mongodb.entity.MethodMng;
+import com.becon.opencelium.backend.database.mongodb.entity.OperatorMng;
+import com.becon.opencelium.backend.versionmanager.Wrapper;
+import com.becon.opencelium.backend.versionmanager.base.UpdaterVersion;
+import com.becon.opencelium.backend.versionmanager.base.Utils;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Brings a ConnectionMng up to the v5.0 multi-connector layout:
+ * <ul>
+ *   <li>Stamps every method with the connector it originally belonged to (MethodConnectorMng).</li>
+ *   <li>Prefixes from-side indexes with {@code "0_"} and to-side indexes with {@code "1_"}.</li>
+ *   <li>Merges all from/to methods + operators under a single {@code fromConnector}.</li>
+ *   <li>Sets {@code fromConnector.connectorId = -1} and {@code title = "DEFAULT"};
+ *       {@code flowId} is preserved from the original fromConnector.</li>
+ *   <li>Clears {@code toConnector}.</li>
+ *   <li>Leaves {@code fieldBindings} untouched — they reference methods by color code.</li>
+ * </ul>
+ * Runs only on the read path; the persisted document is not modified.
+ */
+@Component
+public class Connection50MngUpdater implements ConnectionMngUpdater {
+
+    private static final UpdaterVersion currentVersion = UpdaterVersion.VERSION_5_0;
+    private static final String FROM_INDEX_PREFIX = "0_";
+    private static final String TO_INDEX_PREFIX = "1_";
+
+    private final Connection48MngUpdater connection48MngUpdater;
+
+    public Connection50MngUpdater(Connection48MngUpdater connection48MngUpdater) {
+        this.connection48MngUpdater = connection48MngUpdater;
+    }
+
+    @Override
+    public Wrapper<ConnectionMng> updateToCurrentVersion(ConnectionMng connection) {
+        return updateFromInternal(connection, connection == null ? null : connection.getVersion());
+    }
+
+    @Override
+    public Wrapper<ConnectionMng> updateFrom(ConnectionMng connection, String oldVersion) {
+        return updateFromInternal(connection, oldVersion);
+    }
+
+    private Wrapper<ConnectionMng> updateFromInternal(ConnectionMng connection, String oldVersion) {
+        if (Objects.isNull(connection) || Utils.compare(currentVersion.getVersion(), oldVersion) <= 0) {
+            return Wrapper.notUpdated(connection);
+        }
+
+        // Bring older documents up to 4.8 first; chained updater no-ops when already >= 4.8.
+        if (Utils.compare(oldVersion, UpdaterVersion.VERSION_4_8.getVersion()) < 0) {
+            connection48MngUpdater.updateFrom(connection, oldVersion);
+        }
+
+        ConnectorMng oldFrom = connection.getFromConnector();
+        ConnectorMng oldTo = connection.getToConnector();
+
+        MethodConnectorMng fromRef = refOf(oldFrom);
+        MethodConnectorMng toRef = refOf(oldTo);
+
+        List<MethodMng> mergedMethods = new ArrayList<>();
+        mergedMethods.addAll(stampMethods(methodsOf(oldFrom), fromRef, FROM_INDEX_PREFIX));
+        mergedMethods.addAll(stampMethods(methodsOf(oldTo), toRef, TO_INDEX_PREFIX));
+
+        List<OperatorMng> mergedOperators = new ArrayList<>();
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldFrom), FROM_INDEX_PREFIX));
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldTo), TO_INDEX_PREFIX));
+
+        ConnectorMng merged = new ConnectorMng();
+        merged.setConnectorId(ConnectionConstants.DEFAULT_CONNECTOR_ID);
+        merged.setTitle(ConnectionConstants.DEFAULT_CONNECTOR_NAME);
+        merged.setFlowId(oldFrom != null ? oldFrom.getFlowId() : null);
+        merged.setMethods(mergedMethods);
+        merged.setOperators(mergedOperators);
+
+        connection.setFromConnector(merged);
+        connection.setToConnector(null);
+        connection.setVersion(currentVersion.getVersion());
+
+        return Wrapper.updated(connection)
+                .changed(true)
+                .withOldVersion(oldVersion)
+                .withNewVersion(currentVersion.getVersion());
+    }
+
+    private static MethodConnectorMng refOf(ConnectorMng connector) {
+        if (connector == null) return null;
+        MethodConnectorMng ref = new MethodConnectorMng();
+        ref.setConnectorId(connector.getConnectorId());
+        ref.setTitle(connector.getTitle());
+        return ref;
+    }
+
+    private static List<MethodMng> methodsOf(ConnectorMng connector) {
+        if (connector == null || connector.getMethods() == null) return List.of();
+        return connector.getMethods();
+    }
+
+    private static List<OperatorMng> operatorsOf(ConnectorMng connector) {
+        if (connector == null || connector.getOperators() == null) return List.of();
+        return connector.getOperators();
+    }
+
+    private static List<MethodMng> stampMethods(List<MethodMng> methods, MethodConnectorMng ref, String indexPrefix) {
+        for (MethodMng method : methods) {
+            if (method == null) continue;
+            method.setConnector(ref);
+            method.setIndex(prefixIndex(method.getIndex(), indexPrefix));
+        }
+        return methods;
+    }
+
+    private static List<OperatorMng> reindexOperators(List<OperatorMng> operators, String indexPrefix) {
+        for (OperatorMng operator : operators) {
+            if (operator == null) continue;
+            operator.setIndex(prefixIndex(operator.getIndex(), indexPrefix));
+        }
+        return operators;
+    }
+
+    private static String prefixIndex(String index, String prefix) {
+        return prefix + index;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/connectionmng/ConnectionMngUpdaterProvider.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/connectionmng/ConnectionMngUpdaterProvider.java
@@ -24,6 +24,7 @@ public class ConnectionMngUpdaterProvider {
             case VERSION_4_4, VERSION_4_5 -> connectionMngUpdaters.get(lowerFirstChar(Connection44MngUpdater.class.getSimpleName()));
             case VERSION_4_6 -> connectionMngUpdaters.get(lowerFirstChar(Connection46MngUpdater.class.getSimpleName()));
             case VERSION_4_8 ->  connectionMngUpdaters.get(lowerFirstChar(Connection48MngUpdater.class.getSimpleName()));
+            case VERSION_5_0 -> connectionMngUpdaters.get(lowerFirstChar(Connection50MngUpdater.class.getSimpleName()));
             default -> new DefaultUpdater<>();
         };
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/template/Template50Updater.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/template/Template50Updater.java
@@ -1,0 +1,155 @@
+package com.becon.opencelium.backend.versionmanager.template;
+
+import com.becon.opencelium.backend.constant.ConnectionConstants;
+import com.becon.opencelium.backend.resource.connection.MethodConnectorDTO;
+import com.becon.opencelium.backend.resource.connection.MethodDTO;
+import com.becon.opencelium.backend.resource.connection.OperatorDTO;
+import com.becon.opencelium.backend.resource.template.CtionTemplateResource;
+import com.becon.opencelium.backend.resource.template.CtorTemplateResource;
+import com.becon.opencelium.backend.template.entity.Template;
+import com.becon.opencelium.backend.versionmanager.Wrapper;
+import com.becon.opencelium.backend.versionmanager.base.UpdaterVersion;
+import com.becon.opencelium.backend.versionmanager.base.Utils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Brings a Template up to the v5.0 multi-connector layout:
+ * <ul>
+ *   <li>Stamps every method with the connector it originally belonged to (MethodConnectorDTO).</li>
+ *   <li>Prefixes from-side indexes with {@code "0_"} and to-side indexes with {@code "1_"}.</li>
+ *   <li>Merges all from/to methods + operators under a single {@code fromConnector}.</li>
+ *   <li>Sets {@code fromConnector.connectorId = -1} and {@code title = "DEFAULT"}.</li>
+ *   <li>Clears {@code toConnector}.</li>
+ *   <li>Leaves {@code fieldBinding} untouched.</li>
+ * </ul>
+ * Runs only on the read path; the persisted file is not modified.
+ */
+@Component
+public class Template50Updater implements TemplateUpdater {
+
+    private static final UpdaterVersion currentVersion = UpdaterVersion.VERSION_5_0;
+    private static final String FROM_INDEX_PREFIX = "0_";
+    private static final String TO_INDEX_PREFIX = "1_";
+    private static final Logger log = LoggerFactory.getLogger(Template50Updater.class);
+
+    private final Template44Updater template44Updater;
+    private final ObjectMapper objectMapper;
+
+    public Template50Updater(Template44Updater template44Updater, ObjectMapper objectMapper) {
+        this.template44Updater = template44Updater;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Wrapper<Template> updateToCurrentVersion(Template template) {
+        return updateFromInternal(template, template == null ? null : template.getVersion());
+    }
+
+    @Override
+    public Wrapper<Template> updateFrom(Template template, String oldVersion) {
+        return updateFromInternal(template, oldVersion);
+    }
+
+    private Wrapper<Template> updateFromInternal(Template template, String oldVersion) {
+        if (Objects.isNull(template) || Utils.compare(currentVersion.getVersion(), oldVersion) <= 0) {
+            return Wrapper.notUpdated(template);
+        }
+
+        if (Utils.compare(oldVersion, UpdaterVersion.VERSION_4_4.getVersion()) < 0) {
+            template44Updater.updateFrom(template, oldVersion);
+        }
+
+        CtionTemplateResource connection = template.getConnection();
+        if (connection == null) {
+            template.setVersion(currentVersion.getVersion());
+            return Wrapper.updated(template).changed(true)
+                    .withOldVersion(oldVersion).withNewVersion(currentVersion.getVersion());
+        }
+
+        CtorTemplateResource oldFrom = connection.getFromConnector();
+        CtorTemplateResource oldTo = connection.getToConnector();
+
+        MethodConnectorDTO fromRef = refOf(oldFrom);
+        MethodConnectorDTO toRef = refOf(oldTo);
+
+        List<MethodDTO> mergedMethods = new ArrayList<>();
+        mergedMethods.addAll(stampMethods(methodsOf(oldFrom), fromRef, FROM_INDEX_PREFIX));
+        mergedMethods.addAll(stampMethods(methodsOf(oldTo), toRef, TO_INDEX_PREFIX));
+
+        List<OperatorDTO> mergedOperators = new ArrayList<>();
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldFrom), FROM_INDEX_PREFIX));
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldTo), TO_INDEX_PREFIX));
+
+        CtorTemplateResource merged = new CtorTemplateResource();
+        merged.setConnectorId(ConnectionConstants.DEFAULT_CONNECTOR_ID);
+        merged.setTitle(ConnectionConstants.DEFAULT_CONNECTOR_NAME);
+        merged.setNodeId(oldFrom != null ? oldFrom.getNodeId() : null);
+        merged.setInvoker(oldFrom != null ? oldFrom.getInvoker() : null);
+        merged.setMethods(mergedMethods);
+        merged.setOperators(mergedOperators);
+
+        connection.setFromConnector(merged);
+        connection.setToConnector(null);
+        template.setVersion(currentVersion.getVersion());
+
+        return Wrapper.updated(template).changed(true)
+                .withOldVersion(oldVersion).withNewVersion(currentVersion.getVersion());
+    }
+
+    private MethodConnectorDTO refOf(CtorTemplateResource connector) {
+        if (connector == null) return null;
+        MethodConnectorDTO ref = new MethodConnectorDTO();
+        ref.setConnectorId(connector.getConnectorId());
+        ref.setTitle(connector.getTitle());
+        return ref;
+    }
+
+    private List<MethodDTO> methodsOf(CtorTemplateResource connector) {
+        if (connector == null || connector.getMethods() == null) return List.of();
+        try {
+            return objectMapper.convertValue(connector.getMethods(), new TypeReference<>() {});
+        } catch (Exception e) {
+            log.error("Failed to read methods from template connector [connectorId={}]", connector.getConnectorId(), e);
+            return List.of();
+        }
+    }
+
+    private List<OperatorDTO> operatorsOf(CtorTemplateResource connector) {
+        if (connector == null || connector.getOperators() == null) return List.of();
+        try {
+            return objectMapper.convertValue(connector.getOperators(), new TypeReference<>() {});
+        } catch (Exception e) {
+            log.error("Failed to read operators from template connector [connectorId={}]", connector.getConnectorId(), e);
+            return List.of();
+        }
+    }
+
+    private static List<MethodDTO> stampMethods(List<MethodDTO> methods, MethodConnectorDTO ref, String indexPrefix) {
+        for (MethodDTO method : methods) {
+            if (method == null) continue;
+            method.setConnector(ref);
+            method.setIndex(prefixIndex(method.getIndex(), indexPrefix));
+        }
+        return methods;
+    }
+
+    private static List<OperatorDTO> reindexOperators(List<OperatorDTO> operators, String indexPrefix) {
+        for (OperatorDTO operator : operators) {
+            if (operator == null) continue;
+            operator.setIndex(prefixIndex(operator.getIndex(), indexPrefix));
+        }
+        return operators;
+    }
+
+    private static String prefixIndex(String index, String prefix) {
+        return prefix + index;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/template/TemplateUpdaterProvider.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/template/TemplateUpdaterProvider.java
@@ -23,6 +23,7 @@ public class TemplateUpdaterProvider {
         return switch (version) {
             case VERSION_4_0 -> templateUpdaters.get(lowerFirstChar(Template40Updater.class.getSimpleName()));
             case VERSION_4_4, VERSION_4_5, VERSION_4_6, VERSION_4_8 -> templateUpdaters.get(lowerFirstChar(Template44Updater.class.getSimpleName()));
+            case VERSION_5_0 -> templateUpdaters.get(lowerFirstChar(Template50Updater.class.getSimpleName()));
             default -> new DefaultUpdater<>();
         };
     }


### PR DESCRIPTION
## What
- Implemented read-only in-memory migration to 5.0 connection structure

## Why
This migration is required for 5.0 release, all connections must be converted to new structure before sending frontend

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code