### PR TITLE
[OC-1442] Fix Root Object Path in reference

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/ReferenceExtractor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/ReferenceExtractor.java
@@ -166,7 +166,7 @@ public class ReferenceExtractor implements Extractor {
         //   CASE 1.4: '#ababab.(response).[*].body'
 
         if (ref.getPart() == DirectReference.Part.ALL) {
-            if (path == null) { // CASE 1.1
+            if (path.isBlank()) { // CASE 1.1
                 TreeMap<String, ResponseEx> responses = new TreeMap<>(NUMERIC_PARTS);
                 operation.getResponses().forEach((K, V) -> responses.put(K, ResponseEx.of(V)));
 
@@ -316,7 +316,7 @@ public class ReferenceExtractor implements Extractor {
         // C1: 'parts' contains values supported by JsonPath -> extract at once
         if (!hasForInKey && !hasSplit) {
             String resolvedPath = resolveLoops(paths);
-            String jsonPath = resolvedPath.startsWith("[") ? "$" + resolvedPath : "$." + resolvedPath;
+            String jsonPath = toJsonPath(resolvedPath);
 
             return JsonPath.read(normalizedBody, jsonPath);
         }
@@ -349,7 +349,7 @@ public class ReferenceExtractor implements Extractor {
         if (basePath.isEmpty()) {
             base = body;
         } else {
-            String jsonPath = basePath.startsWith("[") ? "$" + basePath : "$." + basePath;
+            String jsonPath = toJsonPath(basePath);
             base = JsonPath.read(normalizedBody, jsonPath);
         }
 
@@ -576,6 +576,12 @@ public class ReferenceExtractor implements Extractor {
         }
 
         return path;
+    }
+
+    private String toJsonPath(String paths) {
+        return paths.startsWith("[") || paths.isBlank()
+                ? "$" + paths
+                : "$." + paths;
     }
 
     private List<String> getFieldNames(Object body) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/DirectReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/DirectReference.java
@@ -166,7 +166,7 @@ public final class DirectReference implements Reference {
         if (p < rawReference.length()) {
             path = rawReference.substring(p); // remove ".$."
         } else {
-            path = null;
+            path = "";
         }
 
         return new DirectReference(

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/utility/ReferenceUtility.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/utility/ReferenceUtility.java
@@ -60,7 +60,7 @@ public class ReferenceUtility {
     }
 
     public static String[] splitPaths(String paths) {
-        if (paths.isEmpty()) {
+        if (paths.isBlank()) {
             return new String[]{""};
         }
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/OperationFixture.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -87,6 +88,25 @@ public final class OperationFixture {
         );
 
         return operation("#ababab", 2, responses);
+    }
+
+    public static Operation anOperationWithRootArrayResponseBody() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE);
+
+        ResponseEntity<?> response = new ResponseEntity<>(
+                List.of("A", "B", "C"),
+                headers,
+                HttpStatus.OK
+        );
+
+        Operation operation = new Operation();
+        operation.setColor("#ababab");
+        operation.setLoopDepth(0);
+
+        operation.getResponses().put("#", response);
+
+        return operation;
     }
 
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/oc721/ReferenceExtractorTest.java
@@ -150,6 +150,50 @@ public class ReferenceExtractorTest {
     }
 
     @Test
+    @DisplayName("$ - root object")
+    void extractValueReturnsRootAsObjectWhenPathTargetsRoot() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$");
+
+        // THEN
+        assertInstanceOf(Map.class, val);
+
+        Map<String, Object> root = (Map<String, Object>) val;
+        assertEquals("ok", root.get("status"));
+        assertTrue(root.containsKey("meta"));
+        assertTrue(root.containsKey("data"));
+    }
+
+    @Test
+    @DisplayName("$ - root array")
+    void extractValueReturnsRootAsArrayWhenPathTargetsRoot() {
+        // GIVEN
+        Operation operation = OperationFixture.anOperationWithRootArrayResponseBody();
+
+        when(executionManager.findOperationByColor("#ababab"))
+                .thenReturn(Optional.of(operation));
+
+        when(executionManager.generateKey(operation.getLoopDepth()))
+                .thenReturn("#");
+
+        // WHEN
+        Object val = extractValue("#ababab.(response).body.$");
+
+        // THEN
+        assertInstanceOf(List.class, val);
+        assertEquals(List.of("A", "B", "C"), val);
+    }
+
+    @Test
     @DisplayName("obj['i']~ - field name on ith index (indexing starts from 0)")
     void extractValueReturnsFieldNameWhenIndexIsSpecified() {
         // GIVEN


### PR DESCRIPTION
## What
- Add new tests in `ReferenceExtractorTest` to cover root object extraction bug. No inline data creation, uses helper methods.
- Refactor ReferenceExtractor to support root object extraction

## Why
Resolves: [[OC-1442] Fix Root Object Path in reference](https://becon.atlassian.net/browse/OC-1442)

## How to test
​```bash
./gradlew test --tests "*.ReferenceExtractorTest"
​```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code