### PR TITLE
[OC-1447] Children of Log pahases should be searched in both buffer and DB during execution.

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/InMemoryLogBlockBuffer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/InMemoryLogBlockBuffer.java
@@ -1,6 +1,7 @@
 package com.becon.opencelium.backend.execution.logger.buffer;
 
 import com.becon.opencelium.backend.database.mongodb.entity.LogDataMng;
+import com.becon.opencelium.backend.execution.logger.enums.PhaseStatus;
 
 import java.util.*;
 
@@ -41,8 +42,16 @@ public class InMemoryLogBlockBuffer implements LogBlockBuffer {
     }
 
     @Override
-    public Optional<LogDataMng> findInBufferById(String elementId) {
+    public synchronized Optional<LogDataMng> findInBufferById(String elementId) {
         return Optional.ofNullable(blockById.get(elementId));
+    }
+
+    @Override
+    public synchronized List<LogDataMng> findAllCompletedByExecutionId(String executionId) {
+        return buffer.stream()
+                .filter(block -> block.getStatus() == PhaseStatus.COMPLETE)
+                .filter(block -> Objects.equals(block.getExecutionId(), executionId))
+                .toList();
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/LogBlockBuffer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/LogBlockBuffer.java
@@ -23,6 +23,8 @@ public interface LogBlockBuffer {
      */
     Optional<LogDataMng> findInBufferById(String elementId);
 
+    List<LogDataMng> findAllCompletedByExecutionId(String executionId);
+
     /**
      * Explicit flush (e.g., on shutdown).
      */

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
@@ -21,10 +21,20 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
-import static com.becon.opencelium.backend.execution.logger.enums.PhaseCategory.*;
+import static com.becon.opencelium.backend.execution.logger.enums.PhaseCategory.EXECUTION;
+import static com.becon.opencelium.backend.execution.logger.enums.PhaseCategory.FLOWCHART;
+import static com.becon.opencelium.backend.execution.logger.enums.PhaseCategory.OPERATION;
 
 /**
  * LogMetaDataServiceImp handles persistence and enrichment of parsed execution blocks (e.g. IF, LOOP, METHOD).
@@ -357,7 +367,13 @@ public class LogDataServiceImp implements LogDataService {
     private List<LogDataMng> executionChildren(LogDataMng entity) {
         String executionId = entity.getExecutionId();
 
-        return metaDataLogRepository.findChildren(executionId, FLOWCHART.name(), SORT_ASCENDING);
+        var savedChildren = metaDataLogRepository.findChildren(executionId, FLOWCHART.name(), SORT_ASCENDING);
+
+        var bufferedChildren = buffer.findAllCompletedByExecutionId(executionId).stream()
+                .filter(child -> child.getType() == FLOWCHART)
+                .toList();
+
+        return mergeChildren(savedChildren, bufferedChildren);
     }
 
     private List<LogDataMng> flowchartChildren(LogDataMng entity) {
@@ -365,7 +381,11 @@ public class LogDataServiceImp implements LogDataService {
         String flowchartId = entity.getFlowId();
         String regex = "^[0-9]+$"; // filters only numbers (first level children)
 
-        return metaDataLogRepository.findChildren(executionId, flowchartId, regex, SORT_ASCENDING);
+        var savedChildren = metaDataLogRepository.findChildren(executionId, flowchartId, regex, SORT_ASCENDING);
+
+        var bufferedChildren = findBufferedChildren(executionId, flowchartId, regex, null);
+
+        return mergeChildren(savedChildren, bufferedChildren);
     }
 
     private List<LogDataMng> ifChildren(LogDataMng entity) {
@@ -373,14 +393,16 @@ public class LogDataServiceImp implements LogDataService {
         String flowchartId = entity.getFlowId();
         String indexPath = entity.getIndexPath();
         String regex = "^" + Pattern.quote(indexPath) + "_[0-9]+$"; // filters only first-level children
-        String nearestLoopIndex = (String) entity.getProperties().getOrDefault("loopIndex", "");
 
-        if (nearestLoopIndex.isBlank()) {
-            // IF is outside any LOOP
-            return metaDataLogRepository.findChildren(executionId, flowchartId, regex, SORT_ASCENDING);
-        } else {
-            return metaDataLogRepository.findChildren(executionId, flowchartId, regex, nearestLoopIndex, SORT_ASCENDING);
-        }
+        var savedChildren = hasLoopIndex(entity)
+                ? metaDataLogRepository.findChildren(executionId, flowchartId, regex, getLoopIndex(entity), SORT_ASCENDING)
+                : metaDataLogRepository.findChildren(executionId, flowchartId, regex, SORT_ASCENDING); // IF is outside any LOOP
+
+        var bufferedChildren = hasLoopIndex(entity)
+                ? findBufferedChildren(executionId, flowchartId, regex, getLoopIndex(entity))
+                : findBufferedChildren(executionId, flowchartId, regex, null);
+
+        return mergeChildren(savedChildren, bufferedChildren);
     }
 
     private List<LogDataMng> loopChildren(LogDataMng entity, String loopIndex) { // default loopIndex = 0
@@ -389,10 +411,49 @@ public class LogDataServiceImp implements LogDataService {
         String indexPath = entity.getIndexPath();
         String regex = "^" + Pattern.quote(indexPath) + "_[0-9]+$"; // filters only first-level children
 
-        String nearestLoopIndex = (String) entity.getProperties().getOrDefault("loopIndex", "");
-        String currentLoopIndex = nearestLoopIndex.isBlank() ? loopIndex : nearestLoopIndex + "," + loopIndex;
+        String currentLoopIndex = hasLoopIndex(entity)
+                ? getLoopIndex(entity) + "," + loopIndex
+                : loopIndex;
 
-        return metaDataLogRepository.findChildren(executionId, flowchartId, regex, currentLoopIndex, SORT_ASCENDING);
+        var savedChildren = metaDataLogRepository.findChildren(executionId, flowchartId, regex, currentLoopIndex, SORT_ASCENDING);
+
+        var bufferedChildren = findBufferedChildren(executionId, flowchartId, regex, currentLoopIndex);
+
+        return mergeChildren(savedChildren, bufferedChildren);
+    }
+
+    private List<LogDataMng> findBufferedChildren(String executionId, String flowchartId, String regex, String loopIndex) {
+        Pattern pattern = Pattern.compile(regex);
+
+        return buffer.findAllCompletedByExecutionId(executionId).stream()
+                .filter(child -> Objects.equals(child.getFlowId(), flowchartId))
+                .filter(child -> child.getIndexPath() != null)
+                .filter(child -> pattern.matcher(child.getIndexPath()).matches())
+                .filter(child -> loopIndex == null || (hasLoopIndex(child) && Objects.equals(getLoopIndex(child), loopIndex)))
+                .toList();
+    }
+
+    /**
+     * Merges children log data elements by removing duplicated.
+     * Notice. Both lists are already sorted in ascending order by 'createdDate'
+     * so no need to sort here again
+     *
+     * @param savedChildren    - saved children, sorted in ascending order by 'createdDate'
+     * @param bufferedChildren - buffered children, sorted in ascending order by 'createdDate'
+     * @return list of completed children
+     */
+    private List<LogDataMng> mergeChildren(List<LogDataMng> savedChildren, List<LogDataMng> bufferedChildren) {
+        Map<String, LogDataMng> merged = new LinkedHashMap<>();
+
+        for (LogDataMng child : savedChildren) {
+            merged.put(buildKey(child), child);
+        }
+
+        for (LogDataMng child : bufferedChildren) {
+            merged.put(buildKey(child), child);
+        }
+
+        return new ArrayList<>(merged.values());
     }
 
     // ------------------------------------------------------------------------------------


### PR DESCRIPTION
## What
- Fixed retrieving log data children, search in both repository and buffer

## Why
Resolves: [[OC-1447] Children of Log pahases should be searched in both buffer and DB during execution.](https://becon.atlassian.net/browse/OC-1447)

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code