### PR TITLE
OC-1461 Merged indexes of fromConnector and toConnector elements to one flow

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/base/FlowIndexUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/base/FlowIndexUtils.java
@@ -1,0 +1,49 @@
+package com.becon.opencelium.backend.versionmanager.base;
+
+/**
+ * Helpers for the hierarchical, underscore-separated flow {@code index}
+ * (e.g. {@code "2_0_1"}) shared by the v5.0 connection/template updaters.
+ *
+ * <p>The first component is the root-level position; every further component is a
+ * position inside a parent operator's body. When two legacy connectors are merged
+ * under a single {@code fromConnector}, the to-side root indexes must continue the
+ * from-side root indexes — which is what {@link #rootOffset} and {@link #shiftRoot} do.
+ */
+public final class FlowIndexUtils {
+
+    private FlowIndexUtils() {
+    }
+
+    /**
+     * Number of root-level slots occupied by the given indexes, i.e. {@code max(root component) + 1}.
+     * Returns 0 when there are no indexes, which leaves to-side indexes untouched via {@link #shiftRoot}.
+     */
+    public static int rootOffset(Iterable<String> indexes) {
+        int max = -1;
+        for (String index : indexes) {
+            if (index != null && !index.isEmpty()) {
+                max = Math.max(max, rootOf(index));
+            }
+        }
+        return max + 1;
+    }
+
+    /** Parses the first (root-level) numeric component of a hierarchical {@code "a_b_c"} index. */
+    public static int rootOf(String index) {
+        int us = index.indexOf('_');
+        return Integer.parseInt(us < 0 ? index : index.substring(0, us));
+    }
+
+    /**
+     * Shifts only the root (first) component of a hierarchical index by {@code offset},
+     * preserving every nested component. {@code "2_0"} with offset 3 becomes {@code "5_0"}.
+     * A zero offset (or a blank index) returns the index unchanged.
+     */
+    public static String shiftRoot(String index, int offset) {
+        if (offset == 0 || index == null || index.isEmpty()) return index;
+        int us = index.indexOf('_');
+        String head = (us < 0) ? index : index.substring(0, us);
+        String tail = (us < 0) ? "" : index.substring(us); // keeps the leading '_'
+        return (Integer.parseInt(head) + offset) + tail;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/connectionmng/Connection50MngUpdater.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/connectionmng/Connection50MngUpdater.java
@@ -7,6 +7,7 @@ import com.becon.opencelium.backend.database.mongodb.entity.MethodConnectorMng;
 import com.becon.opencelium.backend.database.mongodb.entity.MethodMng;
 import com.becon.opencelium.backend.database.mongodb.entity.OperatorMng;
 import com.becon.opencelium.backend.versionmanager.Wrapper;
+import com.becon.opencelium.backend.versionmanager.base.FlowIndexUtils;
 import com.becon.opencelium.backend.versionmanager.base.UpdaterVersion;
 import com.becon.opencelium.backend.versionmanager.base.Utils;
 import org.springframework.stereotype.Component;
@@ -19,7 +20,8 @@ import java.util.Objects;
  * Brings a ConnectionMng up to the v5.0 multi-connector layout:
  * <ul>
  *   <li>Stamps every method with the connector it originally belonged to (MethodConnectorMng).</li>
- *   <li>Prefixes from-side indexes with {@code "0_"} and to-side indexes with {@code "1_"}.</li>
+ *   <li>Keeps from-side indexes unchanged and shifts the root component of every to-side index
+ *       so the to-side flow continues the from-side flow at root level.</li>
  *   <li>Merges all from/to methods + operators under a single {@code fromConnector}.</li>
  *   <li>Sets {@code fromConnector.connectorId = -1} and {@code title = "DEFAULT"};
  *       {@code flowId} is preserved from the original fromConnector.</li>
@@ -32,8 +34,6 @@ import java.util.Objects;
 public class Connection50MngUpdater implements ConnectionMngUpdater {
 
     private static final UpdaterVersion currentVersion = UpdaterVersion.VERSION_5_0;
-    private static final String FROM_INDEX_PREFIX = "0_";
-    private static final String TO_INDEX_PREFIX = "1_";
 
     private final Connection48MngUpdater connection48MngUpdater;
 
@@ -67,13 +67,16 @@ public class Connection50MngUpdater implements ConnectionMngUpdater {
         MethodConnectorMng fromRef = refOf(oldFrom);
         MethodConnectorMng toRef = refOf(oldTo);
 
+        // To-side root indexes continue right after the from-side root indexes.
+        int toOffset = FlowIndexUtils.rootOffset(indexesOf(oldFrom));
+
         List<MethodMng> mergedMethods = new ArrayList<>();
-        mergedMethods.addAll(stampMethods(methodsOf(oldFrom), fromRef, FROM_INDEX_PREFIX));
-        mergedMethods.addAll(stampMethods(methodsOf(oldTo), toRef, TO_INDEX_PREFIX));
+        mergedMethods.addAll(stampMethods(methodsOf(oldFrom), fromRef, 0));
+        mergedMethods.addAll(stampMethods(methodsOf(oldTo), toRef, toOffset));
 
         List<OperatorMng> mergedOperators = new ArrayList<>();
-        mergedOperators.addAll(reindexOperators(operatorsOf(oldFrom), FROM_INDEX_PREFIX));
-        mergedOperators.addAll(reindexOperators(operatorsOf(oldTo), TO_INDEX_PREFIX));
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldFrom), 0));
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldTo), toOffset));
 
         ConnectorMng merged = new ConnectorMng();
         merged.setConnectorId(ConnectionConstants.DEFAULT_CONNECTOR_ID);
