### PR TITLE
[OC-1339] Header Reference Extension

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/ReferenceExtractor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/ReferenceExtractor.java
@@ -263,8 +263,15 @@ public class ReferenceExtractor implements Extractor {
         String headerName = path;
         Integer index = null;
         boolean allValues = false;
+        String cookieAttribute = null;
 
-        if (path.endsWith("[*]")) {
+        int attrStart = headerName.lastIndexOf("[\"");
+        int attrEnd = headerName.lastIndexOf("\"]");
+
+        if (attrStart > 0 && attrEnd == headerName.length() - 2) {
+            cookieAttribute = headerName.substring(attrStart + 2, attrEnd);
+            headerName = headerName.substring(0, attrStart);
+        } else if (path.endsWith("[*]")) {
             headerName = path.substring(0, path.length() - 3);
             allValues = true;
         } else {
@@ -286,6 +293,10 @@ public class ReferenceExtractor implements Extractor {
             return allValues ? Collections.emptyList() : "";
         }
 
+        if (cookieAttribute != null) {
+            return extractCookieAttribute(values, cookieAttribute);
+        }
+
         if (allValues) {
             return List.copyOf(values);
         }
@@ -295,6 +306,44 @@ public class ReferenceExtractor implements Extractor {
         }
 
         return headers.getFirst(headerName);
+    }
+
+    private String extractCookieAttribute(List<String> cookies, String requestedAttribute) {
+        for (String cookie : cookies) {
+            String value = extractCookieAttribute(cookie, requestedAttribute);
+            if (!value.isEmpty()) {
+                return value;
+            }
+        }
+
+        return "";
+    }
+
+    private String extractCookieAttribute(String cookie, String requestedAttribute) {
+        if (cookie == null || cookie.isBlank() || requestedAttribute == null || requestedAttribute.isBlank()) {
+            return "";
+        }
+
+        String[] parts = cookie.split(";");
+
+        for (String part : parts) {
+            String trimmed = part.trim();
+
+            int equalsIndex = trimmed.indexOf('=');
+
+            if (equalsIndex > 0) {
+                String name = trimmed.substring(0, equalsIndex).trim();
+                String value = trimmed.substring(equalsIndex + 1).trim();
+
+                if (name.equalsIgnoreCase(requestedAttribute)) {
+                    return value;
+                }
+            } else if (trimmed.equalsIgnoreCase(requestedAttribute)) {
+                return trimmed;
+            }
+        }
+
+        return "";
     }
 
     private Object getFromJSON(Object body, String paths) {

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -44,6 +45,9 @@ public final class OperationFixture {
     public static Operation anOperationWithResponseBody() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE);
+        headers.put("X-Empty", List.of());
+        headers.add("Set-Cookie", "expires=Mon, 17-Jul-2017 16:06:00 GMT; Max-Age=31449600; Path=/; secure");
+        headers.put("Vary", List.of("Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
 
         ResponseEntity<?> response = new ResponseEntity<>(body, headers, HttpStatus.OK);
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
@@ -47,6 +47,7 @@ public final class OperationFixture {
         headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE);
         headers.put("X-Empty", List.of());
         headers.add("Set-Cookie", "expires=Mon, 17-Jul-2017 16:06:00 GMT; Max-Age=31449600; Path=/; secure");
+        headers.add("Set-Cookie", "token=123; SameSite=Lax; Priority=High; MyCustomFlag=ABC");
         headers.put("Vary", List.of("Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
 
         ResponseEntity<?> response = new ResponseEntity<>(body, headers, HttpStatus.OK);

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
@@ -195,6 +195,24 @@ public class ReferenceExtractorTest {
     }
 
     @Test
+    void extractValueReturnsSingleHeaderAsListWhenFullArraySyntaxIsUsed() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.Content-Type[*]");
+
+        // THEN
+        assertEquals(List.of("application/json"), result);
+    }
+
+    @Test
     void extractValueReturnsHeaderValueWhenHeaderIndexIsSpecified() {
         // GIVEN
         Operation operation = OperationFixture.anOperationWithResponseBody();
@@ -210,6 +228,24 @@ public class ReferenceExtractorTest {
 
         // THEN
         assertEquals("Access-Control-Request-Method", result);
+    }
+
+    @Test
+    void extractValueReturnsEmptyStringWhenHeaderIndexIsOutOfBounds() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.Vary[99]");
+
+        // THEN
+        assertEquals("", result);
     }
 
     @Test
@@ -281,6 +317,23 @@ public class ReferenceExtractorTest {
         assertEquals("31449600", extractValue("#ababab.(response).header.$.Set-Cookie[\"max-age\"]"));
         assertEquals("/", extractValue("#ababab.(response).header.$.Set-Cookie[\"path\"]"));
         assertEquals("secure", extractValue("#ababab.(response).header.$.Set-Cookie[\"SECURE\"]"));
+    }
+
+    @Test
+    void extractValueReturnsCookieAttributeFromSecondSetCookieHeader() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN - THEN
+        assertEquals("Lax", extractValue("#ababab.(response).header.$.Set-Cookie[\"SameSite\"]"));
+        assertEquals("High", extractValue("#ababab.(response).header.$.Set-Cookie[\"Priority\"]"));
+        assertEquals("ABC", extractValue("#ababab.(response).header.$.Set-Cookie[\"MyCustomFlag\"]"));
     }
 
     @Test

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
@@ -177,6 +177,131 @@ public class ReferenceExtractorTest {
     }
 
     @Test
+    void extractValueReturnsListWhenJsonPathUsesFullArraySyntax() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).header.$.Vary[*]");
+
+        // THEN
+        assertEquals(List.of("Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"), val);
+    }
+
+    @Test
+    void extractValueReturnsHeaderValueWhenHeaderIndexIsSpecified() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.Vary[1]");
+
+        // THEN
+        assertEquals("Access-Control-Request-Method", result);
+    }
+
+    @Test
+    void extractValueReturnsFirstHeaderValueWhenHeaderIndexIsNotSpecified() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.Content-Type");
+
+        // THEN
+        assertEquals("application/json", result);
+    }
+
+    @Test
+    void extractValueReturnsEmptyStringWhenHeaderExistsButHasNoValues() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.X-Empty");
+
+        // THEN
+        assertEquals("", result);
+    }
+
+    @Test
+    void extractValueReturnsHeaderAttributesWhenJsonPathUsed() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.Set-Cookie[\"expires\"]");
+
+        // THEN
+        assertEquals("Mon, 17-Jul-2017 16:06:00 GMT", result);
+    }
+
+    @Test
+    void extractValueReturnsHeaderAttributesCaseInsensitivelyWhenJsonPathUsed() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN - THEN
+        assertEquals("31449600", extractValue("#ababab.(response).header.$.Set-Cookie[\"max-age\"]"));
+        assertEquals("/", extractValue("#ababab.(response).header.$.Set-Cookie[\"path\"]"));
+        assertEquals("secure", extractValue("#ababab.(response).header.$.Set-Cookie[\"SECURE\"]"));
+    }
+
+    @Test
+    void extractValueReturnsEmptyStringWhenAttributeDoesNotExistByGivenJsonPath() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object result = extractValue("#ababab.(response).header.$.Set-Cookie[\"non-existing-attribute\"]");
+
+        // THEN
+        assertEquals("", result);
+    }
+
+    @Test
     @DisplayName("obj['*']~ - all field names")
     void extractValueReturnsAllFieldNamesWhenPathTargetsObject() {
         // GIVEN


### PR DESCRIPTION
## What
- Add new tests in `ReferenceExtractorTest` to cover new cases. No inline data creation, uses helper methods.
- Refactor ReferenceExtractor when json path like ref is used to get value from header

## Why
Resolves: [[OC-1339] Header Reference Extension](https://becon.atlassian.net/browse/OC-1339)

## How to test
​```bash
./gradlew test --tests "*.ReferenceExtractorTest"
​```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code