### PR TITLE
OC-1467 Add metadataOnly fetching for templates

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/TemplateController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/TemplateController.java
@@ -28,6 +28,7 @@ import com.becon.opencelium.backend.template.entity.Template;
 import com.becon.opencelium.backend.template.service.TemplateServiceImp;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -61,7 +62,12 @@ public class TemplateController {
     @Autowired
     private ConnectorServiceImp connectorService;
 
-    @Operation(summary = "Retrieves a template from the database based on the provided template 'id'")
+    @Operation(summary = "Retrieves a template from the database based on the provided template 'id'",
+            parameters = {
+                @Parameter(name = "metadataOnly",
+                        description = "When true, returns only parent-level template fields (templateId, name, " +
+                                "description, version, link) and omits the heavy 'connection' payload. Defaults to false.")
+            })
     @ApiResponses(value = {
         @ApiResponse( responseCode = "200",
                 description = "Template has been retrieved successfully",
@@ -74,7 +80,14 @@ public class TemplateController {
                 content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping("/{id}")
-    public ResponseEntity<?> get(@PathVariable String id){
+    public ResponseEntity<?> get(@PathVariable String id,
+                                 @RequestParam(defaultValue = "false") boolean metadataOnly){
+
+        if (metadataOnly) {
+            TemplateResource metadata = templateService.getMetadataById(id)
+                    .orElseThrow(() -> new RuntimeException("TEMPLATE_NOT_FOUND"));
+            return ResponseEntity.ok().body(metadata);
+        }
 
         Template template = templateService
                 .findById(id)
@@ -131,6 +144,7 @@ public class TemplateController {
                 description = "Internal Error",
                 content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
+    @Deprecated
     @GetMapping("/all/{fromConnectorId}/{toConnectorId}")
     public ResponseEntity<List<TemplateResource>> getAllByConnectors(@PathVariable int fromConnectorId, @PathVariable int toConnectorId){
         Connector fromConnector = connectorService.findById(fromConnectorId)
@@ -156,7 +170,12 @@ public class TemplateController {
         return ResponseEntity.ok().body(templateResources);
     }
 
-    @Operation(summary = "Retrieves all templates from database")
+    @Operation(summary = "Retrieves all templates from database",
+            parameters = {
+                @Parameter(name = "metadataOnly",
+                        description = "When true, returns only parent-level template fields (templateId, name, " +
+                                "description, version, link) and omits the heavy 'connection' payload. Defaults to false.")
+            })
     @ApiResponses(value = {
             @ApiResponse( responseCode = "200",
                     description = "All templates have been retrieved successfully",
@@ -169,7 +188,12 @@ public class TemplateController {
                     content = @Content(schema = @Schema(implementation = ErrorResource.class))),
     })
     @GetMapping("/all")
-    public ResponseEntity<List<TemplateResource>> getAll(){
+    public ResponseEntity<List<TemplateResource>> getAll(@RequestParam(defaultValue = "false") boolean metadataOnly){
+
+        if (metadataOnly) {
+            List<TemplateResource> metadata = templateService.getAllMetadata();
+            return ResponseEntity.ok().body(metadata);
+        }
 
         List<Template> templates = templateService.findAll();
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/template/TemplateMetadata.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/template/TemplateMetadata.java
@@ -1,0 +1,66 @@
+/*
+ * // Copyright (C) <2020> <becon GmbH>
+ * //
+ * // This program is free software: you can redistribute it and/or modify
+ * // it under the terms of the GNU General Public License as published by
+ * // the Free Software Foundation, version 3 of the License.
+ * //
+ * // This program is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * // GNU General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU General Public License
+ * // along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.becon.opencelium.backend.resource.template;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Lightweight read model used for template listing / metadata requests.
+ * <p>
+ * Deserializing a template file into this type instead of {@link com.becon.opencelium.backend.template.entity.Template}
+ * makes Jackson skip the heavy {@code connection} subtree (connectors, methods, operators, fieldBinding, ui)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TemplateMetadata {
+
+    private String templateId;
+    private String name;
+    private String description;
+    private String version;
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateService.java
@@ -43,6 +43,16 @@ public interface TemplateService {
 
     TemplateResource getByConnectionId(Long connectionId);
 
+    /**
+     * Reads all templates as metadata-only resources (no {@code connection} payload)
+     */
+    List<TemplateResource> getAllMetadata();
+
+    /**
+     * Reads a single template as a metadata-only resource (no {@code connection} payload).
+     */
+    Optional<TemplateResource> getMetadataById(String id);
+
     void updateTemplatesToCurrentVersion();
 
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateServiceImp.java
@@ -24,6 +24,7 @@ import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.resource.connection.ConnectionDTO;
 import com.becon.opencelium.backend.resource.connection.old.ConnectionOldDTO;
 import com.becon.opencelium.backend.resource.template.CtionTemplateResource;
+import com.becon.opencelium.backend.resource.template.TemplateMetadata;
 import com.becon.opencelium.backend.resource.template.TemplateResource;
 import com.becon.opencelium.backend.template.entity.Template;
 import com.becon.opencelium.backend.utility.FileNameUtils;
@@ -89,6 +90,58 @@ public class TemplateServiceImp implements TemplateService {
         templateResource.setConnection(template.getConnection());
         templateResource.setLink(PathConstant.TEMPLATE_URL + template.getTemplateId());
         return templateResource;
+    }
+
+    @Override
+    public List<TemplateResource> getAllMetadata() {
+        return getAllMetadata(PathConstant.TEMPLATE).stream()
+                .filter(Objects::nonNull)
+                .map(this::toResource)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<TemplateResource> getMetadataById(String id) {
+        Path path = Paths.get(PathConstant.TEMPLATE).resolve(id.concat(".json"));
+        if (Files.notExists(path)) {
+            return Optional.empty();
+        }
+        try {
+            String json = Files.readString(path, StandardCharsets.UTF_8);
+            return Optional.of(toResource(objectMapper.readValue(json, TemplateMetadata.class)));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read template metadata: " + path, e);
+        }
+    }
+
+    private TemplateResource toResource(TemplateMetadata metadata) {
+        TemplateResource templateResource = new TemplateResource();
+        templateResource.setTemplateId(metadata.getTemplateId());
+        templateResource.setName(metadata.getName());
+        templateResource.setDescription(metadata.getDescription());
+        templateResource.setVersion(metadata.getVersion());
+        templateResource.setLink(PathConstant.TEMPLATE_URL + metadata.getTemplateId());
+        // connection intentionally left null for metadata-only responses
+        return templateResource;
+    }
+
+    private List<TemplateMetadata> getAllMetadata(String folder) {
+        try (Stream<Path> walk = Files.walk(Paths.get(folder))) {
+            return walk.filter(Files::isRegularFile)
+                    .filter(path -> FileNameUtils.getExtension(path.toString()).equals("json"))
+                    .map(path -> {
+                        try {
+                            String json = Files.readString(path, StandardCharsets.UTF_8);
+                            return objectMapper.readValue(json, TemplateMetadata.class);
+                        } catch (IOException e) {
+                            log.error("Failed to read template metadata from file '{}': {}", path.getFileName(), e.getMessage());
+                            return null;
+                        }
+                    })
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION

## What
- Add an optional `metadataOnly` query parameter (`@RequestParam(defaultValue = "false")`) to:
  - `GET /template/{id}`
  - `GET /template/all`
- When `metadataOnly=true`, the response contains only the parent-level `TemplateResource` fields (`templateId`, `name`, `description`, `version`, `link`) and `connection` is `null`. Default behavior (`false`/absent) is unchanged — the full payload including `connection` is returned.
- Add a lightweight `TemplateMetadata` read model (`@JsonIgnoreProperties(ignoreUnknown = true)`,
  scalar fields only) plus `TemplateService.getAllMetadata()` / `getMetadataById(String)`.
  These deserialize templates from disk into `TemplateMetadata` so Jackson skips the
  entire `connection` subtree (connectors, methods, operators, fieldBinding, ui)
- Deprecate `GET /template/all/{fromConnectorId}/{toConnectorId}` (`@Deprecated`). Because this API is not used no longer on frontend and if you call this api, it returns error because of `toConnector` is null on new structure

## Why
Closes OC-1467

## How to test
### Manual verification
Full payload (unchanged): connection present
curl -s "http://127.0.0.1:9090/template/all"
Metadata only: connection null/absent
curl -s "http://127.0.0.1:9090/template/all?metadataOnly=true"
curl -s "http://127.0.0.1:9090/template/{id}?metadataOnly=true"
```

## Checklist
- [x] Self-reviewed the diff
- [ ] Tests added or updated — none (no existing template test suite; behavior covered manually)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
