### PR TITLE
Feature/oc 1436 clean up orphaned test connection

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -148,8 +148,8 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping(path = "/all")
-    public ResponseEntity<?> getAll() {
-        List<ConnectionDTO> all = connectionService.getAllFullConnection();
+    public ResponseEntity<?> getAll(@RequestParam(name = "test", defaultValue = "false") boolean test) {
+        List<ConnectionDTO> all = schedulerService.filterByTestFlag(connectionService.getAllFullConnection(), test);
         return ResponseEntity.ok(connectionOldDTOMapper.toDTOAll(all));
     }
 
@@ -166,7 +166,8 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping(path = "/dependency/{invokerName}")
-    public ResponseEntity<?> getByInvokerName(@PathVariable String invokerName) {
+    public ResponseEntity<?> getByInvokerName(@PathVariable String invokerName,
+                                              @RequestParam(name = "test", defaultValue = "false") boolean test) {
         List<Integer> connectorIds = connectorService.findAllByInvoker(invokerName).stream().map(Connector::getId).toList();
 
         List<ConnectionDTO> connections = new ArrayList<>();
@@ -182,7 +183,7 @@ public class ConnectionController {
             }
         }
 
-        List<ConnectionOldDTO> result = connections.stream()
+        List<ConnectionOldDTO> result = schedulerService.filterByTestFlag(connections, test).stream()
                 .map(connectionOldDTOMapper::toDTO)
                 .toList();
         return ResponseEntity.ok(result);
@@ -201,8 +202,8 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping(path = "/all/meta")
-    public ResponseEntity<?> getAllMeta() {
-        List<Connection> connections = connectionService.findAll();
+    public ResponseEntity<?> getAllMeta(@RequestParam(name = "test", defaultValue = "false") boolean test) {
+        List<Connection> connections = schedulerService.filterEntitiesByTestFlag(connectionService.findAll(), test);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
         //unnecessary fields
         connectionResources.forEach(c -> {
@@ -232,8 +233,9 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @PostMapping(path = "/all/by-ids")
-    public ResponseEntity<?> getAllMetaById(@RequestBody IdentifiersDTO<Long> ids) {
-        List<Connection> connections = connectionService.findAllByIds(ids);
+    public ResponseEntity<?> getAllMetaById(@RequestBody IdentifiersDTO<Long> ids,
+                                            @RequestParam(name = "test", defaultValue = "false") boolean test) {
+        List<Connection> connections = schedulerService.filterEntitiesByTestFlag(connectionService.findAllByIds(ids), test);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
         //unnecessary fields
         connectionResources.forEach(c -> {
@@ -972,4 +974,5 @@ public class ConnectionController {
         ResultDTO<List<String>> logFileNames = new ResultDTO<>(connectionService.getLogFileNameListById(connectionId));
         return ResponseEntity.ok(logFileNames);
     }
+
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -232,7 +232,7 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @PostMapping(path = "/all/by-ids")
-    public ResponseEntity<?> getAllMeta(@RequestBody IdentifiersDTO<Long> ids) {
+    public ResponseEntity<?> getAllMetaById(@RequestBody IdentifiersDTO<Long> ids) {
         List<Connection> connections = connectionService.findAllByIds(ids);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
         //unnecessary fields

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -747,7 +747,7 @@ public class ConnectionController {
     })
     @PutMapping(path = "/list/delete")
     public ResponseEntity<?> deleteCtionByIdIn(@RequestBody IdentifiersDTO<Long> ids) {
-        ids.getIdentifiers().forEach(connectionService::deleteById);
+        connectionService.deleteByIds(ids.getIdentifiers(), schedulerService.getRunningConnectionIds());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
@@ -30,6 +30,7 @@ import com.github.fge.jsonpatch.JsonPatch;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 public interface ConnectionService {
 
@@ -99,6 +100,10 @@ public interface ConnectionService {
 
 
     ConnectionServiceImp.CleanupResult cleanupAllTestConnections();
+
+    List<ConnectionDTO> filterTestConnections(List<ConnectionDTO> connections, boolean includeTest, Set<Long> runningConnectionIds);
+
+    List<Connection> filterTestConnectionEntities(List<Connection> connections, boolean includeTest, Set<Long> runningConnectionIds);
 
     List<ConnectionVersionedDTO> getConnectionVersions(Long connectionId);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
@@ -105,6 +105,8 @@ public interface ConnectionService {
 
     List<Connection> filterTestConnectionEntities(List<Connection> connections, boolean includeTest, Set<Long> runningConnectionIds);
 
+    void deleteByIds(List<Long> ids, Set<Long> runningConnectionIds);
+
     List<ConnectionVersionedDTO> getConnectionVersions(Long connectionId);
 
     void deleteSnapshot(Long connectionId, String snapshotId);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -669,6 +669,39 @@ public class ConnectionServiceImp implements ConnectionService {
                 .toList();
     }
 
+    /**
+     * Deletes connections by id, tolerating concurrent changes:
+     * <ul>
+     *   <li>ids that no longer exist are skipped (e.g. a test connection finished and was auto-cleaned
+     *       between listing and this call), so a stale id never aborts the whole batch;</li>
+     *   <li>a test connection that is currently running (its id present in {@code runningConnectionIds})
+     *       is skipped, so an active test in progress is never removed.</li>
+     * </ul>
+     */
+    @Override
+    @Transactional
+    public void deleteByIds(List<Long> ids, Set<Long> runningConnectionIds) {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        Set<Long> running = runningConnectionIds == null ? Set.of() : runningConnectionIds;
+        for (Long id : ids) {
+            if (id == null) {
+                continue;
+            }
+            Optional<Connection> connection = connectionRepository.findById(id);
+            if (connection.isEmpty()) {
+                log.info("Skipping deletion of connection id={}: already removed", id);
+                continue;
+            }
+            if (running.contains(id) && isTestConnection(connection.get().getTitle())) {
+                log.info("Skipping deletion of running test connection id={}", id);
+                continue;
+            }
+            deleteById(id);
+        }
+    }
+
     @Transactional
     protected int deleteSqlChunk(List<Long> chunk) {
         chunk.forEach(this::deleteById);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -640,6 +640,35 @@ public class ConnectionServiceImp implements ConnectionService {
         return cleanupResult;
     }
 
+    /**
+     * Filters out test connections (titles matching {@code !*test_connection_...}) unless {@code includeTest} is true.
+     * A test connection that is currently running (its id present in {@code runningConnectionIds}) is always excluded,
+     * so an active test is never offered for cleanup.
+     */
+    @Override
+    public List<ConnectionDTO> filterTestConnections(List<ConnectionDTO> connections, boolean includeTest, Set<Long> runningConnectionIds) {
+        if (connections == null || connections.isEmpty()) {
+            return connections;
+        }
+        Set<Long> runningIds = runningConnectionIds == null ? Set.of() : runningConnectionIds;
+        return connections.stream()
+                .filter(c -> !isTestConnection(c.getTitle())
+                        || (includeTest && c.getId() != null && !runningIds.contains(Long.valueOf(c.getId()))))
+                .toList();
+    }
+
+    @Override
+    public List<Connection> filterTestConnectionEntities(List<Connection> connections, boolean includeTest, Set<Long> runningConnectionIds) {
+        if (connections == null || connections.isEmpty()) {
+            return connections;
+        }
+        Set<Long> runningIds = runningConnectionIds == null ? Set.of() : runningConnectionIds;
+        return connections.stream()
+                .filter(c -> !isTestConnection(c.getTitle())
+                        || (includeTest && c.getId() != null && !runningIds.contains(c.getId())))
+                .toList();
+    }
+
     @Transactional
     protected int deleteSqlChunk(List<Long> chunk) {
         chunk.forEach(this::deleteById);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
@@ -16,9 +16,11 @@
 
 package com.becon.opencelium.backend.database.mysql.service;
 
+import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.EventNotification;
 import com.becon.opencelium.backend.database.mysql.entity.MaskingRule;
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
+import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
 import com.becon.opencelium.backend.resource.notification.NotificationResource;
 import com.becon.opencelium.backend.resource.request.SchedulerRequestResource;
 import com.becon.opencelium.backend.resource.schedule.RunningJobsResource;
@@ -64,6 +66,8 @@ public interface SchedulerService {
     List<RunningJobsResource> getAllRunningJobs() throws Exception;
     List<RunningJobsResource> getAllRunningJobsExcludingOne(int schedulerId);
     Set<Long> getRunningConnectionIds();
+    List<ConnectionDTO> filterByTestFlag(List<ConnectionDTO> connections, boolean test);
+    List<Connection> filterEntitiesByTestFlag(List<Connection> connections, boolean test);
     List<EventNotification> getAllNotifications(int schedulerId);
     Optional<EventNotification> getNotification(int notificationId);
     EventNotification toNotificationEntity(NotificationResource resource);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface SchedulerService {
 
@@ -62,6 +63,7 @@ public interface SchedulerService {
 
     List<RunningJobsResource> getAllRunningJobs() throws Exception;
     List<RunningJobsResource> getAllRunningJobsExcludingOne(int schedulerId);
+    Set<Long> getRunningConnectionIds();
     List<EventNotification> getAllNotifications(int schedulerId);
     Optional<EventNotification> getNotification(int notificationId);
     EventNotification toNotificationEntity(NotificationResource resource);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
@@ -271,6 +271,18 @@ public class SchedulerServiceImp implements SchedulerService {
     }
 
     @Override
+    public List<ConnectionDTO> filterByTestFlag(List<ConnectionDTO> connections, boolean test) {
+        Set<Long> runningIds = test ? getRunningConnectionIds() : Set.of();
+        return connectionService.filterTestConnections(connections, test, runningIds);
+    }
+
+    @Override
+    public List<Connection> filterEntitiesByTestFlag(List<Connection> connections, boolean test) {
+        Set<Long> runningIds = test ? getRunningConnectionIds() : Set.of();
+        return connectionService.filterTestConnectionEntities(connections, test, runningIds);
+    }
+
+    @Override
     public void saveEntity(Scheduler scheduler) {
         schedulerRepository.save(scheduler);
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
@@ -266,6 +266,11 @@ public class SchedulerServiceImp implements SchedulerService {
     }
 
     @Override
+    public Set<Long> getRunningConnectionIds() {
+        return new HashSet<>(schedulingStrategy.getRunningJobs().keySet());
+    }
+
+    @Override
     public void saveEntity(Scheduler scheduler) {
         schedulerRepository.save(scheduler);
     }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectionControllerTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectionControllerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.slice.controller;
+
+import com.becon.opencelium.backend.configuration.interceptors.MasterPasswordInterceptor;
+import com.becon.opencelium.backend.controller.ConnectionController;
+import com.becon.opencelium.backend.database.mongodb.entity.ConnectionMng;
+import com.becon.opencelium.backend.database.mongodb.service.ConnectionMngService;
+import com.becon.opencelium.backend.database.mysql.entity.Connection;
+import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import com.becon.opencelium.backend.database.mysql.service.SchedulerService;
+import com.becon.opencelium.backend.execution.socket.Connection2WebSocketChannelMapping;
+import com.becon.opencelium.backend.mapper.base.Mapper;
+import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
+import com.becon.opencelium.backend.resource.connection.ConnectionResource;
+import com.becon.opencelium.backend.resource.connection.old.ConnectionOldDTO;
+import com.becon.opencelium.backend.security.AuthenticationFilter;
+import com.becon.opencelium.backend.security.AuthorizationFilter;
+import com.becon.opencelium.backend.security.TotpAuthenticationFilter;
+import com.becon.opencelium.backend.utility.patch.PatchHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link ConnectionController}: the {@code test} request parameter on the
+ * listing endpoints and the guarded bulk delete.
+ *
+ * Run with: ./gradlew test --tests "*.ConnectionControllerTest"
+ */
+@WebMvcTest(
+        controllers = ConnectionController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {
+                        AuthenticationFilter.class,
+                        AuthorizationFilter.class,
+                        TotpAuthenticationFilter.class
+                }
+        )
+)
+@ActiveProfiles("test")
+@DisplayName("ConnectionController — web slice")
+class ConnectionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SchedulerService schedulerService;
+
+    @MockBean
+    private ConnectorService connectorService;
+
+    @MockBean(name = "connectionServiceImp")
+    private ConnectionService connectionService;
+
+    @MockBean(name = "connectionMngServiceImp")
+    private ConnectionMngService connectionMngService;
+
+    @MockBean
+    private Connection2WebSocketChannelMapping connection2ChannelMapping;
+
+    @MockBean
+    private Mapper<ConnectionMng, ConnectionDTO> connectionMngMapper;
+
+    @MockBean
+    private Mapper<Connection, ConnectionDTO> connectionMapper;
+
+    @MockBean
+    private Mapper<Connection, ConnectionResource> connectionResourceMapper;
+
+    @MockBean
+    private Mapper<ConnectionDTO, ConnectionOldDTO> connectionOldDTOMapper;
+
+    @MockBean
+    private PatchHelper patchHelper;
+
+    @MockBean
+    private MasterPasswordInterceptor masterPasswordInterceptor;
+
+    // ── GET /connection/all ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /connection/all defaults the test flag to false")
+    void getAllPassesTestFalseToSchedulerServiceByDefault() throws Exception {
+        when(schedulerService.filterByTestFlag(any(), anyBoolean())).thenReturn(List.of());
+
+        mockMvc.perform(get("/connection/all").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Boolean> flag = ArgumentCaptor.forClass(Boolean.class);
+        verify(schedulerService).filterByTestFlag(any(), flag.capture());
+        assertThat(flag.getValue()).isFalse();
+    }
+
+    @Test
+    @DisplayName("GET /connection/all?test=true forwards the test flag")
+    void getAllPassesTestTrueWhenParamSet() throws Exception {
+        when(schedulerService.filterByTestFlag(any(), anyBoolean())).thenReturn(List.of());
+
+        mockMvc.perform(get("/connection/all").param("test", "true").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Boolean> flag = ArgumentCaptor.forClass(Boolean.class);
+        verify(schedulerService).filterByTestFlag(any(), flag.capture());
+        assertThat(flag.getValue()).isTrue();
+    }
+
+    // ── GET /connection/all/meta ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /connection/all/meta?test=true forwards the test flag to the entity filter")
+    void getAllMetaPassesTestTrueWhenParamSet() throws Exception {
+        when(schedulerService.filterEntitiesByTestFlag(any(), anyBoolean())).thenReturn(List.of());
+        when(connectionResourceMapper.toDTOAll(any())).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(get("/connection/all/meta").param("test", "true").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Boolean> flag = ArgumentCaptor.forClass(Boolean.class);
+        verify(schedulerService).filterEntitiesByTestFlag(any(), flag.capture());
+        assertThat(flag.getValue()).isTrue();
+    }
+
+    // ── PUT /connection/list/delete ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("PUT /connection/list/delete delegates with running ids and returns 204")
+    void deleteCtionByIdInDelegatesWithRunningIdsAndReturns204() throws Exception {
+        when(schedulerService.getRunningConnectionIds()).thenReturn(Set.of(2L));
+
+        mockMvc.perform(put("/connection/list/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "identifiers": [1, 2, 3] }
+                                """))
+                .andExpect(status().isNoContent());
+
+        ArgumentCaptor<List<Long>> idsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(connectionService).deleteByIds(idsCaptor.capture(), eq(Set.of(2L)));
+        assertThat(idsCaptor.getValue()).containsExactly(1L, 2L, 3L);
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectionServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectionServiceImpTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mongodb.service.ConnectionMngServiceImp;
+import com.becon.opencelium.backend.database.mysql.entity.Connection;
+import com.becon.opencelium.backend.database.mysql.repository.ConnectionRepository;
+import com.becon.opencelium.backend.database.mysql.service.ConnectionServiceImp;
+import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
+import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the test-connection helpers on {@link ConnectionServiceImp}:
+ * {@code filterTestConnections}, {@code filterTestConnectionEntities} and {@code deleteByIds}.
+ *
+ * Run with: ./gradlew test --tests "*.ConnectionServiceImpTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectionServiceImpTest {
+
+    private static final String TEST_TITLE = "!*test_connection_1700000000000_Demo";
+    private static final String OTHER_TEST_TITLE = "!*test_connection_1700000000001_Other";
+    private static final String NORMAL_TITLE = "Regular connection";
+
+    @Mock
+    private ConnectionRepository connectionRepository;
+
+    @Mock
+    private ConnectionMngServiceImp connectionMngService;
+
+    private ConnectionServiceImp connectionService;
+
+    @BeforeEach
+    void setUp() {
+        // The constructor calls entityVersionManager.getUpdater(...), so it cannot be left null;
+        // construct with the collaborators these tests exercise and a mock version manager for the rest.
+        EntityVersionManager entityVersionManager = mock(EntityVersionManager.class);
+        connectionService = new ConnectionServiceImp(
+                connectionRepository, null, connectionMngService, null, null, null, null, null,
+                null, null, null, null, null, null, entityVersionManager, null, null);
+    }
+
+    // ── filterTestConnections (List<ConnectionDTO>) ───────────────────────────
+
+    @Test
+    void filterTestConnectionsKeepsNonTestConnectionsWhenTestIsFalse() {
+        List<ConnectionDTO> input = List.of(dto("1", NORMAL_TITLE));
+
+        List<ConnectionDTO> result = connectionService.filterTestConnections(input, false, Set.of());
+
+        assertThat(result).extracting(ConnectionDTO::getTitle).containsExactly(NORMAL_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionsExcludesTestConnectionsWhenTestIsFalse() {
+        List<ConnectionDTO> input = List.of(dto("1", NORMAL_TITLE), dto("2", TEST_TITLE));
+
+        List<ConnectionDTO> result = connectionService.filterTestConnections(input, false, Set.of());
+
+        assertThat(result).extracting(ConnectionDTO::getTitle).containsExactly(NORMAL_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionsIncludesTestConnectionsWhenTestIsTrue() {
+        List<ConnectionDTO> input = List.of(dto("1", NORMAL_TITLE), dto("2", TEST_TITLE));
+
+        List<ConnectionDTO> result = connectionService.filterTestConnections(input, true, Set.of());
+
+        assertThat(result).extracting(ConnectionDTO::getTitle)
+                .containsExactlyInAnyOrder(NORMAL_TITLE, TEST_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionsExcludesRunningTestConnectionWhenTestIsTrue() {
+        List<ConnectionDTO> input = List.of(dto("5", TEST_TITLE), dto("6", OTHER_TEST_TITLE));
+
+        List<ConnectionDTO> result = connectionService.filterTestConnections(input, true, Set.of(5L));
+
+        assertThat(result).extracting(ConnectionDTO::getTitle).containsExactly(OTHER_TEST_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionsReturnsEmptyWhenInputEmpty() {
+        List<ConnectionDTO> result = connectionService.filterTestConnections(List.of(), true, Set.of(1L));
+
+        assertThat(result).isEmpty();
+    }
+
+    // ── filterTestConnectionEntities (List<Connection>) ───────────────────────
+
+    @Test
+    void filterTestConnectionEntitiesKeepsNonTestConnectionsWhenTestIsFalse() {
+        List<Connection> input = List.of(entity(1L, NORMAL_TITLE));
+
+        List<Connection> result = connectionService.filterTestConnectionEntities(input, false, Set.of());
+
+        assertThat(result).extracting(Connection::getTitle).containsExactly(NORMAL_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionEntitiesExcludesTestConnectionsWhenTestIsFalse() {
+        List<Connection> input = List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE));
+
+        List<Connection> result = connectionService.filterTestConnectionEntities(input, false, Set.of());
+
+        assertThat(result).extracting(Connection::getTitle).containsExactly(NORMAL_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionEntitiesIncludesTestConnectionsWhenTestIsTrue() {
+        List<Connection> input = List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE));
+
+        List<Connection> result = connectionService.filterTestConnectionEntities(input, true, Set.of());
+
+        assertThat(result).extracting(Connection::getTitle)
+                .containsExactlyInAnyOrder(NORMAL_TITLE, TEST_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionEntitiesExcludesRunningTestConnectionWhenTestIsTrue() {
+        List<Connection> input = List.of(entity(5L, TEST_TITLE), entity(6L, OTHER_TEST_TITLE));
+
+        List<Connection> result = connectionService.filterTestConnectionEntities(input, true, Set.of(5L));
+
+        assertThat(result).extracting(Connection::getTitle).containsExactly(OTHER_TEST_TITLE);
+    }
+
+    @Test
+    void filterTestConnectionEntitiesReturnsEmptyWhenInputEmpty() {
+        List<Connection> result = connectionService.filterTestConnectionEntities(List.of(), true, Set.of(1L));
+
+        assertThat(result).isEmpty();
+    }
+
+    // ── deleteByIds ───────────────────────────────────────────────────────────
+
+    @Test
+    void deleteByIdsDeletesExistingNonRunningConnections() {
+        when(connectionRepository.findById(1L)).thenReturn(Optional.of(entity(1L, NORMAL_TITLE)));
+        when(connectionRepository.findById(2L)).thenReturn(Optional.of(entity(2L, TEST_TITLE)));
+
+        connectionService.deleteByIds(List.of(1L, 2L), Set.of());
+
+        verify(connectionRepository).deleteById(1L);
+        verify(connectionRepository).deleteById(2L);
+    }
+
+    @Test
+    void deleteByIdsSkipsRunningTestConnection() {
+        when(connectionRepository.findById(5L)).thenReturn(Optional.of(entity(5L, TEST_TITLE)));
+
+        connectionService.deleteByIds(List.of(5L), Set.of(5L));
+
+        verify(connectionRepository, never()).deleteById(5L);
+        verify(connectionMngService, never()).deleteAllByConnectionId(5L);
+    }
+
+    @Test
+    void deleteByIdsDeletesRunningNonTestConnection() {
+        when(connectionRepository.findById(5L)).thenReturn(Optional.of(entity(5L, NORMAL_TITLE)));
+
+        connectionService.deleteByIds(List.of(5L), Set.of(5L));
+
+        verify(connectionRepository).deleteById(5L);
+    }
+
+    @Test
+    void deleteByIdsSkipsAlreadyRemovedId() {
+        when(connectionRepository.findById(9L)).thenReturn(Optional.empty());
+
+        connectionService.deleteByIds(List.of(9L), Set.of());
+
+        verify(connectionRepository, never()).deleteById(9L);
+    }
+
+    @Test
+    void deleteByIdsDoesNothingWhenIdsEmpty() {
+        connectionService.deleteByIds(List.of(), Set.of(1L));
+
+        verifyNoInteractions(connectionRepository, connectionMngService);
+    }
+
+    @Test
+    void deleteByIdsSkipsNullId() {
+        connectionService.deleteByIds(java.util.Collections.singletonList(null), Set.of());
+
+        verifyNoInteractions(connectionRepository, connectionMngService);
+    }
+
+    private static ConnectionDTO dto(String id, String title) {
+        ConnectionDTO dto = new ConnectionDTO();
+        dto.setId(id);
+        dto.setTitle(title);
+        return dto;
+    }
+
+    private static Connection entity(Long id, String title) {
+        Connection connection = new Connection();
+        connection.setId(id);
+        connection.setTitle(title);
+        return connection;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/SchedulerServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/SchedulerServiceImpTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connection;
+import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.SchedulerServiceImp;
+import com.becon.opencelium.backend.quartz.SchedulingStrategy;
+import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the test-connection helpers on {@link SchedulerServiceImp}:
+ * {@code getRunningConnectionIds}, {@code filterByTestFlag} and {@code filterEntitiesByTestFlag}.
+ *
+ * Run with: ./gradlew test --tests "*.SchedulerServiceImpTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class SchedulerServiceImpTest {
+
+    @Mock
+    private SchedulingStrategy schedulingStrategy;
+
+    @Mock
+    private ConnectionService connectionService;
+
+    @Captor
+    private ArgumentCaptor<Set<Long>> runningIdsCaptor;
+
+    private SchedulerServiceImp schedulerService;
+
+    @BeforeEach
+    void setUp() {
+        // The constructor derives schedulingStrategy from a SchedulerFactoryBean, so it cannot be
+        // injected directly — construct with the dependencies under test and swap in the mock strategy.
+        SchedulerFactoryBean schedulerFactoryBean = mock(SchedulerFactoryBean.class);
+        schedulerService = new SchedulerServiceImp(
+                connectionService, null, null, null, null, null, null, null, schedulerFactoryBean, null, null);
+        ReflectionTestUtils.setField(schedulerService, "schedulingStrategy", schedulingStrategy);
+    }
+
+    // ── getRunningConnectionIds ───────────────────────────────────────────────
+
+    @Test
+    void getRunningConnectionIdsReturnsConnectionIdsFromStrategy() {
+        when(schedulingStrategy.getRunningJobs()).thenReturn(Map.of(1L, 10, 2L, 20));
+
+        Set<Long> result = schedulerService.getRunningConnectionIds();
+
+        assertThat(result).containsExactlyInAnyOrder(1L, 2L);
+    }
+
+    @Test
+    void getRunningConnectionIdsReturnsDefensiveCopy() {
+        Map<Long, Integer> runningJobs = new HashMap<>();
+        runningJobs.put(1L, 10);
+        when(schedulingStrategy.getRunningJobs()).thenReturn(runningJobs);
+
+        Set<Long> result = schedulerService.getRunningConnectionIds();
+        result.add(99L);
+
+        assertThat(runningJobs).containsOnlyKeys(1L);
+    }
+
+    // ── filterByTestFlag (List<ConnectionDTO>) ────────────────────────────────
+
+    @Test
+    void filterByTestFlagPassesEmptyRunningIdsWhenTestIsFalse() {
+        List<ConnectionDTO> input = List.of(dto("1", "Regular"));
+        List<ConnectionDTO> delegated = List.of(dto("1", "Regular"));
+        when(connectionService.filterTestConnections(eq(input), eq(false), any())).thenReturn(delegated);
+
+        List<ConnectionDTO> result = schedulerService.filterByTestFlag(input, false);
+
+        assertThat(result).isSameAs(delegated);
+        verify(connectionService).filterTestConnections(eq(input), eq(false), runningIdsCaptor.capture());
+        assertThat(runningIdsCaptor.getValue()).isEmpty();
+        verify(schedulingStrategy, never()).getRunningJobs();
+    }
+
+    @Test
+    void filterByTestFlagPassesRunningIdsWhenTestIsTrue() {
+        List<ConnectionDTO> input = List.of(dto("7", "!*test_connection_1700000000000_X"));
+        List<ConnectionDTO> delegated = List.of();
+        when(schedulingStrategy.getRunningJobs()).thenReturn(Map.of(7L, 1));
+        when(connectionService.filterTestConnections(eq(input), eq(true), any())).thenReturn(delegated);
+
+        List<ConnectionDTO> result = schedulerService.filterByTestFlag(input, true);
+
+        assertThat(result).isSameAs(delegated);
+        verify(connectionService).filterTestConnections(eq(input), eq(true), runningIdsCaptor.capture());
+        assertThat(runningIdsCaptor.getValue()).containsExactly(7L);
+    }
+
+    // ── filterEntitiesByTestFlag (List<Connection>) ───────────────────────────
+
+    @Test
+    void filterEntitiesByTestFlagPassesRunningIdsWhenTestIsTrue() {
+        List<Connection> input = List.of(entity(7L, "!*test_connection_1700000000000_X"));
+        List<Connection> delegated = List.of();
+        when(schedulingStrategy.getRunningJobs()).thenReturn(Map.of(7L, 1));
+        when(connectionService.filterTestConnectionEntities(eq(input), eq(true), any())).thenReturn(delegated);
+
+        List<Connection> result = schedulerService.filterEntitiesByTestFlag(input, true);
+
+        assertThat(result).isSameAs(delegated);
+        verify(connectionService).filterTestConnectionEntities(eq(input), eq(true), runningIdsCaptor.capture());
+        assertThat(runningIdsCaptor.getValue()).containsExactly(7L);
+    }
+
+    private static ConnectionDTO dto(String id, String title) {
+        ConnectionDTO dto = new ConnectionDTO();
+        dto.setId(id);
+        dto.setTitle(title);
+        return dto;
+    }
+
+    private static Connection entity(Long id, String title) {
+        Connection connection = new Connection();
+        connection.setId(id);
+        connection.setTitle(title);
+        return connection;
+    }
+}


### PR DESCRIPTION
## What
Add param 'test' in ConenctionController so that client can have passibility to filter "!*test_connection.." like connections.

## Why
Add a test query parameter to ConnectionController listing endpoints, plus a running-aware, idempotent bulk delete — to surface and clean up orphaned test connections (!test_connection_).

Why
Triggering Test Connection creates a temporary '!*test_connection__<title>' record that is normally deleted after the test finishes or errors. If the OC process is killed or crashes before cleanup runs, these records are orphaned and accumulate over time, interfering with normal operation. Startup cleanup already exists ('ConnectionServiceImp.cleanupAllTestConnections()'); this adds a way to remove leftovers without a restart: the listing endpoints hide test connections by default and expose them with '?test=true', so the user can select and delete them via the existing bulk delete ('PUT /connection/list/delete'). A test connection whose test is currently running is excluded from both the listing response and from deletion.
Closes OC-1436.

## How to test
```bash
# Unit tests — no Docker needed
./gradlew test --tests "*.ConnectionServiceImpTest"
./gradlew test --tests "*.SchedulerServiceImpTest"

# Controller slice (test-flag wiring + guarded delete) — no Docker needed
./gradlew test --tests "*.ConnectionControllerTest"
```

Manual: 'GET /connection/all' omits test connections; 'GET /connection/all?test=true' returns them (excluding any in-progress test); selecting them and calling 'PUT /connection/list/delete' removes them, skipping running ones.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `UserRoleServiceImplTest.getOneThrowsRoleNotFoundExceptionWhenIdDoesNotExist`, `UserRoleControllerFlowIT.getByIdReturns404WhenRoleNotFound`
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squasheds