### PR TITLE
OC-1441: Use webhook uuid as execute URL credential instead of JWT

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
@@ -17,4 +17,5 @@ public interface ExceptionMessages {
     String ONLY_OWNER_OR_ADMIN_CAN_PERFORM_ACTION = "Only owner or admin can perform this action";
     String FROM_CONNECTOR_IS_NULL = "fromConnector is null";
     String METHOD_NAME_MUST_BE_NON_NULL = "Method name must not be null";
+    String SCHEDULER_NOT_FOUND = "Scheduler not found";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookService.java
@@ -29,8 +29,6 @@ public interface WebhookService {
 
     Webhook save(int userId, Scheduler schedulerId);
 
-    String generateWebhookToken(int userId, String uuid, int schedulerId);
-
     String buildUrl(Webhook webhook);
 
     int getConnectionIdByUrl();

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookServiceImp.java
@@ -17,6 +17,7 @@
 package com.becon.opencelium.backend.database.mysql.service;
 
 import com.becon.opencelium.backend.constant.ExceptionConstant;
+import com.becon.opencelium.backend.constant.ExceptionMessages;
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
 import com.becon.opencelium.backend.database.mysql.entity.Webhook;
 import com.becon.opencelium.backend.database.mysql.repository.WebhookRepository;
@@ -49,9 +50,37 @@ public class WebhookServiceImp implements WebhookService {
     @Autowired
     private JwtTokenUtil jwtTokenUtil;
 
-    //TODO: rename method - gets some info from token
+    // Resolves the credential found in the execute URL path segment into the data needed to trigger a
+    // webhook. Two formats are supported:
+    //   - legacy JWT (contains '.'): the userId/uuid/schedulerId are read from the signed claims.
+    //   - uuid (no '.'): the row is looked up by uuid and scheduler/createdBy are read from it. The row's
+    //     existence is itself the proof of authenticity (only the backend ever inserts one), so no token
+    //     signing or verification is required.
     @Override
     public Optional<WebhookTokenResource> getTokenObject(String token) {
+        if (token != null && token.contains(".")) {
+            return getTokenObjectFromJwt(token);
+        }
+        return getTokenObjectFromUuid(token);
+    }
+
+    private Optional<WebhookTokenResource> getTokenObjectFromUuid(String uuid) {
+        Webhook webhook = webhookRepository.findByUuid(uuid).orElse(null);
+        if (webhook == null) {
+            return Optional.empty();
+        }
+
+        if (webhook.getScheduler() == null) {
+            throw new GeneralServiceException(ExceptionConstant.SCHEDULER_NOT_FOUND, ExceptionMessages.SCHEDULER_NOT_FOUND);
+        }
+
+        int schedulerId = webhook.getScheduler().getId();
+        int userId = webhook.getCreatedBy() != null ? webhook.getCreatedBy() : -1;
+
+        return Optional.of(new WebhookTokenResource(userId, uuid, schedulerId));
+    }
+
+    private Optional<WebhookTokenResource> getTokenObjectFromJwt(String token) {
         JWTClaimsSet claims = jwtTokenUtil.getAllClaimsFromToken(token);
 
         String uuid = claims.getClaim("uuid").toString();
@@ -79,25 +108,10 @@ public class WebhookServiceImp implements WebhookService {
     public Webhook save(int userId, Scheduler scheduler) {
         Webhook webhook = new Webhook();
         UUID uuid = UUID.randomUUID();
-        String token = generateWebhookToken(userId, uuid.toString(), scheduler.getId());
 
         webhook.setUuid(uuid.toString());
-        webhook.setToken(token);
         webhook.setScheduler(scheduler);
         return webhookRepository.save(webhook);
-    }
-
-    @Override
-    public String generateWebhookToken(int userId, String uuid, int schedulerId) {
-        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-                .subject("webhook")
-                .claim("userId", userId)
-                .claim("uuid", uuid)
-                .claim("schedulerId", schedulerId)
-                .jwtID(Long.toString(schedulerId))
-                .build();
-
-        return jwtTokenUtil.generateToken(claimsSet);
     }
 
     @Override
@@ -125,7 +139,7 @@ public class WebhookServiceImp implements WebhookService {
     @Override
     public String buildUrl(Webhook webhook) {
 //        URI uri = ServletUriComponentsBuilder.fromCurrentRequest().build().toUri();
-        return "./webhook/execute/" + webhook.getToken();
+        return "./webhook/execute/" + webhook.getUuid();
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/webhook/WebhookResource.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/webhook/WebhookResource.java
@@ -30,7 +30,7 @@ public class WebhookResource {
 
     public WebhookResource(Webhook webhook) {
         this.webhookId  = webhook.getId();
-        this.url = webhook.getToken();
+        this.url = webhook.getUuid();
     }
 
     public String getUrl() {

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -727,3 +727,5 @@ ALTER TABLE `enhancement` ADD CONSTRAINT `fk_enhancement_connection1` FOREIGN KE
 ALTER TABLE `connection` MODIFY COLUMN `to_connector` INT NULL;
 --changeset 5.0:2 stripComments:true splitStatements:true endDelimiter:;
 ALTER TABLE `operation_usage_history` MODIFY COLUMN `to_invoker` VARCHAR(255) NULL;
+--changeset 5.0:3 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `webhook` ADD CONSTRAINT `uq_webhook_uuid` UNIQUE (`uuid`);


### PR DESCRIPTION
## What
Replace the signed JWT embedded in webhook execute URLs (`GET|POST /webhook/execute/{token}`) with the webhook's existing random `uuid` as the sole URL credential. The execute endpoint now looks the `Webhook` up by `uuid` and reads `scheduler` and `createdBy` from the row. Legacy JWT-format URLs still resolve and trigger the scheduler.

Key changes:
- `WebhookServiceImp.save` — generate `uuid`, set `createdBy = userId`, drop JWT generation.
- `WebhookServiceImp.buildUrl` — emit `./webhook/execute/{uuid}`.
- `WebhookServiceImp.getTokenObject` — branch on the path segment: contains `.` → existing JWT claim parsing (legacy); otherwise → `findByUuid` and read `scheduler`/`createdBy` from the row. Unknown uuid → not found.
- `changelog.sql` — added unique index on `webhook.uuid` (changeset `5.0:3`).

## Why
The JWT credential produced a ~250-char URL path segment and required HMAC signing/verification on every execute call. The `uuid` is already random (122-bit, `SecureRandom`-backed) and unique, and the database row's existence is itself proof of authenticity — only the backend ever inserts one — so no token signing or verification is needed on the execute path. Result: a 36-char URL segment and no crypto in the hot path, with full backward compatibility for URLs that were already handed out.
Closes OC-1441.

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
