### PR TITLE
OC-1468 Persist latest remote-API test result on connector

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
@@ -382,6 +382,11 @@ public class ConnectorController {
             responseEntity = connectorService.checkCommunication(connector);
         } catch (Exception ex) {
             ex.printStackTrace();
+            // The remote request could not be completed (e.g. host unreachable): record it as a
+            // failed test on the saved connector before surfacing the error to the caller.
+            if (connectorResource.getConnectorId() > 0 && connectorService.existsById(connectorResource.getConnectorId())) {
+                connectorService.updateTestResult(connectorResource.getConnectorId(), false, ex.getMessage());
+            }
             throw new CommunicationFailedException();
         }
 
@@ -401,7 +406,27 @@ public class ConnectorController {
             response = responseEntity.getBody().toString();
         }
 
+        // Classify the outcome once, so it can be both persisted (for saved connectors) and returned.
+        boolean passed;
+        String remoteError = null;
         if ((responseEntity.getStatusCode() == HttpStatus.OK) && hasError(fail, response)) {
+            passed = false;
+            remoteError = response;
+        } else if (responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+            passed = false;
+            remoteError = responseEntity.getBody() != null
+                    ? responseEntity.getBody().toString()
+                    : "Error in remote system";
+        } else {
+            passed = true;
+        }
+
+        // Persist the latest result only for a saved connector; an unsaved/new connector has no row.
+        if (connectorResource.getConnectorId() > 0 && connectorService.existsById(connectorResource.getConnectorId())) {
+            connectorService.updateTestResult(connectorResource.getConnectorId(), passed, remoteError);
+        }
+
+        if ((responseEntity.getStatusCode() == HttpStatus.OK) && !passed) {
             return ResponseEntity.ok().body("{\"status\":\"401\", \"error\":\"401\"}");
         }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
@@ -79,6 +79,14 @@ public class Connector {
     @Column(name = "timeout")
     private int timeout;
 
+    // null = never tested, true = passed, false = failed.
+    @Column(name = "last_test_passed")
+    private Boolean lastTestPassed;
+
+    // Remote error message from the last failed test; null when passed or never tested.
+    @Column(name = "last_test_error", columnDefinition = "TEXT")
+    private String lastTestError;
+
     @OneToMany(mappedBy = "connector", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<RequestData> requestData = new ArrayList<>();
 
@@ -168,6 +176,22 @@ public class Connector {
 
     public void setTimeout(int timeout) {
         this.timeout = timeout;
+    }
+
+    public Boolean getLastTestPassed() {
+        return lastTestPassed;
+    }
+
+    public void setLastTestPassed(Boolean lastTestPassed) {
+        this.lastTestPassed = lastTestPassed;
+    }
+
+    public String getLastTestError() {
+        return lastTestError;
+    }
+
+    public void setLastTestError(String lastTestError) {
+        this.lastTestError = lastTestError;
     }
 
     public List<RequestData> getRequestData() {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
@@ -56,6 +56,11 @@ public interface ConnectorService {
 
     ResponseEntity<?> checkCommunication(Connector connector) throws JsonProcessingException;
 
+    /**
+     * Persists the outcome of the most recent remote-API test on a saved connector.
+     */
+    void updateTestResult(int connectorId, boolean passed, String error);
+
     ResponseEntity<?> getAuthorization(Connector connector);
 
     List<RequestData> buildRequestData(Connector connector);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -222,6 +222,17 @@ public class ConnectorServiceImp implements ConnectorService {
     }
 
     @Override
+    public void updateTestResult(int connectorId, boolean passed, String error) {
+        // Load the raw (still-encrypted) entity and touch only the two test-result columns so the
+        // rest of the connector's persisted state (including encrypted request data) is untouched.
+        connectorRepository.findById(connectorId).ifPresent(connector -> {
+            connector.setLastTestPassed(passed);
+            connector.setLastTestError(passed ? null : error);
+            connectorRepository.save(connector);
+        });
+    }
+
+    @Override
     public ResponseEntity<?> getAuthorization(Connector connector) {
         InvokerRequestBuilder invokerRequestBuilder = new InvokerRequestBuilder();
         FunctionInvoker function = invokerService.getAuthFunction(connector.getInvoker());

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
@@ -31,7 +31,9 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
             @Mapping(target = "icon", expression = "java(StringUtility.resolveImagePath(entity.getIcon()))"),
             @Mapping(target = "invoker", qualifiedByName = {"helperMapper", "getInvokerDTO"}),
             @Mapping(target = "requestData", qualifiedByName = {"requestDataMapper", "toDTO"}),
-            @Mapping(target = "sslCert", source = "sslValidation")
+            @Mapping(target = "sslCert", source = "sslValidation"),
+            @Mapping(target = "lastTestPassed", source = "lastTestPassed"),
+            @Mapping(target = "lastTestError", source = "lastTestError")
     })
     ConnectorResource toDTO(Connector entity);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorResource.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorResource.java
@@ -33,6 +33,10 @@ public class ConnectorResource {
     private boolean sslCert;
     private int timeout;
     private Map<String, String> requestData;
+    // Result of the most recent remote-API test: null = never tested, true = passed, false = failed.
+    private Boolean lastTestPassed;
+    // Remote error message from the last failed test.
+    private String lastTestError;
 
     public int getConnectorId() {
         return connectorId;
@@ -96,5 +100,21 @@ public class ConnectorResource {
 
     public void setRequestData(Map<String, String> requestData) {
         this.requestData = requestData;
+    }
+
+    public Boolean getLastTestPassed() {
+        return lastTestPassed;
+    }
+
+    public void setLastTestPassed(Boolean lastTestPassed) {
+        this.lastTestPassed = lastTestPassed;
+    }
+
+    public String getLastTestError() {
+        return lastTestError;
+    }
+
+    public void setLastTestError(String lastTestError) {
+        this.lastTestError = lastTestError;
     }
 }

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -729,3 +729,6 @@ ALTER TABLE `connection` MODIFY COLUMN `to_connector` INT NULL;
 ALTER TABLE `operation_usage_history` MODIFY COLUMN `to_invoker` VARCHAR(255) NULL;
 --changeset 5.0:3 stripComments:true splitStatements:true endDelimiter:;
 ALTER TABLE `webhook` ADD CONSTRAINT `uq_webhook_uuid` UNIQUE (`uuid`);
+--changeset 5.0:4 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `connector` ADD COLUMN IF NOT EXISTS `last_test_passed` TINYINT(1) DEFAULT NULL;
+ALTER TABLE `connector` ADD COLUMN IF NOT EXISTS `last_test_error` TEXT DEFAULT NULL;


### PR DESCRIPTION
## What
Persist the result of the most recent remote-API test on each connector so connector health can be shown when connectors are listed (passed / failed /never tested), without running a live check on fetch.

## Why
Closes OC-1468.

## Checklist
- [x] Self-reviewed the diff
- [ ] Tests added or updated
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed