### PR TITLE
[Fixed] OC-1436 Add includeTest listing param and on-demand test-connection cleanup

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/configuration/StorageConfiguration.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/configuration/StorageConfiguration.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -143,7 +144,7 @@ public class StorageConfiguration {
         }
 
         // removes connections that contain prefix in their names !*test_connection_
-        connectionService.cleanupAllTestConnections();
+        connectionService.cleanupAllTestConnections(Set.of());
 
         // deleting old version zip files
         cleanOldFiles(PathConstant.ASSISTANT + PathConstant.VERSIONS, File::isDirectory, "");

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -27,6 +27,7 @@ import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.entity.MaskingRule;
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectionServiceImp;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
 import com.becon.opencelium.backend.database.mysql.service.SchedulerService;
 import com.becon.opencelium.backend.exception.ConcurrentTestIsForbidden;
@@ -148,8 +149,8 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping(path = "/all")
-    public ResponseEntity<?> getAll(@RequestParam(name = "test", defaultValue = "false") boolean test) {
-        List<ConnectionDTO> all = schedulerService.filterByTestFlag(connectionService.getAllFullConnection(), test);
+    public ResponseEntity<?> getAll(@RequestParam(name = "includeTest", defaultValue = "false") Boolean includeTest) {
+        List<ConnectionDTO> all = connectionService.getAllFullConnection(includeTest);
         return ResponseEntity.ok(connectionOldDTOMapper.toDTOAll(all));
     }
 
@@ -167,14 +168,17 @@ public class ConnectionController {
     })
     @GetMapping(path = "/dependency/{invokerName}")
     public ResponseEntity<?> getByInvokerName(@PathVariable String invokerName,
-                                              @RequestParam(name = "test", defaultValue = "false") boolean test) {
-        List<Integer> connectorIds = connectorService.findAllByInvoker(invokerName).stream().map(Connector::getId).toList();
+                                              @RequestParam(name = "includeTest", defaultValue = "false") boolean includeTest) {
+        List<Integer> connectorIds = connectorService.findAllByInvoker(invokerName)
+                .stream()
+                .map(Connector::getId)
+                .toList();
 
         List<ConnectionDTO> connections = new ArrayList<>();
         Set<Long> connectionIds = new HashSet<>();
 
         for (Integer connectorId : connectorIds) {
-            List<Connection> connectionsByConnectorId = connectionService.findAllByConnectorId(connectorId);
+            List<Connection> connectionsByConnectorId = connectionService.findAllByConnectorId(connectorId, includeTest);
 
             for (Connection connection : connectionsByConnectorId) {
                 if (connectionIds.add(connection.getId())) {
@@ -182,11 +186,7 @@ public class ConnectionController {
                 }
             }
         }
-
-        List<ConnectionOldDTO> result = schedulerService.filterByTestFlag(connections, test).stream()
-                .map(connectionOldDTOMapper::toDTO)
-                .toList();
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(connectionOldDTOMapper.toDTOAll(connections));
     }
 
     @Operation(summary = "Retrieves all Metadata of connections from database")
@@ -202,8 +202,8 @@ public class ConnectionController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping(path = "/all/meta")
-    public ResponseEntity<?> getAllMeta(@RequestParam(name = "test", defaultValue = "false") boolean test) {
-        List<Connection> connections = schedulerService.filterEntitiesByTestFlag(connectionService.findAll(), test);
+    public ResponseEntity<?> getAllMeta(@RequestParam(name = "includeTest", defaultValue = "false") Boolean includeTest) {
+        List<Connection> connections = connectionService.findAll(includeTest);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
         //unnecessary fields
         connectionResources.forEach(c -> {
@@ -234,8 +234,8 @@ public class ConnectionController {
     })
     @PostMapping(path = "/all/by-ids")
     public ResponseEntity<?> getAllMetaById(@RequestBody IdentifiersDTO<Long> ids,
-                                            @RequestParam(name = "test", defaultValue = "false") boolean test) {
-        List<Connection> connections = schedulerService.filterEntitiesByTestFlag(connectionService.findAllByIds(ids), test);
+                                            @RequestParam(name = "includeTest", defaultValue = "false") boolean includeTest) {
+        List<Connection> connections = connectionService.findAllByIds(ids, includeTest);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
         //unnecessary fields
         connectionResources.forEach(c -> {
@@ -751,6 +751,23 @@ public class ConnectionController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Removes all leftover test connections (titles prefixed with !*test_connection_). " +
+            "Any test connection currently running is excluded from deletion.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Test connections have been cleaned up",
+                    content = @Content(schema = @Schema(implementation = ConnectionServiceImp.CleanupResult.class))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+            @ApiResponse(responseCode = "500",
+                    description = "Internal Error",
+                    content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+    })
+    @DeleteMapping(path = "/test")
+    public ResponseEntity<ConnectionServiceImp.CleanupResult> deleteTestConnections() {
+        return ResponseEntity.ok(connectionService.cleanupAllTestConnections(schedulerService.getRunningConnectionIds()));
+    }
 
     @Operation(summary = "Removes webhook")
     @ApiResponses(value = {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
@@ -46,11 +46,22 @@ public interface ConnectionService {
 
     List<Connection> findAll();
 
+    /**
+     * @param includeTest when {@code false}, test connections (titles matching
+     *                    {@code !*test_connection_...}) are excluded from the result
+     */
+    List<Connection> findAll(Boolean includeTest);
+
     boolean existsByName(String name);
 
     boolean existsById(Long id);
 
     List<Connection> findAllByConnectorId(int connectorId);
+
+    /**
+     * @param includeTest when {@code false}, test connections are excluded from the result
+     */
+    List<Connection> findAllByConnectorId(int connectorId, Boolean includeTest);
 
     List<Connection> findAllByNameContains(String name);
 
@@ -73,6 +84,11 @@ public interface ConnectionService {
     List<Connection> getAllByCategoryId(Integer categoryId);
 
     List<ConnectionDTO> getAllFullConnection();
+
+    /**
+     * @param includeTest when {@code false}, test connections are excluded from the result
+     */
+    List<ConnectionDTO> getAllFullConnection(Boolean includeTest);
 
     void updateCategory(Connection connection, Integer newCategory);
 
@@ -98,12 +114,12 @@ public interface ConnectionService {
 
     List<Connection> findAllByIds(IdentifiersDTO<Long> ids);
 
+    /**
+     * @param includeTest when {@code false}, test connections are excluded from the result
+     */
+    List<Connection> findAllByIds(IdentifiersDTO<Long> ids, Boolean includeTest);
 
-    ConnectionServiceImp.CleanupResult cleanupAllTestConnections();
-
-    List<ConnectionDTO> filterTestConnections(List<ConnectionDTO> connections, boolean includeTest, Set<Long> runningConnectionIds);
-
-    List<Connection> filterTestConnectionEntities(List<Connection> connections, boolean includeTest, Set<Long> runningConnectionIds);
+    ConnectionServiceImp.CleanupResult cleanupAllTestConnections(Set<Long> runningConnectionIds);
 
     void deleteByIds(List<Long> ids, Set<Long> runningConnectionIds);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -313,12 +313,22 @@ public class ConnectionServiceImp implements ConnectionService {
 
     @Override
     public List<Connection> findAll() {
-        return connectionRepository.findAll();
+        return findAll(false);
+    }
+
+    @Override
+    public List<Connection> findAll(Boolean includeTest) {
+        return excludeTestIfNeeded(connectionRepository.findAll(), includeTest);
     }
 
     @Override
     public List<Connection> findAllByConnectorId(int connectorId) {
-        return connectionRepository.findAllByConnectorId(connectorId);
+        return findAllByConnectorId(connectorId, false);
+    }
+
+    @Override
+    public List<Connection> findAllByConnectorId(int connectorId, Boolean includeTest) {
+        return excludeTestIfNeeded(connectionRepository.findAllByConnectorId(connectorId), includeTest);
     }
 
     @Override
@@ -402,7 +412,12 @@ public class ConnectionServiceImp implements ConnectionService {
 
     @Override
     public List<ConnectionDTO> getAllFullConnection() {
-        List<Connection> all = findAll();
+        return getAllFullConnection(false);
+    }
+
+    @Override
+    public List<ConnectionDTO> getAllFullConnection(Boolean includeTest) {
+        List<Connection> all = findAll(includeTest);
         List<ConnectionDTO> res = new ArrayList<>();
         for (Connection connection : all) {
             res.add(getFullConnection(connection.getId()));
@@ -548,11 +563,16 @@ public class ConnectionServiceImp implements ConnectionService {
 
     @Override
     public List<Connection> findAllByIds(IdentifiersDTO<Long> ids) {
+        return findAllByIds(ids, false);
+    }
+
+    @Override
+    public List<Connection> findAllByIds(IdentifiersDTO<Long> ids, Boolean includeTest) {
         if (ids == null || CollectionUtils.isEmpty(ids.getIdentifiers())) {
             return Collections.emptyList();
         }
 
-        return connectionRepository.findAllById(ids.getIdentifiers());
+        return excludeTestIfNeeded(connectionRepository.findAllById(ids.getIdentifiers()), includeTest);
     }
 
     @Override
@@ -625,9 +645,15 @@ public class ConnectionServiceImp implements ConnectionService {
      */
     @Override
     @Transactional
-    public CleanupResult cleanupAllTestConnections() {
-        log.info("Test connection cleanup completed started");
-        List<Long> ids = connectionRepository.findIdsByTitleLike(TEST_PREFIX_LIKE);
+    public CleanupResult cleanupAllTestConnections(Set<Long> runningConnectionIds) {
+        log.info("Test connection cleanup started");
+        Set<Long> running = runningConnectionIds == null ? Set.of() : runningConnectionIds;
+
+        // exclude connections with a test currently running so an active test is never deleted
+        List<Long> ids = connectionRepository.findIdsByTitleLike(TEST_PREFIX_LIKE).stream()
+                .filter(id -> !running.contains(id))
+                .toList();
+
         if (ids.isEmpty()) return new CleanupResult(0, 0, 0);
 
         long totalMongoDeleted = 0;
@@ -651,31 +677,15 @@ public class ConnectionServiceImp implements ConnectionService {
     }
 
     /**
-     * Filters out test connections (titles matching {@code !*test_connection_...}) unless {@code includeTest} is true.
-     * A test connection that is currently running (its id present in {@code runningConnectionIds}) is always excluded,
-     * so an active test is never offered for cleanup.
+     * Returns {@code connections} as-is when {@code includeTest} is true; otherwise drops every test
+     * connection (title matching {@code !*test_connection_...}).
      */
-    @Override
-    public List<ConnectionDTO> filterTestConnections(List<ConnectionDTO> connections, boolean includeTest, Set<Long> runningConnectionIds) {
-        if (connections == null || connections.isEmpty()) {
+    private List<Connection> excludeTestIfNeeded(List<Connection> connections, Boolean includeTest) {
+        if (Boolean.TRUE.equals(includeTest) || connections == null || connections.isEmpty()) {
             return connections;
         }
-        Set<Long> runningIds = runningConnectionIds == null ? Set.of() : runningConnectionIds;
         return connections.stream()
-                .filter(c -> !isTestConnection(c.getTitle())
-                        || (includeTest && c.getId() != null && !runningIds.contains(Long.valueOf(c.getId()))))
-                .toList();
-    }
-
-    @Override
-    public List<Connection> filterTestConnectionEntities(List<Connection> connections, boolean includeTest, Set<Long> runningConnectionIds) {
-        if (connections == null || connections.isEmpty()) {
-            return connections;
-        }
-        Set<Long> runningIds = runningConnectionIds == null ? Set.of() : runningConnectionIds;
-        return connections.stream()
-                .filter(c -> !isTestConnection(c.getTitle())
-                        || (includeTest && c.getId() != null && !runningIds.contains(c.getId())))
+                .filter(c -> !isTestConnection(c.getTitle()))
                 .toList();
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
@@ -66,8 +66,6 @@ public interface SchedulerService {
     List<RunningJobsResource> getAllRunningJobs() throws Exception;
     List<RunningJobsResource> getAllRunningJobsExcludingOne(int schedulerId);
     Set<Long> getRunningConnectionIds();
-    List<ConnectionDTO> filterByTestFlag(List<ConnectionDTO> connections, boolean test);
-    List<Connection> filterEntitiesByTestFlag(List<Connection> connections, boolean test);
     List<EventNotification> getAllNotifications(int schedulerId);
     Optional<EventNotification> getNotification(int notificationId);
     EventNotification toNotificationEntity(NotificationResource resource);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
@@ -277,18 +277,6 @@ public class SchedulerServiceImp implements SchedulerService {
     }
 
     @Override
-    public List<ConnectionDTO> filterByTestFlag(List<ConnectionDTO> connections, boolean test) {
-        Set<Long> runningIds = test ? getRunningConnectionIds() : Set.of();
-        return connectionService.filterTestConnections(connections, test, runningIds);
-    }
-
-    @Override
-    public List<Connection> filterEntitiesByTestFlag(List<Connection> connections, boolean test) {
-        Set<Long> runningIds = test ? getRunningConnectionIds() : Set.of();
-        return connectionService.filterTestConnectionEntities(connections, test, runningIds);
-    }
-
-    @Override
     public void saveEntity(Scheduler scheduler) {
         schedulerRepository.save(scheduler);
     }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectionControllerTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectionControllerTest.java
@@ -52,7 +52,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Slice tests for {@link ConnectionController}: the {@code test} request parameter on the
+ * Slice tests for {@link ConnectionController}: the {@code includeTest} request parameter on the
  * listing endpoints and the guarded bulk delete.
  *
  * Run with: ./gradlew test --tests "*.ConnectionControllerTest"
@@ -111,44 +111,44 @@ class ConnectionControllerTest {
     // ── GET /connection/all ───────────────────────────────────────────────────
 
     @Test
-    @DisplayName("GET /connection/all defaults the test flag to false")
-    void getAllPassesTestFalseToSchedulerServiceByDefault() throws Exception {
-        when(schedulerService.filterByTestFlag(any(), anyBoolean())).thenReturn(List.of());
+    @DisplayName("GET /connection/all defaults includeTest to false")
+    void getAllDefaultsIncludeTestToFalse() throws Exception {
+        when(connectionService.getAllFullConnection(anyBoolean())).thenReturn(List.of());
 
         mockMvc.perform(get("/connection/all").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<Boolean> flag = ArgumentCaptor.forClass(Boolean.class);
-        verify(schedulerService).filterByTestFlag(any(), flag.capture());
+        verify(connectionService).getAllFullConnection(flag.capture());
         assertThat(flag.getValue()).isFalse();
     }
 
     @Test
-    @DisplayName("GET /connection/all?test=true forwards the test flag")
-    void getAllPassesTestTrueWhenParamSet() throws Exception {
-        when(schedulerService.filterByTestFlag(any(), anyBoolean())).thenReturn(List.of());
+    @DisplayName("GET /connection/all?includeTest=true forwards the flag")
+    void getAllForwardsIncludeTestTrue() throws Exception {
+        when(connectionService.getAllFullConnection(anyBoolean())).thenReturn(List.of());
 
-        mockMvc.perform(get("/connection/all").param("test", "true").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/connection/all").param("includeTest", "true").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<Boolean> flag = ArgumentCaptor.forClass(Boolean.class);
-        verify(schedulerService).filterByTestFlag(any(), flag.capture());
+        verify(connectionService).getAllFullConnection(flag.capture());
         assertThat(flag.getValue()).isTrue();
     }
 
     // ── GET /connection/all/meta ──────────────────────────────────────────────
 
     @Test
-    @DisplayName("GET /connection/all/meta?test=true forwards the test flag to the entity filter")
-    void getAllMetaPassesTestTrueWhenParamSet() throws Exception {
-        when(schedulerService.filterEntitiesByTestFlag(any(), anyBoolean())).thenReturn(List.of());
+    @DisplayName("GET /connection/all/meta?includeTest=true forwards the flag to findAll")
+    void getAllMetaForwardsIncludeTestTrue() throws Exception {
+        when(connectionService.findAll(anyBoolean())).thenReturn(List.of());
         when(connectionResourceMapper.toDTOAll(any())).thenReturn(new ArrayList<>());
 
-        mockMvc.perform(get("/connection/all/meta").param("test", "true").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/connection/all/meta").param("includeTest", "true").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<Boolean> flag = ArgumentCaptor.forClass(Boolean.class);
-        verify(schedulerService).filterEntitiesByTestFlag(any(), flag.capture());
+        verify(connectionService).findAll(flag.capture());
         assertThat(flag.getValue()).isTrue();
     }
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectionServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectionServiceImpTest.java
@@ -12,7 +12,6 @@ import com.becon.opencelium.backend.database.mongodb.service.ConnectionMngServic
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.repository.ConnectionRepository;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionServiceImp;
-import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
 import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -62,96 +62,69 @@ class ConnectionServiceImpTest {
                 null, null, null, null, null, null, entityVersionManager, null, null);
     }
 
-    // ── filterTestConnections (List<ConnectionDTO>) ───────────────────────────
+    // ── findAll(includeTest) ──────────────────────────────────────────────────
 
     @Test
-    void filterTestConnectionsKeepsNonTestConnectionsWhenTestIsFalse() {
-        List<ConnectionDTO> input = List.of(dto("1", NORMAL_TITLE));
+    void findAllIncludesEveryConnectionWhenIncludeTestTrue() {
+        when(connectionRepository.findAll())
+                .thenReturn(List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE)));
 
-        List<ConnectionDTO> result = connectionService.filterTestConnections(input, false, Set.of());
-
-        assertThat(result).extracting(ConnectionDTO::getTitle).containsExactly(NORMAL_TITLE);
-    }
-
-    @Test
-    void filterTestConnectionsExcludesTestConnectionsWhenTestIsFalse() {
-        List<ConnectionDTO> input = List.of(dto("1", NORMAL_TITLE), dto("2", TEST_TITLE));
-
-        List<ConnectionDTO> result = connectionService.filterTestConnections(input, false, Set.of());
-
-        assertThat(result).extracting(ConnectionDTO::getTitle).containsExactly(NORMAL_TITLE);
-    }
-
-    @Test
-    void filterTestConnectionsIncludesTestConnectionsWhenTestIsTrue() {
-        List<ConnectionDTO> input = List.of(dto("1", NORMAL_TITLE), dto("2", TEST_TITLE));
-
-        List<ConnectionDTO> result = connectionService.filterTestConnections(input, true, Set.of());
-
-        assertThat(result).extracting(ConnectionDTO::getTitle)
-                .containsExactlyInAnyOrder(NORMAL_TITLE, TEST_TITLE);
-    }
-
-    @Test
-    void filterTestConnectionsExcludesRunningTestConnectionWhenTestIsTrue() {
-        List<ConnectionDTO> input = List.of(dto("5", TEST_TITLE), dto("6", OTHER_TEST_TITLE));
-
-        List<ConnectionDTO> result = connectionService.filterTestConnections(input, true, Set.of(5L));
-
-        assertThat(result).extracting(ConnectionDTO::getTitle).containsExactly(OTHER_TEST_TITLE);
-    }
-
-    @Test
-    void filterTestConnectionsReturnsEmptyWhenInputEmpty() {
-        List<ConnectionDTO> result = connectionService.filterTestConnections(List.of(), true, Set.of(1L));
-
-        assertThat(result).isEmpty();
-    }
-
-    // ── filterTestConnectionEntities (List<Connection>) ───────────────────────
-
-    @Test
-    void filterTestConnectionEntitiesKeepsNonTestConnectionsWhenTestIsFalse() {
-        List<Connection> input = List.of(entity(1L, NORMAL_TITLE));
-
-        List<Connection> result = connectionService.filterTestConnectionEntities(input, false, Set.of());
-
-        assertThat(result).extracting(Connection::getTitle).containsExactly(NORMAL_TITLE);
-    }
-
-    @Test
-    void filterTestConnectionEntitiesExcludesTestConnectionsWhenTestIsFalse() {
-        List<Connection> input = List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE));
-
-        List<Connection> result = connectionService.filterTestConnectionEntities(input, false, Set.of());
-
-        assertThat(result).extracting(Connection::getTitle).containsExactly(NORMAL_TITLE);
-    }
-
-    @Test
-    void filterTestConnectionEntitiesIncludesTestConnectionsWhenTestIsTrue() {
-        List<Connection> input = List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE));
-
-        List<Connection> result = connectionService.filterTestConnectionEntities(input, true, Set.of());
+        List<Connection> result = connectionService.findAll(true);
 
         assertThat(result).extracting(Connection::getTitle)
                 .containsExactlyInAnyOrder(NORMAL_TITLE, TEST_TITLE);
     }
 
     @Test
-    void filterTestConnectionEntitiesExcludesRunningTestConnectionWhenTestIsTrue() {
-        List<Connection> input = List.of(entity(5L, TEST_TITLE), entity(6L, OTHER_TEST_TITLE));
+    void findAllExcludesTestConnectionsWhenIncludeTestFalse() {
+        when(connectionRepository.findAll())
+                .thenReturn(List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE)));
 
-        List<Connection> result = connectionService.filterTestConnectionEntities(input, true, Set.of(5L));
+        List<Connection> result = connectionService.findAll(false);
 
-        assertThat(result).extracting(Connection::getTitle).containsExactly(OTHER_TEST_TITLE);
+        assertThat(result).extracting(Connection::getTitle).containsExactly(NORMAL_TITLE);
     }
 
     @Test
-    void filterTestConnectionEntitiesReturnsEmptyWhenInputEmpty() {
-        List<Connection> result = connectionService.filterTestConnectionEntities(List.of(), true, Set.of(1L));
+    void findAllIncludesTestConnectionsRegardlessOfRunningStateWhenIncludeTestTrue() {
+        // Running state must NOT affect listing: includeTest=true returns all test connections.
+        when(connectionRepository.findAll())
+                .thenReturn(List.of(entity(5L, TEST_TITLE), entity(6L, OTHER_TEST_TITLE)));
 
-        assertThat(result).isEmpty();
+        List<Connection> result = connectionService.findAll(true);
+
+        assertThat(result).extracting(Connection::getTitle)
+                .containsExactlyInAnyOrder(TEST_TITLE, OTHER_TEST_TITLE);
+    }
+
+    @Test
+    void findAllReturnsEmptyWhenRepositoryEmpty() {
+        when(connectionRepository.findAll()).thenReturn(List.of());
+
+        assertThat(connectionService.findAll(false)).isEmpty();
+    }
+
+    // ── findAllByConnectorId(includeTest) ─────────────────────────────────────
+
+    @Test
+    void findAllByConnectorIdExcludesTestConnectionsWhenIncludeTestFalse() {
+        when(connectionRepository.findAllByConnectorId(7))
+                .thenReturn(new LinkedList<>(List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE))));
+
+        List<Connection> result = connectionService.findAllByConnectorId(7, false);
+
+        assertThat(result).extracting(Connection::getTitle).containsExactly(NORMAL_TITLE);
+    }
+
+    @Test
+    void findAllByConnectorIdKeepsTestConnectionsWhenIncludeTestTrue() {
+        when(connectionRepository.findAllByConnectorId(7))
+                .thenReturn(new LinkedList<>(List.of(entity(1L, NORMAL_TITLE), entity(2L, TEST_TITLE))));
+
+        List<Connection> result = connectionService.findAllByConnectorId(7, true);
+
+        assertThat(result).extracting(Connection::getTitle)
+                .containsExactlyInAnyOrder(NORMAL_TITLE, TEST_TITLE);
     }
 
     // ── deleteByIds ───────────────────────────────────────────────────────────
@@ -207,13 +180,6 @@ class ConnectionServiceImpTest {
         connectionService.deleteByIds(java.util.Collections.singletonList(null), Set.of());
 
         verifyNoInteractions(connectionRepository, connectionMngService);
-    }
-
-    private static ConnectionDTO dto(String id, String title) {
-        ConnectionDTO dto = new ConnectionDTO();
-        dto.setId(id);
-        dto.setTitle(title);
-        return dto;
     }
 
     private static Connection entity(Long id, String title) {

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/SchedulerServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/SchedulerServiceImpTest.java
@@ -8,19 +8,15 @@
 
 package com.becon.opencelium.backend.unit.database.mysql.service;
 
-import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
 import com.becon.opencelium.backend.database.mysql.service.SchedulerService;
 import com.becon.opencelium.backend.database.mysql.service.SchedulerServiceImp;
 import com.becon.opencelium.backend.quartz.SchedulingStrategy;
-import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
 import com.becon.opencelium.backend.resource.schedule.RunningJob;
 import com.becon.opencelium.backend.testutil.fixture.RunningJobFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
@@ -32,11 +28,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -53,9 +45,6 @@ class SchedulerServiceImpTest {
 
     @Mock
     private ConnectionService connectionService;
-
-    @Captor
-    private ArgumentCaptor<Set<Long>> runningIdsCaptor;
 
     private SchedulerService schedulerService;
 
@@ -103,65 +92,5 @@ class SchedulerServiceImpTest {
 
         assertThatThrownBy(() -> result.add(99L))
                 .isInstanceOf(UnsupportedOperationException.class);
-    }
-
-    // ── filterByTestFlag (List<ConnectionDTO>) ────────────────────────────────
-
-    @Test
-    void filterByTestFlagPassesEmptyRunningIdsWhenTestIsFalse() {
-        List<ConnectionDTO> input = List.of(dto("1", "Regular"));
-        List<ConnectionDTO> delegated = List.of(dto("1", "Regular"));
-        when(connectionService.filterTestConnections(eq(input), eq(false), any())).thenReturn(delegated);
-
-        List<ConnectionDTO> result = schedulerService.filterByTestFlag(input, false);
-
-        assertThat(result).isSameAs(delegated);
-        verify(connectionService).filterTestConnections(eq(input), eq(false), runningIdsCaptor.capture());
-        assertThat(runningIdsCaptor.getValue()).isEmpty();
-        verify(schedulingStrategy, never()).getRunningJobs();
-    }
-
-    @Test
-    void filterByTestFlagPassesRunningIdsWhenTestIsTrue() {
-        List<ConnectionDTO> input = List.of(dto("7", "!*test_connection_1700000000000_X"));
-        List<ConnectionDTO> delegated = List.of();
-        when(schedulingStrategy.getRunningJobs()).thenReturn(List.of(RunningJobFixture.aRunningJob(7L, 2, 1L)));
-        when(connectionService.filterTestConnections(eq(input), eq(true), any())).thenReturn(delegated);
-
-        List<ConnectionDTO> result = schedulerService.filterByTestFlag(input, true);
-
-        assertThat(result).isSameAs(delegated);
-        verify(connectionService).filterTestConnections(eq(input), eq(true), runningIdsCaptor.capture());
-        assertThat(runningIdsCaptor.getValue()).containsExactly(7L);
-    }
-
-    // ── filterEntitiesByTestFlag (List<Connection>) ───────────────────────────
-
-    @Test
-    void filterEntitiesByTestFlagPassesRunningIdsWhenTestIsTrue() {
-        List<Connection> input = List.of(entity(7L, "!*test_connection_1700000000000_X"));
-        List<Connection> delegated = List.of();
-        when(schedulingStrategy.getRunningJobs()).thenReturn(List.of(RunningJobFixture.aRunningJob(7L, 2, 1L)));
-        when(connectionService.filterTestConnectionEntities(eq(input), eq(true), any())).thenReturn(delegated);
-
-        List<Connection> result = schedulerService.filterEntitiesByTestFlag(input, true);
-
-        assertThat(result).isSameAs(delegated);
-        verify(connectionService).filterTestConnectionEntities(eq(input), eq(true), runningIdsCaptor.capture());
-        assertThat(runningIdsCaptor.getValue()).containsExactly(7L);
-    }
-
-    private static ConnectionDTO dto(String id, String title) {
-        ConnectionDTO dto = new ConnectionDTO();
-        dto.setId(id);
-        dto.setTitle(title);
-        return dto;
-    }
-
-    private static Connection entity(Long id, String title) {
-        Connection connection = new Connection();
-        connection.setId(id);
-        connection.setTitle(title);
-        return connection;
     }
 }


### PR DESCRIPTION
## What
Make leftover **test connection** cleanup (titles prefixed `!*test_connection_`) triggerable on demand and safe against in-progress tests, and replace the `test` listing flag with `includeTest`.

- `cleanupAllTestConnections(...)` now takes a `Set<Long> runningConnectionIds` parameter and skips those ids, so a test that is currently running is never deleted (the deletion logic itself is unchanged; also fixed a log typo).
- New endpoint `DELETE /connection/test` runs the cleanup with the live running set from `SchedulerService.getRunningConnectionIds()` and returns the `CleanupResult` summary (`candidateSqlIds`, `mongoDeleted`, `sqlDeleted`).
- Startup hook (`StorageConfiguration`, `ApplicationReadyEvent`) calls the cleanup with `Set.of()` (nothing runs that early).
- New optional query param `includeTest=true|false` (default `false`) on `GET /connection/all`, `/all/meta`, `/all/by-ids`, `/dependency/{invokerName}`, replacing the old `test` param. Filtering moved into `ConnectionService` overloads (`findAll`, `findAllByConnectorId`, `findAllByIds`, `getAllFullConnection`).
- Removed the now-unused `SchedulerService.filterByTestFlag` / `filterEntitiesByTestFlag` and `ConnectionService.filterTestConnections` / `filterTestConnectionEntities`.

## Why
When the OC process is killed/crashes before its normal post-test cleanup runs, orphaned test connections accumulate and can affect correct operation. Implements OC-1436.

## How to test
```bash
# Unit + slice tests — no Docker needed
./gradlew test --tests "*.ConnectionServiceImpTest" \
               --tests "*.ConnectionControllerTest" \
               --tests "*.SchedulerServiceImpTest"

# Manual: leave a "!*test_connection_..." row (ideally with a scheduler), then
curl -X DELETE http://127.0.0.1:9090/connection/test
# -> running test connections are excluded; response reports deleted counts.

# Listing: test connections hidden by default, included with the flag
curl 'http://127.0.0.1:9090/connection/all'
curl 'http://127.0.0.1:9090/connection/all?includeTest=true'
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally (affected suites)
- [x] Tests added or updated — `ConnectionServiceImpTest`, `ConnectionControllerTest`, `SchedulerServiceImpTest`
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed