### PR TITLE
[OC-1396] Subscription Unit Test

### DIFF
--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/LicenseKeyFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/LicenseKeyFixture.java
@@ -1,0 +1,50 @@
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.subscription.dto.LicenseKey;
+
+/**
+ * Object mother for {@link LicenseKey} test data.
+ *
+ * Use named factory methods instead of constructing LicenseKey inline.
+ */
+public final class LicenseKeyFixture {
+
+    private LicenseKeyFixture() {
+    }
+
+    public static LicenseKey aValidLicenseKey() {
+        LicenseKey licenseKey = new LicenseKey();
+
+        licenseKey.setHmac("valid-hmac");
+        licenseKey.setStartDate(System.currentTimeMillis() - 86400000);
+        licenseKey.setEndDate(System.currentTimeMillis() + 86400000);
+
+        return licenseKey;
+    }
+
+    public static LicenseKey aLicenseKeyWithFutureStartDate() {
+        LicenseKey licenseKey = aValidLicenseKey();
+
+        licenseKey.setStartDate(System.currentTimeMillis() + 86400000);
+
+        return licenseKey;
+    }
+
+    public static LicenseKey anExpiredLicenseKey() {
+        LicenseKey licenseKey = aValidLicenseKey();
+
+        licenseKey.setEndDate(System.currentTimeMillis() - 86400000);
+
+        return licenseKey;
+    }
+
+    public static String aValidLicenseKeyJson() {
+        return """
+                {
+                  "hmac":"valid-hmac",
+                  "startDate":1000,
+                  "endDate":9999999999999
+                }
+                """;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/subscription/utility/LicenseKeyUtilityTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/subscription/utility/LicenseKeyUtilityTest.java
@@ -1,0 +1,266 @@
+package com.becon.opencelium.backend.unit.subscription.utility;
+
+import com.becon.opencelium.backend.subscription.dto.LicenseKey;
+import com.becon.opencelium.backend.subscription.utility.LicenseKeyUtility;
+import com.becon.opencelium.backend.subscription.utility.MonthPeriod;
+import com.becon.opencelium.backend.testutil.fixture.LicenseKeyFixture;
+import com.becon.opencelium.backend.utility.crypto.CryptoUtil;
+import com.becon.opencelium.backend.utility.crypto.HmacValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.MockedStatic;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LicenseKeyUtility}.
+ * <p>
+ * CryptoUtil is mocked intentionally. Real crypto behaviour is already covered
+ * in CryptoUtilTest.
+ * <p>
+ * No Spring context is loaded. No dependency is required to set up test class.
+ * Run with: ./gradlew test
+ */
+@DisplayName("LicenseKeyUtility — unit")
+class LicenseKeyUtilityTest {
+    private final String ENCRYPTED_LICENCE_PLACEHOLDER = "encrypted-licence";
+
+    // ── verify(String, HmacValidator) ────────────────────────────────────────
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void verifyReturnsFalseWhenLicenseKeyNullOrEmpty(String licenseKey) {
+        HmacValidator validator = mock(HmacValidator.class);
+
+        boolean result = LicenseKeyUtility.verify(licenseKey, validator);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void verifyReturnsTrueWhenLicenseKeyValid() {
+        try (MockedStatic<LicenseKeyUtility> mocked = mockStatic(LicenseKeyUtility.class, CALLS_REAL_METHODS)) {
+            // GIVEN
+            LicenseKey licenseKey = LicenseKeyFixture.aValidLicenseKey();
+
+            mocked.when(() -> LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER))
+                    .thenReturn(licenseKey);
+
+            HmacValidator validator = mock(HmacValidator.class);
+
+            when(validator.verify(licenseKey.getHmac()))
+                    .thenReturn(true);
+
+            // WHEN
+            boolean result = LicenseKeyUtility.verify(ENCRYPTED_LICENCE_PLACEHOLDER, validator);
+
+            // THEN
+            assertThat(result).isTrue();
+        }
+    }
+
+    @Test
+    void verifyReturnsFalseWhenHmacValidationFails() {
+        try (MockedStatic<LicenseKeyUtility> mocked = mockStatic(LicenseKeyUtility.class, CALLS_REAL_METHODS)) {
+            // GIVEN
+            LicenseKey licenseKey = LicenseKeyFixture.aValidLicenseKey();
+
+            mocked.when(() -> LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER))
+                    .thenReturn(licenseKey);
+
+            HmacValidator validator = mock(HmacValidator.class);
+
+            when(validator.verify(licenseKey.getHmac()))
+                    .thenReturn(false);
+
+            // WHEN
+            boolean result = LicenseKeyUtility.verify(ENCRYPTED_LICENCE_PLACEHOLDER, validator);
+
+            // THEN
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Test
+    void verifyThrowsRuntimeExceptionWhenStartDateIsInFuture() {
+        try (MockedStatic<LicenseKeyUtility> mocked = mockStatic(LicenseKeyUtility.class, CALLS_REAL_METHODS)) {
+            // GIVEN
+            LicenseKey licenseKey = LicenseKeyFixture.aLicenseKeyWithFutureStartDate();
+
+            mocked.when(() -> LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER))
+                    .thenReturn(licenseKey);
+
+            HmacValidator validator = mock(HmacValidator.class);
+
+            when(validator.verify(licenseKey.getHmac()))
+                    .thenReturn(true);
+
+            // WHEN-THEN
+            assertThatThrownBy(() ->
+                    LicenseKeyUtility.verify(ENCRYPTED_LICENCE_PLACEHOLDER, validator))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Subscription will start at");
+        }
+    }
+
+    @Test
+    void verifyThrowsRuntimeExceptionWhenLicenseKeyExpired() {
+        try (MockedStatic<LicenseKeyUtility> mocked = mockStatic(LicenseKeyUtility.class, CALLS_REAL_METHODS)) {
+            // GIVEN
+            LicenseKey licenseKey = LicenseKeyFixture.anExpiredLicenseKey();
+
+            mocked.when(() -> LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER))
+                    .thenReturn(licenseKey);
+
+            HmacValidator validator = mock(HmacValidator.class);
+
+            when(validator.verify(licenseKey.getHmac()))
+                    .thenReturn(true);
+
+            // WHEN-THEN
+            assertThatThrownBy(() ->
+                    LicenseKeyUtility.verify(ENCRYPTED_LICENCE_PLACEHOLDER, validator))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("expired");
+        }
+    }
+
+    // ── verify(LicenseKey, HmacValidator) ────────────────────────────────────
+
+    @Test
+    void verifyReturnsTrueWhenLicenseObjectValid() {
+        // GIVEN
+        LicenseKey licenseKey = LicenseKeyFixture.aValidLicenseKey();
+
+        HmacValidator validator = mock(HmacValidator.class);
+
+        when(validator.verify(licenseKey.getHmac()))
+                .thenReturn(true);
+
+        // WHEN
+        boolean result = LicenseKeyUtility.verify(licenseKey, validator);
+
+        // THEN
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void verifyReturnsFalseWhenLicenseObjectHmacInvalid() {
+        // GIVEN
+        LicenseKey licenseKey = LicenseKeyFixture.aValidLicenseKey();
+
+        HmacValidator validator = mock(HmacValidator.class);
+
+        when(validator.verify(licenseKey.getHmac()))
+                .thenReturn(false);
+
+        // WHEN
+        boolean result = LicenseKeyUtility.verify(licenseKey, validator);
+
+        // THEN
+        assertThat(result).isFalse();
+    }
+
+    // ── decrypt ──────────────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void decryptReturnsNullWhenEncryptedLicenseNullOrEmpty(String encryptedLicense) {
+        // WHEN
+        LicenseKey result = LicenseKeyUtility.decrypt(encryptedLicense);
+
+        // THEN
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void decryptReturnsLicenseKeyWhenPayloadValid() {
+        try (MockedStatic<CryptoUtil> mocked = mockStatic(CryptoUtil.class)) {
+            // GIVEN
+            String json = LicenseKeyFixture.aValidLicenseKeyJson();
+
+            mocked.when(() -> CryptoUtil.decrypt(anyString(), anyString()))
+                    .thenReturn(json.getBytes(StandardCharsets.UTF_8));
+
+            // WHEN
+            LicenseKey result = LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER);
+
+            // THEN
+            assertThat(result).isNotNull();
+            assertThat(result.getHmac()).isEqualTo("valid-hmac");
+            assertThat(result.getStartDate()).isEqualTo(1000);
+            assertThat(result.getEndDate()).isEqualTo(9999999999999L);
+        }
+    }
+
+    @Test
+    void decryptThrowsRuntimeExceptionWhenPayloadMalformed() {
+        try (MockedStatic<CryptoUtil> mocked = mockStatic(CryptoUtil.class)) {
+            // GIVEN
+            mocked.when(() -> CryptoUtil.decrypt(anyString(), anyString()))
+                    .thenReturn("not-json".getBytes(StandardCharsets.UTF_8));
+
+            // WHEN-THEN
+            assertThatThrownBy(() ->
+                    LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER))
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Test
+    void decryptThrowsRuntimeExceptionWhenCryptoFails() {
+        try (MockedStatic<CryptoUtil> mocked = mockStatic(CryptoUtil.class)) {
+            // GIVEN
+            String exceptionMessage = "crypto-failure";
+
+            mocked.when(() -> CryptoUtil.decrypt(anyString(), anyString()))
+                    .thenThrow(new RuntimeException(exceptionMessage));
+
+            // WHEN-THEN
+            assertThatThrownBy(() ->
+                    LicenseKeyUtility.decrypt(ENCRYPTED_LICENCE_PLACEHOLDER))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining(exceptionMessage);
+        }
+    }
+
+    // ── getCurrentMonthPeriod ────────────────────────────────────────────────
+
+    @Test
+    void getCurrentMonthPeriodReturnsValidMonthlyRange() {
+        // GIVEN
+        long initialDate = Instant.now()
+                .minusSeconds(86400)
+                .toEpochMilli();
+
+        // WHEN
+        MonthPeriod result = LicenseKeyUtility.getCurrentMonthPeriod(initialDate);
+
+        // THEN
+        assertThat(result).isNotNull();
+        assertThat(result.getStartDate())
+                .isLessThan(result.getEndDate());
+    }
+
+    // ── readFreeLicense ──────────────────────────────────────────────────────
+
+    @Test
+    void readFreeLicenseReturnsConfiguredLicense() {
+        // WHEN
+        String result = LicenseKeyUtility.readFreeLicense();
+
+        // THEN
+        assertThat(result).isNotBlank();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/MachineUtilityTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/MachineUtilityTest.java
@@ -1,0 +1,99 @@
+package com.becon.opencelium.backend.unit.utility;
+
+import com.becon.opencelium.backend.utility.MachineUtility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit tests for {@link MachineUtility}.
+ *
+ * OS or runtime environment dependent, permissions required methods are not tests.
+ *
+ * No Spring context is loaded. No dependency is required to set up test class.
+ * Run with: ./gradlew test
+ */
+@DisplayName("MachineUtility — unit")
+class MachineUtilityTest {
+
+    // ── getStringForHmacEncode ────────────────────────────────────────────────
+
+    @Test
+    void getStringForHmacEncodeReturnsConcatenatedValuesWhenAllIdentifiersPresent() {
+        try (MockedStatic<MachineUtility> mocked = mockStatic(MachineUtility.class, CALLS_REAL_METHODS)) {
+            // GIVEN
+            String machineUuid = "UUID-1111";
+            String macAddress = "AA-BB-CC-DD-EE-FF";
+            String systemUUID = "SYS-2222";
+            String computerName = "TestStation";
+
+            mocked.when(MachineUtility::getMachineUUID)
+                    .thenReturn(machineUuid);
+
+            mocked.when(MachineUtility::getMacAddress)
+                    .thenReturn(macAddress);
+
+            mocked.when(MachineUtility::getSystemUuid)
+                    .thenReturn(systemUUID);
+
+            mocked.when(MachineUtility::getComputerName)
+                    .thenReturn(computerName);
+
+            // WHEN
+            String result = MachineUtility.getStringForHmacEncode();
+
+            // THEN
+            assertThat(result)
+                    .isEqualTo(machineUuid + macAddress + systemUUID + computerName);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidIdentifierValues")
+    void getStringForHmacEncodeThrowsIllegalArgumentExceptionWhenIdentifierMissing(
+            String machineUuid, String macAddress, String systemUuid, String computerName, String expectedMessage
+    ) {
+        try (MockedStatic<MachineUtility> mocked = mockStatic(MachineUtility.class, CALLS_REAL_METHODS)) {
+            // GIVEN
+            mocked.when(MachineUtility::getMachineUUID)
+                    .thenReturn(machineUuid);
+
+            mocked.when(MachineUtility::getMacAddress)
+                    .thenReturn(macAddress);
+
+            mocked.when(MachineUtility::getSystemUuid)
+                    .thenReturn(systemUuid);
+
+            mocked.when(MachineUtility::getComputerName)
+                    .thenReturn(computerName);
+
+            // WHEN-THEN
+            assertThatThrownBy(MachineUtility::getStringForHmacEncode)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(expectedMessage);
+        }
+    }
+
+    private static Stream<Arguments> invalidIdentifierValues() {
+        String machineUuid = "UUID-1111";
+        String macAddress = "AA-BB-CC-DD-EE-FF";
+        String systemUUID = "SYS-2222";
+        String computerName = "TestStation";
+
+        return Stream.of(
+                Arguments.of(         "", macAddress, systemUUID, computerName, "Machine UUID is empty"),
+                Arguments.of(machineUuid,       null, systemUUID, computerName, "MAC Address is empty"),
+                Arguments.of(machineUuid, macAddress,         "", computerName, "System UUID is empty"),
+                Arguments.of(machineUuid, macAddress, systemUUID,         null, "Computer Name is empty"));
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/crypto/CryptoUtilTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/crypto/CryptoUtilTest.java
@@ -1,0 +1,139 @@
+package com.becon.opencelium.backend.unit.utility.crypto;
+
+import com.becon.opencelium.backend.utility.crypto.CryptoUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Cipher;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.util.ArrayList;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link CryptoUtil}.
+ *
+ * In tests real RSA key pairs are used instead of mocking crypto internals,
+ * this validates the actual encryption/decryption contract. Tests also include
+ * block concatenation behaviour for large payload.
+ */
+@DisplayName("CryptoUtil — unit")
+class CryptoUtilTest {
+
+    private KeyPair keyPair;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        keyPair = generateKeyPair();
+    }
+
+    // ── decrypt ───────────────────────────────────────────────────────────────
+
+    @Test
+    void decryptReturnsOriginalPayloadWhenContentEncryptedWithMatchingPrivateKey() throws Exception {
+        String payload = "subscription-license-payload";
+
+        String encrypted = encrypt(payload, keyPair.getPrivate());
+
+        String publicKey = Base64.getEncoder()
+                .encodeToString(keyPair.getPublic().getEncoded());
+
+        byte[] decrypted = CryptoUtil.decrypt(encrypted, publicKey);
+
+        assertThat(new String(decrypted, StandardCharsets.UTF_8))
+                .isEqualTo(payload);
+    }
+
+    @Test
+    void decryptReturnsOriginalPayloadWhenPayloadExceedsBlockMaxSize() throws Exception {
+        String payload = "A".repeat(600);
+
+        String encrypted = encrypt(payload, keyPair.getPrivate());
+
+        String publicKey = Base64.getEncoder()
+                .encodeToString(keyPair.getPublic().getEncoded());
+
+        byte[] decrypted = CryptoUtil.decrypt(encrypted, publicKey);
+
+        assertThat(new String(decrypted, StandardCharsets.UTF_8))
+                .isEqualTo(payload);
+    }
+
+    @Test
+    void decryptThrowsRuntimeExceptionWhenPublicKeyInvalid() {
+        assertThatThrownBy(() ->
+                CryptoUtil.decrypt("payload", "invalid-public-key"))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void decryptThrowsRuntimeExceptionWhenEncryptedPayloadInvalid() {
+        String publicKey = Base64.getEncoder()
+                .encodeToString(keyPair.getPublic().getEncoded());
+
+        assertThatThrownBy(() ->
+                CryptoUtil.decrypt("invalid-base64", publicKey))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void decryptThrowsRuntimeExceptionWhenDifferentPrivateKeyUsed() throws Exception {
+        String payload = "subscription-license-payload";
+        PrivateKey differentPrivateKey = generateKeyPair().getPrivate();
+
+        String encrypted = encrypt(payload, differentPrivateKey);
+
+        String publicKey = Base64.getEncoder()
+                .encodeToString(keyPair.getPublic().getEncoded());
+
+        assertThatThrownBy(() ->
+                CryptoUtil.decrypt(encrypted, publicKey))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+
+        return generator.generateKeyPair();
+    }
+
+    private String encrypt(String payload, PrivateKey privateKey) throws Exception {
+        final int MAX_ENCRYPT_BLOCK_SIZE = 245;
+
+        Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, privateKey);
+
+        byte[] data = payload.getBytes(StandardCharsets.UTF_8);
+
+        ArrayList<byte[]> encryptedChunks = new ArrayList<>();
+
+        int totalLength = 0;
+        for (int i = 0; i < data.length; i += MAX_ENCRYPT_BLOCK_SIZE) {
+            int length = Math.min(MAX_ENCRYPT_BLOCK_SIZE, data.length - i);
+            byte[] encryptedChunk = cipher.doFinal(data, i, length);
+            encryptedChunks.add(encryptedChunk);
+
+            totalLength += encryptedChunk.length;
+        }
+
+        byte[] result = new byte[totalLength];
+
+        int offset = 0;
+        for (byte[] chunk : encryptedChunks) {
+            System.arraycopy(chunk, 0, result, offset, chunk.length);
+            offset += chunk.length;
+        }
+
+        return Base64.getEncoder().encodeToString(result);
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/crypto/HmacUtilityTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/crypto/HmacUtilityTest.java
@@ -1,0 +1,150 @@
+package com.becon.opencelium.backend.unit.utility.crypto;
+
+import com.becon.opencelium.backend.utility.crypto.HmacUtility;
+import com.becon.opencelium.backend.utility.crypto.HmacValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HmacUtility}.
+ *
+ * No Spring context is loaded.
+ *
+ * The utility clas has a static secret key internally, thus the generated
+ * hashes are deterministic and safe to assert directly.
+ */
+@DisplayName("HmacUtility — unit")
+class HmacUtilityTest {
+
+    // ── encode(String) ────────────────────────────────────────────────────────
+
+    @Test
+    void encodeReturnsNonBlankHashWhenInputValid() {
+        String result = HmacUtility.encode("licenseId-extraData");
+
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    void encodeReturnsSameHashWhenInputIsSame() {
+        String first = HmacUtility.encode("licenseId-extraData");
+        String second = HmacUtility.encode("licenseId-extraData");
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void encodeReturnsDifferentHashWhenInputDiffers() {
+        String first = HmacUtility.encode("licenseId-extraData-1");
+        String second = HmacUtility.encode("licenseId-extraData-2");
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void encodeThrowsRuntimeExceptionWhenInputNull() {
+        assertThatThrownBy(() -> HmacUtility.encode((String) null))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    // ── encode(byte[]) ────────────────────────────────────────────────────────
+
+    @Test
+    void encodeReturnsNonBlankHashWhenByteArrayNull() {
+        String result = HmacUtility.encode((byte[]) null);
+
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    void encodeReturnsHashWhenByteArrayValid() {
+        byte[] bytes = "invoker-file".getBytes();
+        String result = HmacUtility.encode(bytes);
+
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    void encodeReturnsSameHashWhenByteArrayIsSame() {
+        byte[] payload = "invoker-file".getBytes();
+
+        String first = HmacUtility.encode(payload);
+        String second = HmacUtility.encode(payload);
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void encodeReturnsDifferentHashWhenByteArrayDiffers() {
+        String first = HmacUtility.encode("invoker-file-1".getBytes());
+        String second = HmacUtility.encode("invoker-file-2".getBytes());
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    // ── verify(String, String) ────────────────────────────────────────────────
+
+    @Test
+    void verifyReturnsTrueWhenHmacMatches() {
+        String data = "licenseId-extraData";
+        String hmac = HmacUtility.encode(data);
+
+        boolean result = HmacUtility.verify(data, hmac);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void verifyReturnsFalseWhenHmacDoesNotMatch() {
+        boolean result = HmacUtility.verify("licenseId-extraData", "invalid-hmac");
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void verifyThrowsRuntimeExceptionWhenHmacNull() {
+        assertThatThrownBy(() -> HmacUtility.verify("licenseId-extraData", null))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void verifyThrowsRuntimeExceptionWhenDataNull() {
+        String data = "licenseId-extraData";
+        String hmac = HmacUtility.encode(data);
+
+        assertThatThrownBy(() -> HmacUtility.verify((String) null, hmac))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    // ── verify(HmacValidator, String) ─────────────────────────────────────────
+
+    @Test
+    void verifyReturnsTrueWhenValidatorVerifiesHmac() {
+        HmacValidator validator = mock(HmacValidator.class);
+
+        when(validator.verify("valid-hmac")).thenReturn(true);
+
+        boolean result = HmacUtility.verify(validator, "valid-hmac");
+
+        assertThat(result).isTrue();
+        verify(validator).verify("valid-hmac");
+    }
+
+    @Test
+    void verifyReturnsFalseWhenValidatorRejectsHmac() {
+        HmacValidator validator = mock(HmacValidator.class);
+
+        when(validator.verify("invalid-hmac")).thenReturn(false);
+
+        boolean result = HmacUtility.verify(validator, "invalid-hmac");
+
+        assertThat(result).isFalse();
+        verify(validator).verify("invalid-hmac");
+    }
+}


### PR DESCRIPTION
## What
- Created tests for CryptoUtil class
- Created tests for HmacUtility class
- Created tests for MachineUtility class
- Created tests for LicenseKeyUtility class
## Why
Resolves: [[OC-1396] Subscription Unit Test](https://becon.atlassian.net/browse/OC-1396)

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code