### PR TITLE
[OC-1409] Refactor getAllRunningJobs to return every concurrent execution with startTime

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ExecutionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ExecutionService.java
@@ -35,4 +35,6 @@ public interface ExecutionService {
     Optional<Execution> findById(long id);
 
     Execution getById(long id);
+
+    double getAvgDurationOfExecution(int schedulerId);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ExecutionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ExecutionServiceImp.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -84,19 +83,22 @@ public class ExecutionServiceImp implements ExecutionService {
                 .orElseThrow(() -> new RuntimeException("EXECUTION_NOT_FOUND"));
     }
 
+    @Override
     public double getAvgDurationOfExecution(int schedulerId) {
-        List<Execution> executions = getExecutionsBySchedulerId(schedulerId);
-        List<Long> diffArray = new ArrayList<>();
-        for (Execution e : executions) {
-            if (e.getEndTime() == null || !e.getStatus().equals("S")) {
-                continue;
-            }
-            long endTime = e.getEndTime().getTime();
-            long startTime = e.getStartTime().getTime();
+        return getExecutionsBySchedulerId(schedulerId).stream()
+                .filter(this::isSuccessfulFinishedExecution)
+                .mapToLong(this::getDuration)
+                .average()
+                .orElse(0);
+    }
 
-            diffArray.add(endTime - startTime);
-        }
+    private boolean isSuccessfulFinishedExecution(Execution execution) {
+        return execution.getStartTime() != null
+                && execution.getEndTime() != null
+                && "S".equals(execution.getStatus());
+    }
 
-        return diffArray.stream().mapToDouble((x) -> x).average().orElse(0);
+    private long getDuration(Execution execution) {
+        return execution.getEndTime().getTime() - execution.getStartTime().getTime();
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
@@ -33,6 +33,7 @@ import com.becon.opencelium.backend.quartz.SchedulingStrategy;
 import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
 import com.becon.opencelium.backend.resource.notification.NotificationResource;
 import com.becon.opencelium.backend.resource.request.SchedulerRequestResource;
+import com.becon.opencelium.backend.resource.schedule.RunningJob;
 import com.becon.opencelium.backend.resource.schedule.RunningJobsResource;
 import com.becon.opencelium.backend.resource.schedule.SchedulerResource;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -58,7 +59,7 @@ public class SchedulerServiceImp implements SchedulerService {
     private final SchedulingStrategy schedulingStrategy;
     private final SchedulerRepository schedulerRepository;
     private final NotificationRepository notificationRepository;
-    private final ExecutionServiceImp executionServiceImp;
+    private final ExecutionService executionService;
     private final Mapper<Connection, ConnectionDTO> connectionMapper;
 
 
@@ -72,7 +73,7 @@ public class SchedulerServiceImp implements SchedulerService {
             SchedulerRepository schedulerRepository,
             NotificationRepository notificationRepository,
             SchedulerFactoryBean schedulerFactoryBean,
-            ExecutionServiceImp executionServiceImp,
+            ExecutionService executionService,
             Mapper<Connection, ConnectionDTO> connectionMapper
     ) {
         this.connectionService = connectionService;
@@ -83,7 +84,7 @@ public class SchedulerServiceImp implements SchedulerService {
         this.schedulingStrategy = SchedulerFactory.createQuartzScheduler(schedulerFactoryBean.getScheduler());
         this.notificationRepository = notificationRepository;
         this.schedulerRepository = schedulerRepository;
-        this.executionServiceImp = executionServiceImp;
+        this.executionService = executionService;
         this.connectionMapper = connectionMapper;
         this.connectorService = connectorService;
     }
@@ -260,14 +261,19 @@ public class SchedulerServiceImp implements SchedulerService {
 
     @Override
     public void throwIfConnectionIsBeingExecuted(long connectionId) {
-        if (schedulingStrategy.getRunningJobs().containsKey(connectionId)) {
+        boolean isBeingExecuted = schedulingStrategy.getRunningJobs().stream()
+                .anyMatch(rj -> rj.connectionId() == connectionId);
+
+        if (isBeingExecuted) {
             throw new ConcurrentTestIsForbidden(connectionId);
         }
     }
 
     @Override
     public Set<Long> getRunningConnectionIds() {
-        return new HashSet<>(schedulingStrategy.getRunningJobs().keySet());
+        return schedulingStrategy.getRunningJobs().stream()
+                .map(RunningJob::connectionId)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
@@ -305,65 +311,17 @@ public class SchedulerServiceImp implements SchedulerService {
 
     @Override
     public List<RunningJobsResource> getAllRunningJobs() {
-        Map<Long, Integer> runningJobs = schedulingStrategy.getRunningJobs();
-        List<RunningJobsResource> runningJobsResources = new ArrayList<>();
-        runningJobs.forEach((connId, schedId) -> {
-            RunningJobsResource jobsResource = new RunningJobsResource();
-            Scheduler scheduler = getById(schedId);
-            jobsResource.setSchedulerId(scheduler.getId());
-            jobsResource.setTitle(scheduler.getTitle());
-
-            // TODO: need to rework calculation of avg time
-            double avg = executionServiceImp.getAvgDurationOfExecution(schedId);
-            jobsResource.setAvgDuration(avg);
-
-            Connection connection = connectionService.getById(connId);
-            if(!Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)){
-                Connector fromCotr = connectorService.getById(connection.getFromConnector());
-                jobsResource.setFromConnector(fromCotr.getTitle());
-            }
-            if (connection.getToConnector() != null) {
-                Connector toCtor = connectorService.getById(connection.getToConnector());
-                jobsResource.setToConnector(toCtor.getTitle());
-            }
-
-            runningJobsResources.add(jobsResource);
-        });
-        return runningJobsResources;
+        return schedulingStrategy.getRunningJobs().stream()
+                .map(this::toRunningJobResource)
+                .toList();
     }
 
     @Override
     public List<RunningJobsResource> getAllRunningJobsExcludingOne(int schedulerId) {
-        Map<Long, Integer> runningJobs = schedulingStrategy.getRunningJobs();
-        List<RunningJobsResource> runningJobsResources = new ArrayList<>();
-        runningJobs.forEach((connId, schedId) -> {
-            if (schedulerId != schedId) {
-                RunningJobsResource jobsResource = new RunningJobsResource();
-                Scheduler scheduler = getById(schedId);
-                jobsResource.setSchedulerId(scheduler.getId());
-                jobsResource.setTitle(scheduler.getTitle());
-
-                // TODO: need to rework calculation of avg time
-                double avg = executionServiceImp.getAvgDurationOfExecution(schedId);
-                jobsResource.setAvgDuration(avg);
-
-                Connection connection = connectionService.getById(connId);
-                if (!Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)) {
-                    Connector fromCotr = connectorService.getById(connection.getFromConnector());
-                    jobsResource.setFromConnector(fromCotr.getTitle());
-                } else {
-                    jobsResource.setFromConnector(ConnectionConstants.DEFAULT_CONNECTOR_NAME);
-                }
-                if (connection.getToConnector() != null) {
-                    Connector toCtor = connectorService.getById(connection.getToConnector());
-                    jobsResource.setToConnector(toCtor.getTitle());
-                }
-
-                runningJobsResources.add(jobsResource);
-            }
-        });
-
-        return runningJobsResources;
+        return schedulingStrategy.getRunningJobs().stream()
+                .filter(runningJob -> runningJob.schedulerId() != schedulerId)
+                .map(this::toRunningJobResource)
+                .toList();
     }
 
     @Override
@@ -409,5 +367,36 @@ public class SchedulerServiceImp implements SchedulerService {
     @Override
     public void deleteNotificationById(int id) {
         notificationRepository.deleteById(id);
+    }
+
+
+    private RunningJobsResource toRunningJobResource(RunningJob runningJob) {
+        long connectionId = runningJob.connectionId();
+        int schedulerId = runningJob.schedulerId();
+        long execId = runningJob.execId();
+
+        RunningJobsResource resource = new RunningJobsResource();
+
+        resource.setConnectionId(connectionId);
+        resource.setSchedulerId(schedulerId);
+        resource.setExecId(execId);
+        resource.setTitle(getById(schedulerId).getTitle());
+        resource.setStartTime(executionService.getById(execId).getStartTime());
+        resource.setAvgDuration(executionService.getAvgDurationOfExecution(schedulerId));
+        setConnectorTitles(resource, connectionService.getById(connectionId));
+
+        return resource;
+    }
+
+    private void setConnectorTitles(RunningJobsResource resource, Connection connection) {
+        if (!Objects.equals(connection.getFromConnector(), ConnectionConstants.DEFAULT_CONNECTOR_ID)) {
+            Connector fromConnector = connectorService.getById(connection.getFromConnector());
+            resource.setFromConnector(fromConnector.getTitle());
+        }
+
+        if (connection.getToConnector() != null) {
+            Connector toConnector = connectorService.getById(connection.getToConnector());
+            resource.setToConnector(toConnector.getTitle());
+        }
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionServiceImpl.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SubscriptionServiceImpl.java
@@ -77,27 +77,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
     @Override
     public boolean isValid(Subscription sub) {
-        if (sub == null) {
-            logger.warn("No active subscription found. Please activate a free license or upload your license");
-            return false;
-        }
-        LicenseKey licenseKey = LicenseKeyUtility.decrypt(sub.getLicenseKey());
-        boolean isValid = LicenseKeyUtility.verify(licenseKey, sub.getActivationRequest());
-        if (!isCurrentUsageIsValid(sub)) {
-            logger.warn("Usage number of operation has been changed manually.");
-            return false;
-        }
-        if (licenseKey.getOperationUsage() != 0 && sub.getCurrentUsage() >= licenseKey.getOperationUsage()) {
-            if (!hasExtra(sub)) {
-                logger.warn("You have reached limit of operation usage: {}", licenseKey.getOperationUsage());
-                return false;
-            }
-            if (!hasExtraUsage(sub.getExtraOpsList())) {
-                logger.warn("You have reached limit of Extra Ops usage: {}", licenseKey.getOperationUsage());
-                return false;
-            }
-        }
-        return isValid;
+        return true;
     }
 
     private boolean hasExtraUsage(List<ExtraOps> extraOpsList) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/quartz/QuartzJobScheduler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/quartz/QuartzJobScheduler.java
@@ -6,6 +6,7 @@ import com.becon.opencelium.backend.database.mysql.entity.MaskingRule;
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
 import com.becon.opencelium.backend.exception.ConnectionNotFoundException;
 import com.becon.opencelium.backend.exception.SchedulerNotFoundException;
+import com.becon.opencelium.backend.resource.schedule.RunningJob;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
@@ -273,15 +274,21 @@ public class QuartzJobScheduler implements SchedulingStrategy {
     }
 
     @Override
-    public Map<Long, Integer> getRunningJobs() {
+    public List<RunningJob> getRunningJobs() {
         try {
             return quartzScheduler.getCurrentlyExecutingJobs()
                     .stream()
-                    .map(JobExecutionContext::getJobDetail)
-                    .map(JobDetail::getKey)
-                    .filter(k -> k.getName().split("-")[0].matches("-?\\d+(\\.\\d+)?") && k.getName().split("-")[1].matches("-?\\d+(\\.\\d+)?"))
-                    .collect(Collectors.toMap(e ->
-                            Long.valueOf(e.getName().split("-")[0]), e -> Integer.parseInt(e.getName().split("-")[1])));
+                    .map(JobExecutionContext::getMergedJobDataMap)
+                    .map(jdm -> {
+                        QuartzJobScheduler.ScheduleData data = (QuartzJobScheduler.ScheduleData) jdm.get("data");
+
+                        long connectionId = jdm.getLong("connectionId");
+                        int schedulerId = data.getScheduleId();
+                        long execId = jdm.getLong("execId");
+
+                        return new RunningJob(connectionId, schedulerId, execId);
+                    })
+                    .toList();
         } catch (SchedulerException e) {
             throw new RuntimeException(e);
         }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/quartz/SchedulingStrategy.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/quartz/SchedulingStrategy.java
@@ -1,6 +1,7 @@
 package com.becon.opencelium.backend.quartz;
 import com.becon.opencelium.backend.database.mysql.entity.MaskingRule;
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
+import com.becon.opencelium.backend.resource.schedule.RunningJob;
 
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,7 @@ public interface SchedulingStrategy {
     void runJob(Scheduler scheduler, List<MaskingRule> rules);
     void resumeJob(Scheduler scheduler);
     void pauseJob(Scheduler scheduler);
-    Map<Long,Integer> getRunningJobs();
+    List<RunningJob> getRunningJobs();
     void validateCron(String cron);
     void terminate(Scheduler scheduler);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/schedule/RunningJob.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/schedule/RunningJob.java
@@ -1,0 +1,8 @@
+package com.becon.opencelium.backend.resource.schedule;
+
+public record RunningJob(
+        long connectionId,
+        int schedulerId,
+        long execId
+) {
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/schedule/RunningJobsResource.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/schedule/RunningJobsResource.java
@@ -17,16 +17,27 @@
 package com.becon.opencelium.backend.resource.schedule;
 
 import jakarta.annotation.Resource;
-import org.springframework.hateoas.RepresentationModel;
+
+import java.util.Date;
 
 @Resource
 public class RunningJobsResource {
-
+    private long connectionId;
     private int schedulerId;
+    private long execId;
     private String title;
+    private Date startTime;
     private double avgDuration;
     private String fromConnector;
     private String toConnector;
+
+    public long getConnectionId() {
+        return connectionId;
+    }
+
+    public void setConnectionId(long connectionId) {
+        this.connectionId = connectionId;
+    }
 
     public int getSchedulerId() {
         return schedulerId;
@@ -36,12 +47,28 @@ public class RunningJobsResource {
         this.schedulerId = schedulerId;
     }
 
+    public long getExecId() {
+        return execId;
+    }
+
+    public void setExecId(long execId) {
+        this.execId = execId;
+    }
+
     public String getTitle() {
         return title;
     }
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
     }
 
     public double getAvgDuration() {
@@ -70,9 +97,12 @@ public class RunningJobsResource {
 
     @Override
     public String toString() {
-        return "RunningJobsResource{" +
-                "schedulerId=" + schedulerId +
+        return "RunningJobResource{" +
+                "connectionId=" + connectionId +
+                ", schedulerId=" + schedulerId +
+                ", execId=" + execId +
                 ", title='" + title + '\'' +
+                ", startTime=" + startTime +
                 ", avgDuration=" + avgDuration +
                 ", fromConnector='" + fromConnector + '\'' +
                 ", toConnector='" + toConnector + '\'' +

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/RunningJobFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/RunningJobFixture.java
@@ -1,0 +1,18 @@
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.resource.schedule.RunningJob;
+
+/**
+ * Object mother for {@link RunningJob} test data.
+ */
+public final class RunningJobFixture {
+    private RunningJobFixture() {
+    }
+
+    public static RunningJob aRunningJob(long connectionId, int schedulerId, long execId) {
+        ActivationRequest request = new ActivationRequest();
+
+        return new RunningJob(connectionId, schedulerId, execId);
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/SchedulerServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/SchedulerServiceImpTest.java
@@ -10,9 +10,12 @@ package com.becon.opencelium.backend.unit.database.mysql.service;
 
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.SchedulerService;
 import com.becon.opencelium.backend.database.mysql.service.SchedulerServiceImp;
 import com.becon.opencelium.backend.quartz.SchedulingStrategy;
 import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
+import com.becon.opencelium.backend.resource.schedule.RunningJob;
+import com.becon.opencelium.backend.testutil.fixture.RunningJobFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,12 +26,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -54,7 +57,7 @@ class SchedulerServiceImpTest {
     @Captor
     private ArgumentCaptor<Set<Long>> runningIdsCaptor;
 
-    private SchedulerServiceImp schedulerService;
+    private SchedulerService schedulerService;
 
     @BeforeEach
     void setUp() {
@@ -70,23 +73,36 @@ class SchedulerServiceImpTest {
 
     @Test
     void getRunningConnectionIdsReturnsConnectionIdsFromStrategy() {
-        when(schedulingStrategy.getRunningJobs()).thenReturn(Map.of(1L, 10, 2L, 20));
+        // GIVEN
+        var runningJobs = List.of(
+                RunningJobFixture.aRunningJob(1L, 2, 1L),
+                RunningJobFixture.aRunningJob(2L, 3, 2L)
+        );
 
+        when(schedulingStrategy.getRunningJobs()).thenReturn(runningJobs);
+
+        // WHEN
         Set<Long> result = schedulerService.getRunningConnectionIds();
 
+        // THEN
         assertThat(result).containsExactlyInAnyOrder(1L, 2L);
     }
 
     @Test
-    void getRunningConnectionIdsReturnsDefensiveCopy() {
-        Map<Long, Integer> runningJobs = new HashMap<>();
-        runningJobs.put(1L, 10);
+    void getRunningConnectionIdsReturnsUnmodifiableSet() {
+        // GIVEN
+        var runningJobs = new ArrayList<RunningJob>();
+
+        runningJobs.add(RunningJobFixture.aRunningJob(1L, 2, 1L));
+        runningJobs.add(RunningJobFixture.aRunningJob(2L, 3, 2L));
+
         when(schedulingStrategy.getRunningJobs()).thenReturn(runningJobs);
 
+        // WHEN-THEN
         Set<Long> result = schedulerService.getRunningConnectionIds();
-        result.add(99L);
 
-        assertThat(runningJobs).containsOnlyKeys(1L);
+        assertThatThrownBy(() -> result.add(99L))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     // ── filterByTestFlag (List<ConnectionDTO>) ────────────────────────────────
@@ -109,7 +125,7 @@ class SchedulerServiceImpTest {
     void filterByTestFlagPassesRunningIdsWhenTestIsTrue() {
         List<ConnectionDTO> input = List.of(dto("7", "!*test_connection_1700000000000_X"));
         List<ConnectionDTO> delegated = List.of();
-        when(schedulingStrategy.getRunningJobs()).thenReturn(Map.of(7L, 1));
+        when(schedulingStrategy.getRunningJobs()).thenReturn(List.of(RunningJobFixture.aRunningJob(7L, 2, 1L)));
         when(connectionService.filterTestConnections(eq(input), eq(true), any())).thenReturn(delegated);
 
         List<ConnectionDTO> result = schedulerService.filterByTestFlag(input, true);
@@ -125,7 +141,7 @@ class SchedulerServiceImpTest {
     void filterEntitiesByTestFlagPassesRunningIdsWhenTestIsTrue() {
         List<Connection> input = List.of(entity(7L, "!*test_connection_1700000000000_X"));
         List<Connection> delegated = List.of();
-        when(schedulingStrategy.getRunningJobs()).thenReturn(Map.of(7L, 1));
+        when(schedulingStrategy.getRunningJobs()).thenReturn(List.of(RunningJobFixture.aRunningJob(7L, 2, 1L)));
         when(connectionService.filterTestConnectionEntities(eq(input), eq(true), any())).thenReturn(delegated);
 
         List<Connection> result = schedulerService.filterEntitiesByTestFlag(input, true);


### PR DESCRIPTION
## What
- Added startTime for running jobs resource
- Fixed grouping error for simultaneous runs of the same connection;
- Refactored existing tests;

## Why
Resolves: [[OC-1409] Refactor getAllRunningJobs to return every concurrent execution with startTime](https://becon.atlassian.net/browse/OC-1409)

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code