### PR TITLE
[OC-1397] Tests for ActivationRequestServiceImp

### DIFF
--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/ActivationRequestRepositoryTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/ActivationRequestRepositoryTest.java
@@ -1,0 +1,214 @@
+package com.becon.opencelium.backend.slice.database.mysql.repository;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.database.mysql.repository.ActivationRequestRepository;
+import com.becon.opencelium.backend.enums.ActivReqStatus;
+import com.becon.opencelium.backend.testutil.annotation.SliceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * JPA slice tests for {@link ActivationRequestRepository}.
+ *
+ * These tests run against H2 because the repository contains custom JPQL and
+ * native queries for activation-request expiry, deactivation, active-request
+ * lookup, HMAC lookup, and status updates that cannot be verified with mocks.
+ *
+ * Run with: ./gradlew test --tests "*.ActivationRequestRepositoryTest"
+ */
+@SliceTest
+@DisplayName("ActivationRequestRepository — JPA slice")
+class ActivationRequestRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private ActivationRequestRepository repository;
+
+    // ── expireAllActivationRequests ──────────────────────────────────────────
+
+    @Test
+    void expireAllActivationRequestsExpiresOnlyPendingActivationRequests() {
+        // GIVEN
+        String pendingId = persistAndFlush(ActivReqStatus.PENDING, false)
+                .getId();
+
+        String processedId = persistAndFlush(ActivReqStatus.PROCESSED, true)
+                .getId();
+
+        String expiredId = persistAndFlush(ActivReqStatus.EXPIRED, false)
+                .getId();
+
+        // WHEN
+        repository.expireAllActivationRequests();
+        em.flush();
+        em.clear();
+
+        // THEN
+        assertThat(em.find(ActivationRequest.class, pendingId).getStatus())
+                .isEqualTo(ActivReqStatus.EXPIRED);
+        assertThat(em.find(ActivationRequest.class, processedId).getStatus())
+                .isEqualTo(ActivReqStatus.PROCESSED);
+        assertThat(em.find(ActivationRequest.class, expiredId).getStatus())
+                .isEqualTo(ActivReqStatus.EXPIRED);
+    }
+
+    // ── deactivateAll ────────────────────────────────────────────────────────
+
+    @Test
+    void deactivateAllMarksEveryActivationRequestInactive() {
+        // GIVEN
+        persistAndFlush(ActivReqStatus.PENDING, true);
+        persistAndFlush(ActivReqStatus.PROCESSED, true);
+        persistAndFlush(ActivReqStatus.EXPIRED, false);
+
+        // WHEN
+        repository.deactivateAll();
+        em.flush();
+        em.clear();
+
+        // THEN
+        assertThat(repository.findAll())
+                .extracting(ActivationRequest::isActive)
+                .containsOnly(false);
+    }
+
+    // ── findActiveAR ─────────────────────────────────────────────────────────
+
+    @Test
+    void findActiveARReturnsActivationRequestWhenActiveEntryExists() {
+        // GIVEN
+        persistAndFlush(ActivReqStatus.EXPIRED, false);
+
+        ActivationRequest active = persistAndFlush(ActivReqStatus.PROCESSED, true);
+        String activeId = active.getId();
+
+        // WHEN
+        Optional<ActivationRequest> result = repository.findActiveAR();
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(activeId);
+        assertThat(result.get().isActive()).isTrue();
+    }
+
+    @Test
+    void findActiveARReturnsEmptyWhenNoActivationRequestIsActive() {
+        // GIVEN
+        persistAndFlush(ActivReqStatus.PENDING, false);
+        persistAndFlush(ActivReqStatus.EXPIRED, false);
+
+        // WHEN-THEN
+        assertThat(repository.findActiveAR()).isEmpty();
+    }
+
+    // ── findFirstByHmac ──────────────────────────────────────────────────────
+
+    @Test
+    void findFirstByHmacReturnsActivationRequestWhenMatchExists() {
+        // GIVEN
+        ActivationRequest request = persistAndFlush(ActivReqStatus.PENDING,false);
+        String id = request.getId();
+        String hmac = request.getHmac();
+
+        // WHEN
+        Optional<ActivationRequest> result = repository.findFirstByHmac(hmac);
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(id);
+        assertThat(result.get().getHmac()).isEqualTo(hmac);
+    }
+
+    @Test
+    void findFirstByHmacReturnsEmptyWhenMatchDoesNotExist() {
+        // GIVEN
+        persistAndFlush(ActivReqStatus.PENDING, false);
+
+        // WHEN-THEN
+        assertThat(repository.findFirstByHmac("nonexisting-hmac")).isEmpty();
+    }
+
+    // ── updateStatusIfNotProcessed ───────────────────────────────────────────
+
+    @Test
+    void updateStatusIfNotProcessedUpdatesStatusWhenActivationRequestIsPending() {
+        // GIVEN
+        ActivationRequest request = persistAndFlush(ActivReqStatus.PENDING, false);
+        String id = request.getId();
+
+        // WHEN
+        repository.updateStatusIfNotProcessed(
+                id,
+                ActivReqStatus.EXPIRED,
+                ActivReqStatus.PROCESSED
+        );
+        em.flush();
+        em.clear();
+
+        // THEN
+        ActivationRequest result = em.find(ActivationRequest.class, id);
+        assertThat(result.getStatus()).isEqualTo(ActivReqStatus.EXPIRED);
+    }
+
+    @Test
+    void updateStatusIfNotProcessedLeavesStatusUnchangedWhenActivationRequestIsProcessed() {
+        // GIVEN
+        ActivationRequest request = persistAndFlush(ActivReqStatus.PROCESSED, true);
+        String id = request.getId();
+
+        // WHEN
+        repository.updateStatusIfNotProcessed(
+                id,
+                ActivReqStatus.EXPIRED,
+                ActivReqStatus.PROCESSED
+        );
+        em.flush();
+        em.clear();
+
+        // THEN
+        ActivationRequest result = em.find(ActivationRequest.class, id);
+        assertThat(result.getStatus()).isEqualTo(ActivReqStatus.PROCESSED);
+    }
+
+    @Test
+    void updateStatusIfNotProcessedDoesNothingWhenActivationRequestDoesNotExist() {
+        // WHEN
+        repository.updateStatusIfNotProcessed(
+                UUID.randomUUID().toString(), // non-existing id
+                ActivReqStatus.EXPIRED,
+                ActivReqStatus.PROCESSED
+        );
+        em.flush();
+        em.clear();
+
+        // THEN
+        assertThat(repository.findAll()).isEmpty();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private ActivationRequest persistAndFlush(ActivReqStatus status, boolean active) {
+        String hmac = "hmac-" + status + (active ? "-active" : "-inactive");
+
+        ActivationRequest request = new ActivationRequest();
+
+        request.setId(UUID.randomUUID().toString());
+        request.setHmac(hmac);
+        request.setStatus(status);
+        request.setActive(active);
+        request.setTtl(3600);
+        request.setCreatedAt(LocalDateTime.now());
+
+        return em.persistAndFlush(request);
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/ActivationRequestFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/ActivationRequestFixture.java
@@ -1,0 +1,60 @@
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.enums.ActivReqStatus;
+
+/**
+ * Object mother for {@link ActivationRequest} test data.
+ */
+public final class ActivationRequestFixture {
+    private ActivationRequestFixture() {
+    }
+
+    /**
+     * Activation request in the initial state generated locally before
+     * license activation. Mirrors the default bundled activation request.
+     */
+    public static ActivationRequest aPendingActivationRequest() {
+        ActivationRequest request = new ActivationRequest();
+
+        request.setId("eff042a1-b9db-43b3-855d-b62d712ce4c9");
+        request.setHmac("Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=");
+        request.setStatus(ActivReqStatus.PENDING);
+        request.setActive(false);
+        request.setTtl(3600);
+
+        return request;
+    }
+
+    /**
+     * Activation request that can no longer be redeemed for license activation.
+     * Used to pin expiry-related validation branches.
+     */
+    public static ActivationRequest aExpiredActivationRequest() {
+        ActivationRequest request = new ActivationRequest();
+
+        request.setId("eff042a1-b9db-43b3-855d-b62d712ce4c9");
+        request.setHmac("Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=");
+        request.setStatus(ActivReqStatus.EXPIRED);
+        request.setActive(false);
+        request.setTtl(3600);
+
+        return request;
+    }
+
+    /**
+     * Activation request that was successfully redeemed for a license and
+     * activated on the current machine.
+     */
+    public static ActivationRequest aProcessedActivationRequest() {
+        ActivationRequest request = new ActivationRequest();
+
+        request.setId("eff042a1-b9db-43b3-855d-b62d712ce4c9");
+        request.setHmac("Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=");
+        request.setStatus(ActivReqStatus.PROCESSED);
+        request.setActive(true);
+        request.setTtl(3600);
+
+        return request;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ActivationRequestServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ActivationRequestServiceImpTest.java
@@ -1,0 +1,369 @@
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.database.mysql.repository.ActivationRequestRepository;
+import com.becon.opencelium.backend.database.mysql.service.ActivationRequestServiceImp;
+import com.becon.opencelium.backend.enums.ActivReqStatus;
+import com.becon.opencelium.backend.testutil.fixture.ActivationRequestFixture;
+import com.becon.opencelium.backend.utility.MachineUtility;
+import com.becon.opencelium.backend.utility.crypto.HmacUtility;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ActivationRequestServiceImp}.
+ *
+ * No Spring context is loaded. Repository and scheduler interactions are
+ * mocked with Mockito.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ActivationRequestServiceImp — unit")
+class ActivationRequestServiceImpTest {
+
+    @Mock
+    private ActivationRequestRepository repository;
+
+    @Mock
+    private ScheduledExecutorService scheduler;
+
+    @InjectMocks
+    private ActivationRequestServiceImp service;
+
+    // ── save ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void saveReturnsPersistedActivationRequestWhenRepositorySucceeds() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+
+        when(repository.save(request))
+                .thenReturn(request);
+
+        // WHEN
+        ActivationRequest result = service.save(request);
+
+        // THEN
+        assertThat(result).isSameAs(request);
+        verify(repository).save(request);
+    }
+
+    // ── verify ───────────────────────────────────────────────────────────────
+
+    @Test
+    void verifyReturnsTrueWhenActivationRequestHmacMatches() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+        String hmac = request.getHmac();
+
+        // WHEN-THEN
+        assertThat(service.verify(request, hmac)).isTrue();
+    }
+
+    @Test
+    void verifyReturnsFalseWhenActivationRequestHmacDoesNotMatch() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+
+        // WHEN-THEN
+        assertThat(service.verify(request, "wrong-hmac")).isFalse();
+    }
+
+    @Test
+    void verifyReturnsFalseWhenActivationRequestIsExpired() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aExpiredActivationRequest();
+        String hmac = request.getHmac();
+
+        // WHEN-THEN
+        assertThat(service.verify(request, hmac)).isFalse();
+    }
+
+    @Test
+    void verifyReturnsFalseWhenActivationRequestIdIsNull() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+        request.setId(null);
+        String hmac = request.getHmac();
+
+        // WHEN-THEN
+        assertThat(service.verify(request, hmac)).isFalse();
+    }
+
+    // ── generateActivReq ─────────────────────────────────────────────────────
+
+    @Test
+    void generateActivReqReturnsPendingActivationRequestWithEncodedHmac() {
+        try (
+                MockedStatic<MachineUtility> machineUtility = mockStatic(MachineUtility.class);
+                MockedStatic<HmacUtility> hmacUtility = mockStatic(HmacUtility.class)
+        ) {
+            // GIVEN
+            String machineId = "machine-id";
+            String hmac = "Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=";
+
+            machineUtility.when(MachineUtility::getStringForHmacEncode)
+                    .thenReturn(machineId);
+
+            hmacUtility.when(() -> HmacUtility.encode(anyString()))
+                    .thenReturn(hmac);
+
+            // WHEN
+            ActivationRequest result = service.generateActivReq();
+
+            // THEN
+            assertThat(result.getId()).isNotBlank();
+            assertThat(result.getCreatedAt()).isNotNull();
+            assertThat(result.getStatus()).isEqualTo(ActivReqStatus.PENDING);
+            assertThat(result.getTtl()).isEqualTo(3600);
+            assertThat(result.isActive()).isFalse();
+            assertThat(result.getHmac()).isEqualTo(hmac);
+
+            hmacUtility.verify(() -> HmacUtility.encode(result.getId() + machineId));
+        }
+    }
+
+    // ── activateTTL ──────────────────────────────────────────────────────────
+
+    @Test
+    void activateTTLSchedulesExpirationUpdateWhenActivationRequestTtlElapses() {
+        ReflectionTestUtils.setField(service, "scheduler", scheduler);
+
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+        String id = request.getId();
+        long ttl = request.getTtl();
+
+        // WHEN
+        service.activateTTL(request);
+
+        // THEN
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).schedule(runnableCaptor.capture(), eq(ttl), eq(TimeUnit.SECONDS));
+
+        runnableCaptor.getValue().run();
+
+        verify(repository).updateStatusIfNotProcessed(
+                id,
+                ActivReqStatus.EXPIRED,
+                ActivReqStatus.PROCESSED
+        );
+    }
+
+    // ── deactivateAll ────────────────────────────────────────────────────────
+
+    @Test
+    void deactivateAllExpiresAndDeactivatesAllActivationRequests() {
+        // WHEN
+        service.deactivateAll();
+
+        // THEN
+        verify(repository).expireAllActivationRequests();
+        verify(repository).deactivateAll();
+    }
+
+    // ── getActiveAR ──────────────────────────────────────────────────────────
+
+    @Test
+    void getActiveARReturnsActivationRequestWhenRepositoryContainsActiveEntry() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aProcessedActivationRequest();
+
+        when(repository.findActiveAR())
+                .thenReturn(Optional.of(request));
+
+        // WHEN
+        ActivationRequest result = service.getActiveAR();
+
+        // THEN
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void getActiveARReturnsNullWhenRepositoryDoesNotContainActiveEntry() {
+        // GIVEN
+        when(repository.findActiveAR())
+                .thenReturn(Optional.empty());
+
+        // WHEN-THEN
+        assertThat(service.getActiveAR()).isNull();
+    }
+
+    // ── createFile ───────────────────────────────────────────────────────────
+
+    @Test
+    void createFileWritesActivationRequestContentToTempFile() throws Exception {
+        // WHEN
+        File file = service.createFile("activation-request-content", "activation-request");
+
+        try {
+            // THEN
+            assertThat(file).exists().isFile();
+            assertThat(Files.readString(file.toPath())).isEqualTo("activation-request-content");
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    // ── findByHmac ───────────────────────────────────────────────────────────
+
+    @Test
+    void findByHmacReturnsActivationRequestWhenRepositoryContainsMatch() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+        String hmac = request.getHmac();
+
+        when(repository.findFirstByHmac(hmac))
+                .thenReturn(Optional.of(request));
+
+        // WHEN
+        ActivationRequest result = service.findByHmac(hmac);
+
+        // THEN
+        assertThat(result).isSameAs(request);
+    }
+
+    @Test
+    void findByHmacThrowsRuntimeExceptionWhenRepositoryDoesNotContainMatch() {
+        // GIVEN
+        String hmac = "hmac-nonexisting";
+
+        when(repository.findFirstByHmac(hmac))
+                .thenReturn(Optional.empty());
+
+        // WHEN-THEN
+        assertThatThrownBy(() -> service.findByHmac(hmac))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Activation Request not found by hmac: " + hmac);
+    }
+
+    // ── readFreeAR ───────────────────────────────────────────────────────────
+
+    @Test
+    void readFreeARReturnsDecodedActivationRequestWhenDefaultPayloadIsValid() {
+        // WHEN
+        Optional<ActivationRequest> result = service.readFreeAR();
+
+        // THEN
+        assertThat(result).isPresent();
+
+        ActivationRequest request = result.get();
+
+        assertThat(request.getId()).isNotBlank();
+        assertThat(request.getHmac()).isNotBlank();
+        assertThat(request.getTtl()).isEqualTo(3600);
+        assertThat(request.getStatus()).isEqualTo(ActivReqStatus.PENDING);
+
+        assertThat(request.getMachineUuid()).isNotBlank();
+        assertThat(request.getMacAddress()).isNotBlank();
+        assertThat(request.getSystemUUID()).isNotBlank();
+        assertThat(request.getComputerName()).isNotBlank();
+    }
+
+    // ── findById ─────────────────────────────────────────────────────────────
+
+    @Test
+    void findByIdReturnsActivationRequestWhenRepositoryContainsId() {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+        String id = request.getId();
+
+        when(repository.findById(id))
+                .thenReturn(Optional.of(request));
+
+        // WHEN-THEN
+        assertThat(service.findById(id)).containsSame(request);
+    }
+
+    @Test
+    void findByIdReturnsEmptyWhenRepositoryDoesNotContainId() {
+        // GIVEN
+        String id = "nonexisting-id";
+
+        when(repository.findById(id))
+                .thenReturn(Optional.empty());
+
+        // WHEN-THEN
+        assertThat(service.findById(id)).isEmpty();
+    }
+
+    // ── decodeBase64AR ───────────────────────────────────────────────────────
+
+    @Test
+    void decodeBase64ARReturnsActivationRequestWhenPayloadIsValid() throws Exception {
+        // GIVEN
+        ActivationRequest request = ActivationRequestFixture.aPendingActivationRequest();
+
+        String id = request.getId();
+        String hmac = request.getHmac();
+        String machineUUID = "machine-uuid";
+        String macAddress = "mac-address";
+        String systemUUID = "system-uuid";
+        String computerName = "computer-name";
+
+        request.setMachineUuid(machineUUID);
+        request.setMacAddress(macAddress);
+        request.setSystemUUID(systemUUID);
+        request.setComputerName(computerName);
+
+        byte[] json = new ObjectMapper().writeValueAsBytes(request);
+        String encoded = Base64.getEncoder().encodeToString(json);
+
+        // WHEN
+        ActivationRequest result = service.decodeBase64AR(encoded);
+
+        // THEN
+        assertThat(result.getId()).isEqualTo(id);
+        assertThat(result.getHmac()).isEqualTo(hmac);
+        assertThat(result.getTtl()).isEqualTo(3600);
+        assertThat(result.getStatus()).isEqualTo(ActivReqStatus.PENDING);
+        assertThat(result.getMachineUuid()).isEqualTo(machineUUID);
+        assertThat(result.getMacAddress()).isEqualTo(macAddress);
+        assertThat(result.getSystemUUID()).isEqualTo(systemUUID);
+        assertThat(result.getComputerName()).isEqualTo(computerName);
+    }
+
+    @Test
+    void decodeBase64ARThrowsIllegalArgumentExceptionWhenPayloadIsNotBase64() {
+        // GIVEN
+        String payload = "not-base64";
+
+        // WHEN-THEN
+        assertThatThrownBy(() -> service.decodeBase64AR(payload))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void decodeBase64ARThrowsIOExceptionWhenDecodedPayloadIsNotJson() {
+        // GIVEN
+        String encoded = Base64.getEncoder()
+                .encodeToString("not-json".getBytes(StandardCharsets.UTF_8));
+
+        // WHEN-THEN
+        assertThatThrownBy(() -> service.decodeBase64AR(encoded))
+                .isInstanceOf(Exception.class);
+    }
+}


### PR DESCRIPTION
## What
- Add `ActivationRequestRepositoryTest` — 9 slice tests. No inline data creation, uses helper methods.
- Add `ActivationRequestServiceImpTest` — 19 unit tests. No inline data creation, uses fixtures.

## Why
Resolves: [[OC-1397] Tests for ActivationRequestServiceImp](https://becon.atlassian.net/browse/OC-1397)

## How to test
​```bash
./gradlew test --tests "*.ActivationRequestRepositoryTest"
​```
​```bash
./gradlew test --tests "*.ActivationRequestServiceImpTest"
​```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code