### PR TITLE
[OC-1430] Preserve original connection error cause in ReferenceExtractor instead of overriding it

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/ReferenceExtractor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/ReferenceExtractor.java
@@ -23,6 +23,7 @@ import jakarta.annotation.Nullable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -209,6 +210,10 @@ public class ReferenceExtractor implements Extractor {
         final HttpEntity<?> entity;
         if (ref.getExchangeType() == ExchangeType.RESPONSE) {
             entity = operation.getResponses().get(key);
+
+            if (isErrorResponse(entity)) {
+                throw new RuntimeException((String) entity.getBody());
+            }
         } else {
             entity = operation.getRequests().get(key);
         }
@@ -523,6 +528,10 @@ public class ReferenceExtractor implements Extractor {
         }
 
         return input;
+    }
+
+    private boolean isErrorResponse(HttpEntity<?> entity) {
+        return entity instanceof ResponseEntity<?> responseEntity && responseEntity.getStatusCode().isError();
     }
 
     private Loop getLoopByIterator(String iterator) {

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
@@ -56,6 +56,21 @@ public final class OperationFixture {
         return operation;
     }
 
+    public static Operation anOperationWithErrorResponseBody(String message) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE);
+
+        ResponseEntity<?> response = new ResponseEntity<>(message, headers, HttpStatus.NOT_FOUND);
+
+        Operation operation = new Operation();
+        operation.setColor("#ababab");
+        operation.setLoopDepth(0);
+
+        operation.getResponses().put("#", response);
+
+        return operation;
+    }
+
     public static Operation anOperationInDoubleLoop() {
         String body = "{\"index\": \"%s\"}";
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -493,6 +494,27 @@ public class ReferenceExtractorTest {
 
         Object val3 = extractValue("#ababab.(response).body.$.data.key_with_underscore.['key.with.dot'].inner-value");
         assertEquals(42, val3);
+    }
+
+    @Test
+    void extractValueThrowsExceptionWhenHttpExceptionIsWrappedInResponse() {
+        // GIVEN
+        String ref = "#ababab.(response).body.$.data";
+        String message = "NOT_FOUND message";
+
+        Operation operation = OperationFixture.anOperationWithErrorResponseBody(message);
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN - THEN
+        assertThatThrownBy(() -> extractValue(ref))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining(ref)
+                .hasMessageContaining(message);
     }
 
     @Test


### PR DESCRIPTION
## What
Throw exception containing exact reason of reference extraction failure if response is an exception wrapper

## Why
Resolves: [[OC-1430] Preserve original connection error cause in ReferenceExtractor instead of overriding it](https://becon.atlassian.net/browse/OC-1430)

## How to test
​```bash
./gradlew test --tests "*.ReferenceExtractorTest"
​```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code