### PR TITLE
[Fixed] OC-1447: Remove check for 'COMPLETED' when searching children…

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/InMemoryLogBlockBuffer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/InMemoryLogBlockBuffer.java
@@ -47,9 +47,8 @@ public class InMemoryLogBlockBuffer implements LogBlockBuffer {
     }
 
     @Override
-    public synchronized List<LogDataMng> findAllCompletedByExecutionId(String executionId) {
+    public synchronized List<LogDataMng> findAllByExecutionId(String executionId) {
         return buffer.stream()
-                .filter(block -> block.getStatus() == PhaseStatus.COMPLETE)
                 .filter(block -> Objects.equals(block.getExecutionId(), executionId))
                 .toList();
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/InMemoryLogBlockBuffer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/InMemoryLogBlockBuffer.java
@@ -1,7 +1,6 @@
 package com.becon.opencelium.backend.execution.logger.buffer;
 
 import com.becon.opencelium.backend.database.mongodb.entity.LogDataMng;
-import com.becon.opencelium.backend.execution.logger.enums.PhaseStatus;
 
 import java.util.*;
 
@@ -36,13 +35,13 @@ public class InMemoryLogBlockBuffer implements LogBlockBuffer {
     }
 
     @Override
-    public synchronized Optional<LogDataMng> findInBufferByKey(LogDataMng example) {
+    public synchronized Optional<LogDataMng> findByKey(LogDataMng example) {
         String key = keyExtractor.extractKey(example);
         return Optional.ofNullable(blockByKey.get(key));
     }
 
     @Override
-    public synchronized Optional<LogDataMng> findInBufferById(String elementId) {
+    public synchronized Optional<LogDataMng> findById(String elementId) {
         return Optional.ofNullable(blockById.get(elementId));
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/LogBlockBuffer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/LogBlockBuffer.java
@@ -23,7 +23,7 @@ public interface LogBlockBuffer {
      */
     Optional<LogDataMng> findInBufferById(String elementId);
 
-    List<LogDataMng> findAllCompletedByExecutionId(String executionId);
+    List<LogDataMng> findAllByExecutionId(String executionId);
 
     /**
      * Explicit flush (e.g., on shutdown).

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/LogBlockBuffer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/buffer/LogBlockBuffer.java
@@ -16,12 +16,12 @@ public interface LogBlockBuffer {
     /**
      * Find an existing block in the in-memory buffer by key (if any).
      */
-    Optional<LogDataMng> findInBufferByKey(LogDataMng example);
+    Optional<LogDataMng> findByKey(LogDataMng example);
 
     /**
      * Find an existing block in the in-memory buffer by elementId (if any).
      */
-    Optional<LogDataMng> findInBufferById(String elementId);
+    Optional<LogDataMng> findById(String elementId);
 
     List<LogDataMng> findAllByExecutionId(String executionId);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
@@ -369,7 +369,7 @@ public class LogDataServiceImp implements LogDataService {
 
         var savedChildren = metaDataLogRepository.findChildren(executionId, FLOWCHART.name(), SORT_ASCENDING);
 
-        var bufferedChildren = buffer.findAllCompletedByExecutionId(executionId).stream()
+        var bufferedChildren = buffer.findAllByExecutionId(executionId).stream()
                 .filter(child -> child.getType() == FLOWCHART)
                 .toList();
 
@@ -425,7 +425,7 @@ public class LogDataServiceImp implements LogDataService {
     private List<LogDataMng> findBufferedChildren(String executionId, String flowchartId, String regex, String loopIndex) {
         Pattern pattern = Pattern.compile(regex);
 
-        return buffer.findAllCompletedByExecutionId(executionId).stream()
+        return buffer.findAllByExecutionId(executionId).stream()
                 .filter(child -> Objects.equals(child.getFlowId(), flowchartId))
                 .filter(child -> child.getIndexPath() != null)
                 .filter(child -> pattern.matcher(child.getIndexPath()).matches())

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
@@ -345,7 +345,7 @@ public class LogDataServiceImp implements LogDataService {
         return metaDataLogRepository.findById(phaseId)
                 .or(() -> metaDataLogRepository.findByExecutionIdAndType(phaseId, EXECUTION.name()))
                 .or(() -> metaDataLogRepository.findByFlowIdAndType(phaseId, FLOWCHART.name()))
-                .or(() -> buffer.findInBufferById(phaseId))
+                .or(() -> buffer.findById(phaseId))
                 .orElseThrow(() -> new RuntimeException("LogData element not found with specified id = " + phaseId));
     }
 
@@ -501,7 +501,7 @@ public class LogDataServiceImp implements LogDataService {
      * First check in-memory buffer, then DB.
      */
     private Optional<LogDataMng> findExistingBlock(LogDataMng block) {
-        Optional<LogDataMng> inBuffer = buffer.findInBufferByKey(block);
+        Optional<LogDataMng> inBuffer = buffer.findByKey(block);
         if (inBuffer.isPresent()) {
             return inBuffer;
         }


### PR DESCRIPTION
## What
- Fixed retrieving log data children, search in both repository and buffer

## Why
Resolves: [[OC-1447] Children of Log pahases should be searched in both buffer and DB during execution.](https://becon.atlassian.net/browse/OC-1447)

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code