@@ -110,24 +113,32 @@ public class Connection50MngUpdater implements ConnectionMngUpdater {
         return connector.getOperators();
     }
 
-    private static List<MethodMng> stampMethods(List<MethodMng> methods, MethodConnectorMng ref, String indexPrefix) {
+    private static List<MethodMng> stampMethods(List<MethodMng> methods, MethodConnectorMng ref, int rootOffset) {
         for (MethodMng method : methods) {
             if (method == null) continue;
             method.setConnector(ref);
-            method.setIndex(prefixIndex(method.getIndex(), indexPrefix));
+            method.setIndex(FlowIndexUtils.shiftRoot(method.getIndex(), rootOffset));
         }
         return methods;
     }
 
-    private static List<OperatorMng> reindexOperators(List<OperatorMng> operators, String indexPrefix) {
+    private static List<OperatorMng> reindexOperators(List<OperatorMng> operators, int rootOffset) {
         for (OperatorMng operator : operators) {
             if (operator == null) continue;
-            operator.setIndex(prefixIndex(operator.getIndex(), indexPrefix));
+            operator.setIndex(FlowIndexUtils.shiftRoot(operator.getIndex(), rootOffset));
         }
         return operators;
     }
 
-    private static String prefixIndex(String index, String prefix) {
-        return prefix + index;
+    /** Collects the flow indexes of every method and operator of {@code connector}. */
+    private static List<String> indexesOf(ConnectorMng connector) {
+        List<String> indexes = new ArrayList<>();
+        for (MethodMng method : methodsOf(connector)) {
+            if (method != null) indexes.add(method.getIndex());
+        }
+        for (OperatorMng operator : operatorsOf(connector)) {
+            if (operator != null) indexes.add(operator.getIndex());
+        }
+        return indexes;
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/template/Template50Updater.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/versionmanager/template/Template50Updater.java
@@ -8,6 +8,7 @@ import com.becon.opencelium.backend.resource.template.CtionTemplateResource;
 import com.becon.opencelium.backend.resource.template.CtorTemplateResource;
 import com.becon.opencelium.backend.template.entity.Template;
 import com.becon.opencelium.backend.versionmanager.Wrapper;
+import com.becon.opencelium.backend.versionmanager.base.FlowIndexUtils;
 import com.becon.opencelium.backend.versionmanager.base.UpdaterVersion;
 import com.becon.opencelium.backend.versionmanager.base.Utils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,7 +25,8 @@ import java.util.Objects;
  * Brings a Template up to the v5.0 multi-connector layout:
  * <ul>
  *   <li>Stamps every method with the connector it originally belonged to (MethodConnectorDTO).</li>
- *   <li>Prefixes from-side indexes with {@code "0_"} and to-side indexes with {@code "1_"}.</li>
+ *   <li>Keeps from-side indexes unchanged and shifts the root component of every to-side index
+ *       so the to-side flow continues the from-side flow at root level.</li>
  *   <li>Merges all from/to methods + operators under a single {@code fromConnector}.</li>
  *   <li>Sets {@code fromConnector.connectorId = -1} and {@code title = "DEFAULT"}.</li>
  *   <li>Clears {@code toConnector}.</li>
@@ -36,8 +38,6 @@ import java.util.Objects;
 public class Template50Updater implements TemplateUpdater {
 
     private static final UpdaterVersion currentVersion = UpdaterVersion.VERSION_5_0;
-    private static final String FROM_INDEX_PREFIX = "0_";
-    private static final String TO_INDEX_PREFIX = "1_";
     private static final Logger log = LoggerFactory.getLogger(Template50Updater.class);
 
     private final Template44Updater template44Updater;
@@ -80,13 +80,19 @@ public class Template50Updater implements TemplateUpdater {
         MethodConnectorDTO fromRef = refOf(oldFrom);
         MethodConnectorDTO toRef = refOf(oldTo);
 
+        List<MethodDTO> fromMethods = methodsOf(oldFrom);
+        List<OperatorDTO> fromOperators = operatorsOf(oldFrom);
+
+        // To-side root indexes continue right after the from-side root indexes.
+        int toOffset = FlowIndexUtils.rootOffset(indexesOf(fromMethods, fromOperators));
+
         List<MethodDTO> mergedMethods = new ArrayList<>();
-        mergedMethods.addAll(stampMethods(methodsOf(oldFrom), fromRef, FROM_INDEX_PREFIX));
-        mergedMethods.addAll(stampMethods(methodsOf(oldTo), toRef, TO_INDEX_PREFIX));
+        mergedMethods.addAll(stampMethods(fromMethods, fromRef, 0));
+        mergedMethods.addAll(stampMethods(methodsOf(oldTo), toRef, toOffset));
 
         List<OperatorDTO> mergedOperators = new ArrayList<>();
-        mergedOperators.addAll(reindexOperators(operatorsOf(oldFrom), FROM_INDEX_PREFIX));
-        mergedOperators.addAll(reindexOperators(operatorsOf(oldTo), TO_INDEX_PREFIX));
+        mergedOperators.addAll(reindexOperators(fromOperators, 0));
+        mergedOperators.addAll(reindexOperators(operatorsOf(oldTo), toOffset));
 
         CtorTemplateResource merged = new CtorTemplateResource();
         merged.setConnectorId(ConnectionConstants.DEFAULT_CONNECTOR_ID);
@@ -132,24 +138,32 @@ public class Template50Updater implements TemplateUpdater {
         }
     }
 
-    private static List<MethodDTO> stampMethods(List<MethodDTO> methods, MethodConnectorDTO ref, String indexPrefix) {
+    private static List<MethodDTO> stampMethods(List<MethodDTO> methods, MethodConnectorDTO ref, int rootOffset) {
         for (MethodDTO method : methods) {
             if (method == null) continue;
             method.setConnector(ref);
-            method.setIndex(prefixIndex(method.getIndex(), indexPrefix));
+            method.setIndex(FlowIndexUtils.shiftRoot(method.getIndex(), rootOffset));
         }
         return methods;
     }
 
-    private static List<OperatorDTO> reindexOperators(List<OperatorDTO> operators, String indexPrefix) {
+    private static List<OperatorDTO> reindexOperators(List<OperatorDTO> operators, int rootOffset) {
         for (OperatorDTO operator : operators) {
             if (operator == null) continue;
-            operator.setIndex(prefixIndex(operator.getIndex(), indexPrefix));
+            operator.setIndex(FlowIndexUtils.shiftRoot(operator.getIndex(), rootOffset));
         }
         return operators;
     }
 
-    private static String prefixIndex(String index, String prefix) {
-        return prefix + index;
+    /** Collects the flow indexes of every from-side method and operator. */
+    private static List<String> indexesOf(List<MethodDTO> methods, List<OperatorDTO> operators) {
+        List<String> indexes = new ArrayList<>();
+        for (MethodDTO method : methods) {
+            if (method != null) indexes.add(method.getIndex());
+        }
+        for (OperatorDTO operator : operators) {
+            if (operator != null) indexes.add(operator.getIndex());
+        }
+        return indexes;
     }
 }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/versionmanager/base/FlowIndexUtilsTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/versionmanager/base/FlowIndexUtilsTest.java
@@ -1,0 +1,167 @@
+package com.becon.opencelium.backend.unit.versionmanager.base;
+
+import com.becon.opencelium.backend.versionmanager.base.FlowIndexUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link FlowIndexUtils}.
+ * <p>
+ * Pure static helpers — no Spring context, no mocks.
+ */
+@DisplayName("FlowIndexUtils — unit")
+class FlowIndexUtilsTest {
+
+    //-----------------------------------------------------------
+    //                        rootOf
+    //-----------------------------------------------------------
+
+    @ParameterizedTest(name = "rootOf(\"{0}\") = {1}")
+    @CsvSource({
+            "0, 0",
+            "7, 7",
+            "10, 10",
+            "0_0, 0",
+            "1_0, 1",
+            "2_3_4, 2",
+            "12_5_9, 12",
+    })
+    void rootOfReturnsFirstComponent(String index, int expected) {
+        assertThat(FlowIndexUtils.rootOf(index)).isEqualTo(expected);
+    }
+
+    @Test
+    void rootOfParsesLeadingZeroComponentNumerically() {
+        assertThat(FlowIndexUtils.rootOf("02_1")).isEqualTo(2);
+    }
+
+    @Test
+    void rootOfThrowsNullPointerExceptionWhenIndexIsNull() {
+        assertThatThrownBy(() -> FlowIndexUtils.rootOf(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void rootOfThrowsNumberFormatExceptionWhenRootIsNotNumeric() {
+        assertThatThrownBy(() -> FlowIndexUtils.rootOf("a_1"))
+                .isInstanceOf(NumberFormatException.class);
+    }
+
+    //-----------------------------------------------------------
+    //                       rootOffset
+    //-----------------------------------------------------------
+
+    @Test
+    void rootOffsetReturnsZeroWhenIterableIsEmpty() {
+        assertThat(FlowIndexUtils.rootOffset(Collections.emptyList())).isZero();
+    }
+
+    @Test
+    @DisplayName("rootOffset returns max(root) + 1 for contiguous roots")
+    void rootOffsetReturnsMaxRootPlusOneWhenRootsAreContiguous() {
+        // roots 0,1,2 -> next free root is 3
+        assertThat(FlowIndexUtils.rootOffset(List.of("0", "1", "2"))).isEqualTo(3);
+    }
+
+    @Test
+    void rootOffsetCountsOnlyRootComponentWhenIndexesAreNested() {
+        // 1_0 / 1_5 still live at root 1 -> roots are 0,1 -> offset 2
+        assertThat(FlowIndexUtils.rootOffset(List.of("0", "1", "1_0", "1_5"))).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("rootOffset uses max(root) + 1 even when roots have gaps")
+    void rootOffsetReturnsMaxRootPlusOneWhenRootsHaveGaps() {
+        // roots 0,1,3 (gap at 2) -> max+1 = 4 guarantees no collision
+        assertThat(FlowIndexUtils.rootOffset(List.of("0", "1", "3"))).isEqualTo(4);
+    }
+
+    @Test
+    void rootOffsetIsIndependentOfOrdering() {
+        assertThat(FlowIndexUtils.rootOffset(List.of("3_0", "1", "0", "2"))).isEqualTo(4);
+    }
+
+    @Test
+    void rootOffsetSkipsNullAndEmptyIndexes() {
+        assertThat(FlowIndexUtils.rootOffset(Arrays.asList("0", null, "", "1"))).isEqualTo(2);
+    }
+
+    @Test
+    void rootOffsetReturnsZeroWhenAllIndexesAreNullOrEmpty() {
+        assertThat(FlowIndexUtils.rootOffset(Arrays.asList(null, "", ""))).isZero();
+    }
+
+    //-----------------------------------------------------------
+    //                        shiftRoot
+    //-----------------------------------------------------------
+
+    @ParameterizedTest(name = "shiftRoot(\"{0}\", {1}) = \"{2}\"")
+    @CsvSource({
+            "0,     2, 2",
+            "1,     2, 3",
+            "2_0,   3, 5_0",
+            "1_4,   2, 3_4",
+            "2_1_3, 5, 7_1_3",
+            "10,    5, 15",
+    })
+    void shiftRootShiftsOnlyRootComponent(String index, int offset, String expected) {
+        assertThat(FlowIndexUtils.shiftRoot(index, offset)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "shiftRoot(\"{0}\", 0) = \"{0}\"")
+    @ValueSource(strings = {"0", "5", "2_0", "1_3_7"})
+    void shiftRootReturnsIndexUnchangedWhenOffsetIsZero(String index) {
+        assertThat(FlowIndexUtils.shiftRoot(index, 0)).isEqualTo(index);
+    }
+
+    @Test
+    void shiftRootReturnsNullWhenIndexIsNull() {
+        assertThat(FlowIndexUtils.shiftRoot(null, 3)).isNull();
+    }
+
+    @Test
+    void shiftRootReturnsEmptyWhenIndexIsEmpty() {
+        assertThat(FlowIndexUtils.shiftRoot("", 3)).isEmpty();
+    }
+
+    @Test
+    void shiftRootPreservesNestingDepthWhenShiftingRoot() {
+        assertThat(FlowIndexUtils.shiftRoot("4_0_2_9", 1)).isEqualTo("5_0_2_9");
+    }
+
+    //-----------------------------------------------------------
+    //          scenario: merging a to-side after a from-side
+    //-----------------------------------------------------------
+
+    @Test
+    @DisplayName("shiftRoot continues the from-side flow when merging the to-side")
+    void shiftRootContinuesFromSideFlowWhenMergingToSide() {
+        // from-side: method "0", loop "1", method "1_0" inside the loop
+        int offset = FlowIndexUtils.rootOffset(List.of("0", "1", "1_0"));
+        assertThat(offset).isEqualTo(2);
+
+        // to-side: methods "0","1", loop "2", method "2_0" inside it
+        assertThat(FlowIndexUtils.shiftRoot("0", offset)).isEqualTo("2");
+        assertThat(FlowIndexUtils.shiftRoot("1", offset)).isEqualTo("3");
+        assertThat(FlowIndexUtils.shiftRoot("2", offset)).isEqualTo("4");
+        assertThat(FlowIndexUtils.shiftRoot("2_0", offset)).isEqualTo("4_0");
+    }
+
+    @Test
+    void shiftRootLeavesToSideUntouchedWhenFromSideIsEmpty() {
+        int offset = FlowIndexUtils.rootOffset(Collections.emptyList());
+        assertThat(offset).isZero();
+        assertThat(FlowIndexUtils.shiftRoot("0", offset)).isEqualTo("0");
+        assertThat(FlowIndexUtils.shiftRoot("1_0", offset)).isEqualTo("1_0");
+    }
+}


### PR DESCRIPTION
## What
Fix the v5.0 legacy-connection migration so a `toConnector`'s methods and operators **continue the `fromConnector` flow at root level** instead of being nested under a synthetic root.

- `Connection50MngUpdater` / `Template50Updater`: replace the old `"0_"` / `"1_"` index-prefixing with root-component shifting. From-side indexes are left untouched; each to-side index has only its **root (first) component** shifted by `max(from-side root) + 1`, preserving every nested component.
- Extract the shared index math into a new `FlowIndexUtils` (`rootOffset`, `rootOf`, `shiftRoot`) used by both updaters.

## Why
Closes OC-1461.

## How to test
```bash
# Unit tests — no Docker needed
./gradlew test --tests "*.FlowIndexUtilsTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `FlowIndexUtilsTest`
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
