### PR TITLE
[Fixed] OC-1427 Surface field type mismatches during binding as readable errors

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/FieldBindingMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/FieldBindingMngServiceImp.java
@@ -1,6 +1,7 @@
 package com.becon.opencelium.backend.database.mongodb.service;
 
 import com.becon.opencelium.backend.database.mongodb.entity.*;
+import com.becon.opencelium.backend.exception.FieldTypeMismatchException;
 import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.mapper.base.MapperUpdatable;
 import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
@@ -8,6 +9,8 @@ import com.becon.opencelium.backend.resource.connection.MethodDTO;
 import com.becon.opencelium.backend.resource.connection.binding.FieldBindingDTO;
 import com.becon.opencelium.backend.utility.BindingUtility;
 import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +18,8 @@ import java.util.*;
 
 @Service
 public class FieldBindingMngServiceImp implements FieldBindingMngService {
+    private static final Logger log = LogManager.getLogger(FieldBindingMngServiceImp.class);
+
     private final Mapper<FieldBindingMng, FieldBindingDTO> fieldBindingMngMapper;
     private final MapperUpdatable<MethodMng, MethodDTO> methodMngMapper;
     private final MongoTemplate mongoTemplate;
@@ -87,8 +92,14 @@ public class FieldBindingMngServiceImp implements FieldBindingMngService {
                         case "body" -> {
                             String field = PathAndReferenceUtility.getActualPathOfBody(toField.getField());
                             List<String> fieldPaths = PathAndReferenceUtility.splitByDelimiter(field, '.', true, true);
-                            Map<String, Object> boundFields = BindingUtility.doWithBody(method.getRequest().getBody(), fieldPaths, fb.getId(), method.getRequest().getBody().getFormat());
-                            method.getRequest().getBody().setFields(boundFields);
+                            try {
+                                Map<String, Object> boundFields = BindingUtility.doWithBody(method.getRequest().getBody(), fieldPaths, fb.getId(), method.getRequest().getBody().getFormat());
+                                method.getRequest().getBody().setFields(boundFields);
+                            } catch (FieldTypeMismatchException e) {
+                                FieldTypeMismatchException enriched = e.withFieldPath(toField.getField());
+                                log.error("Failed to bind field '{}' on method '{}' [{}]: {}", toField.getField(), method.getName(), method.getColor(), enriched.getMessage(), e);
+                                throw enriched;
+                            }
                         }
                         default -> throw new RuntimeException("UNSUPPORTED_TYPE: " + type);
                     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/exception/FieldTypeMismatchException.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/exception/FieldTypeMismatchException.java
@@ -1,0 +1,69 @@
+package com.becon.opencelium.backend.exception;
+
+import com.becon.opencelium.backend.constant.ExceptionConstant;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Thrown when a field value's actual type does not match the type expected by the
+ * binding/reference path (e.g. the path treats a field as an array while the body
+ * stores it as a primitive string).
+ * <p>
+ * Extends {@link GeneralServiceException} so it is automatically translated into a
+ * user-facing {@code ErrorResource} by the global exception handler.
+ */
+public class FieldTypeMismatchException extends GeneralServiceException {
+
+    private final String fieldPath;
+    private final String expectedType;
+    private final String actualType;
+
+    public FieldTypeMismatchException(String expectedType, Object actualValue) {
+        this(null, expectedType, typeOf(actualValue));
+    }
+
+    public FieldTypeMismatchException(String fieldPath, String expectedType, String actualType) {
+        super(HttpStatus.BAD_REQUEST, ExceptionConstant.INVALID_DATA, buildMessage(fieldPath, expectedType, actualType));
+        this.fieldPath = fieldPath;
+        this.expectedType = expectedType;
+        this.actualType = actualType;
+    }
+
+    /**
+     * Returns a copy of this exception enriched with the field path, used when the
+     * concrete field is only known by an outer caller (the cast site only knows the
+     * expected and actual types).
+     */
+    public FieldTypeMismatchException withFieldPath(String fieldPath) {
+        return this.fieldPath != null ? this : new FieldTypeMismatchException(fieldPath, expectedType, actualType);
+    }
+
+    private static String buildMessage(String fieldPath, String expectedType, String actualType) {
+        return fieldPath == null
+                ? "Field type mismatch: expected '%s' but found '%s'.".formatted(expectedType, actualType)
+                : "Field type mismatch for field '%s': expected '%s' but found '%s'.".formatted(fieldPath, expectedType, actualType);
+    }
+
+    /**
+     * Returns a human-readable JSON-oriented type name for the given value, used in
+     * type-mismatch error messages.
+     */
+    private static String typeOf(Object value) {
+        if (value == null) {
+            return "null";
+        } else if (value instanceof List<?>) {
+            return "array";
+        } else if (value instanceof Map<?, ?>) {
+            return "object";
+        } else if (value instanceof String) {
+            return "string";
+        } else if (value instanceof Boolean) {
+            return "boolean";
+        } else if (value instanceof Number) {
+            return "number";
+        }
+        return value.getClass().getSimpleName();
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/BindingUtility.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/BindingUtility.java
@@ -5,6 +5,7 @@ import com.becon.opencelium.backend.database.mongodb.entity.BodyMng;
 import com.becon.opencelium.backend.database.mongodb.entity.FieldBindingMng;
 import com.becon.opencelium.backend.database.mongodb.entity.LinkedFieldMng;
 import com.becon.opencelium.backend.database.mongodb.entity.MethodMng;
+import com.becon.opencelium.backend.exception.FieldTypeMismatchException;
 
 import java.util.*;
 
@@ -227,13 +228,12 @@ public class BindingUtility {
         return resultMap;
     }
 
-    @SuppressWarnings("unchecked")
     private static Object processJSON(Object value, List<String> fieldPaths, String id, String index) {
         if (index == null) {
             if (fieldPaths.isEmpty()) { // primitive type
                 return putIdToBody(value, id);
             } else { // object
-                Map<String, Object> map = (Map<String, Object>) value;
+                Map<String, Object> map = asObject(value);
                 return doWithJsonBody(map, "object", fieldPaths, id);
             }
         } else { // array
@@ -245,9 +245,9 @@ public class BindingUtility {
                 //ex. param[1]
                 //it means that this field's type is array. We just need to look through 1st element of an array
                 int idx = Integer.parseInt(index);
-                List<Object> list = (List<Object>) value;
+                List<Object> list = asArray(value);
                 if (list.get(idx) instanceof Map<?, ?>) { //array of objects
-                    List<Map<String, Object>> mapList = (List<Map<String, Object>>) value;
+                    List<Map<String, Object>> mapList = asArrayOfObjects(value);
                     mapList.set(idx, doWithJsonBody(mapList.get(idx), "object", fieldPaths, id));
                     return mapList;
                 } else { // array of primitives
@@ -257,9 +257,9 @@ public class BindingUtility {
             } else {
                 //ex. param[i]
                 //it means that this field's type is array. We need to look through every element of an array
-                List<Object> list = (List<Object>) value;
+                List<Object> list = asArray(value);
                 if (list.get(0) instanceof Map<?, ?>) { // array of objects
-                    List<Map<String, Object>> mapList = (List<Map<String, Object>>) value;
+                    List<Map<String, Object>> mapList = asArrayOfObjects(value);
                     return mapList.stream()
                             .map(f -> doWithJsonBody(f, "object", fieldPaths, id));
                 } else { // array of primitives
@@ -323,7 +323,7 @@ public class BindingUtility {
                 }
                 return putIdToBody(value, id);
             } else { // object
-                Map<String, Object> map = (Map<String, Object>) value;
+                Map<String, Object> map = asObject(value);
                 return doWithXMLBody(map, "object", fieldPaths, id);
             }
         } else { // array
@@ -335,9 +335,9 @@ public class BindingUtility {
                 //ex. param[1]
                 //it means that this field's type is array. We just need to look through 1st element of an array
                 int idx = Integer.parseInt(index);
-                List<Object> list = (List<Object>) value;
+                List<Object> list = asArray(value);
                 if (list.get(idx) instanceof Map<?, ?>) { //array of objects
-                    List<Map<String, Object>> mapList = (List<Map<String, Object>>) value;
+                    List<Map<String, Object>> mapList = asArrayOfObjects(value);
                     mapList.set(idx, doWithXMLBody(mapList.get(idx), "object", fieldPaths, id));
                     return mapList;
                 } else { // array of primitives
@@ -347,9 +347,9 @@ public class BindingUtility {
             } else {
                 //ex. param[i]
                 //it means that this field's type is array. We need to look through every element of an array
-                List<Object> list = (List<Object>) value;
+                List<Object> list = asArray(value);
                 if (list.get(0) instanceof Map<?, ?>) { // array of objects
-                    List<Map<String, Object>> mapList = (List<Map<String, Object>>) value;
+                    List<Map<String, Object>> mapList = asArrayOfObjects(value);
                     return mapList.stream()
                             .map(f -> doWithXMLBody(f, "object", fieldPaths, id));
                 } else { // array of primitives
@@ -367,5 +367,38 @@ public class BindingUtility {
     private static String putIdToBody(Object value, String id) {
         //just returns 'wrapped' id. Might be changed!
         return "#{%" + id + "%}";
+    }
+
+//--------------------------------------------------------------------------------------------------------//
+//----------------------------------------- type-checked casts -------------------------------------------//
+
+    /**
+     * Casts the body value to a JSON object, failing with a descriptive {@link FieldTypeMismatchException}
+     * when the binding path expects an object but the actual value is of another type.
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asObject(Object value) {
+        if (!(value instanceof Map<?, ?>)) {
+            throw new FieldTypeMismatchException("object", value);
+        }
+        return (Map<String, Object>) value;
+    }
+
+    /**
+     * Casts the body value to a JSON array, failing with a descriptive {@link FieldTypeMismatchException}
+     * when the binding path expects an array but the actual value is of another type.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Object> asArray(Object value) {
+        if (!(value instanceof List<?>)) {
+            throw new FieldTypeMismatchException("array", value);
+        }
+        return (List<Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> asArrayOfObjects(Object value) {
+        asArray(value);
+        return (List<Map<String, Object>>) value;
     }
 }


### PR DESCRIPTION
## What
Replace the raw `ClassCastException` thrown during field binding with a descriptive, user-facing error. A type mismatch between a binding path and the actual body value now returns HTTP 400 with a message naming the field and the expected vs. actual type, instead of a 500 carrying a reflection stack trace.

Changes:
- New `FieldTypeMismatchException` (extends `GeneralServiceException`) carrying `fieldPath` / `expectedType` / `actualType`; error code `INVALID_DATA`, status `400`.
- `BindingUtility.processJSON`/`processXML` now use type-checked `asObject` / `asArray` / `asArrayOfObjects` helpers instead of unchecked casts.
- `FieldBindingMngServiceImp.bindIds` enriches the exception with the full field path and logs the original detail before rethrowing.

## Why
`BindingUtility` cast body values directly (e.g. `(List<Object>) value`). When a binding path described a field as an array/object but the body stored a primitive, this threw a `ClassCastException`. No `@ExceptionHandler` matches it, so the global catch-all returned a 500 with an internal stack trace (`GeneratedMethodAccessor...invoke`) — unhelpful to the user and leaking internals. `FieldTypeMismatchException` is a `GeneralServiceException` subclass, so the existing `GlobalExceptionHandler` maps it to a clean 400 `ErrorResource`, while the full detail is still logged server-side for diagnostics.

Example message: `Field type mismatch for field 'body.$.param': expected 'array' but found 'string'.`

## How to test
No automated test is included in this PR. Manual verification:

1. Create/save a connection with a field binding whose target path indexes a field as an array (e.g. `body.$.param[i]`) while the request body stores `param` as a plain string.
2. Save the connection.
3. **Expected:** HTTP 400 with body `{ "error": "INVALID_DATA", "message": "Field type mismatch for field 'body.$.param': expected 'array' but found 'string'.", ... }`, and the original detail/stack trace recorded in the server log.
4. **Regression:** a binding where the path type matches the body type saves successfully as before.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew compileJava` passes locally
- [ ] Tests added or updated — none added (manual verification only)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
