### PR TITLE
OC-1478: Implement validation for references on Jumping

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
@@ -312,14 +312,14 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
             return;
         }
 
-        List<JumpViolation> violations = collectJumpViolations(connectionMng.getFromConnector());
+        List<JumpViolation> violations = collectJumpViolations(connectionMng.getFromConnector(), connectionMng.getFieldBindings());
 
         if (!violations.isEmpty()) {
             throw new JumpValidationException(violations);
         }
     }
 
-    private List<JumpViolation> collectJumpViolations(ConnectorMng connector) {
+    private List<JumpViolation> collectJumpViolations(ConnectorMng connector, List<FieldBindingMng> fieldBindings) {
         if (connector == null || connector.getMethods() == null) {
             return Collections.emptyList();
         }
@@ -328,7 +328,7 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
             return Collections.emptyList();
         }
 
-        JumpGraph graph = MongoJumpGraphBuilder.build(connector);
+        JumpGraph graph = MongoJumpGraphBuilder.build(connector, fieldBindings);
 
         List<JumpViolation> jumpViolations = new ArrayList<>();
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpGraph.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpGraph.java
@@ -19,18 +19,23 @@ import java.util.Map;
  */
 public final class JumpGraph {
 
+    /** Nodes ordered the same way the executor walks the connector. */
+    private final List<JumpNode> ordered;
     private final Map<String, JumpNode> byIndex;
     private final Map<String, JumpNode> methodByColor;
+    private final Map<String, Integer> positionByIndex;
 
     public JumpGraph(List<JumpNode> nodes) {
-        // Ordered the same way the executor walks the connector, so structural derivations stay consistent.
-        List<JumpNode> ordered = new ArrayList<>(nodes);
-        ordered.sort(Comparator.comparing(JumpNode::index, Comparators.NUMERIC_PARTS));
+        this.ordered = new ArrayList<>(nodes);
+        this.ordered.sort(Comparator.comparing(JumpNode::index, Comparators.NUMERIC_PARTS));
 
         this.byIndex = new HashMap<>();
         this.methodByColor = new HashMap<>();
-        for (JumpNode node : ordered) {
+        this.positionByIndex = new HashMap<>();
+        for (int i = 0; i < ordered.size(); i++) {
+            JumpNode node = ordered.get(i);
             byIndex.put(node.index(), node);
+            positionByIndex.put(node.index(), i);
             if (!node.isOperator() && node.color() != null) {
                 methodByColor.put(node.color(), node);
             }
@@ -59,6 +64,51 @@ public final class JumpGraph {
         }
         JumpNode method = methodByColor.get(reference);
         return method != null ? method : byIndex.get(reference);
+    }
+
+    /** Zero-based position of a node in the executor's walk order. */
+    public int positionOf(JumpNode node) {
+        return positionByIndex.get(node.index());
+    }
+
+    /**
+     * Last position occupied by {@code node}'s subtree — for a leaf method this is its own position,
+     * for an operator the last element of its body. Mirrors {@code ConnectorExecutor.getTailPointer}.
+     */
+    public int tailPositionOf(JumpNode node) {
+        String prefix = node.index() + "_";
+        int tail = positionOf(node);
+        for (int i = tail + 1; i < ordered.size(); i++) {
+            if (ordered.get(i).index().startsWith(prefix)) {
+                tail = i;
+            } else {
+                break;
+            }
+        }
+        return tail;
+    }
+
+    /** Methods strictly between {@code source}'s tail and {@code target} in the walk order. */
+    public List<JumpNode> methodsBetween(JumpNode source, JumpNode target) {
+        int from = tailPositionOf(source);
+        int to = positionOf(target);
+        List<JumpNode> result = new ArrayList<>();
+        for (int i = from + 1; i < to && i < ordered.size(); i++) {
+            JumpNode node = ordered.get(i);
+            if (!node.isOperator()) {
+                result.add(node);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Executables that still run once the jump lands — {@code node} and everything after it in the
+     * walk order, methods and operators alike. These are the elements whose references could dangle
+     * if the jump skips a method they depend on (a loop/if expression consumes methods too).
+     */
+    public List<JumpNode> executablesAtOrAfter(JumpNode node) {
+        return new ArrayList<>(ordered.subList(positionOf(node), ordered.size()));
     }
 
     /** Container operators of {@code index}, innermost-first ({@code 1_1_1_0} -> {@code 1_1_1, 1_1, 1}). */

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpNode.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpNode.java
@@ -1,6 +1,7 @@
 package com.becon.opencelium.backend.execution.jump;
 
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * An executable element (method or operator) as the jump validator sees it.
@@ -13,19 +14,24 @@ import java.util.Objects;
  * @param color 6-char method identifier; {@code null} for operators
  * @param kind  structural role
  */
-public record JumpNode(String index, String color, NodeKind kind) {
+public record JumpNode(String index, String color, NodeKind kind, Set<String> referencedColors) {
 
     public JumpNode {
         Objects.requireNonNull(index, "index");
         Objects.requireNonNull(kind, "kind");
+        referencedColors = referencedColors == null ? Set.of() : Set.copyOf(referencedColors);
     }
 
-    public static JumpNode method(String index, String color) {
-        return new JumpNode(index, color, NodeKind.METHOD);
+    public static JumpNode method(String index, String color, Set<String> referencedColors) {
+        return new JumpNode(index, color, NodeKind.METHOD, referencedColors);
     }
 
     public static JumpNode operator(String index, NodeKind kind) {
-        return new JumpNode(index, null, kind);
+        return new JumpNode(index, null, kind, Set.of());
+    }
+
+    public static JumpNode operator(String index, NodeKind kind, Set<String> referencedColors) {
+        return new JumpNode(index, null, kind, referencedColors);
     }
 
     public boolean isOperator() {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpValidationCode.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpValidationCode.java
@@ -15,6 +15,8 @@ public enum JumpValidationCode {
     JUMP_ESCAPES_LOOP,
     /** The target does not run strictly after the source. */
     JUMP_BACKWARD,
+    /** The target consumes output of a method this jump would skip. */
+    JUMP_SKIPS_REFERENCED_METHOD,
     /** The target color/index is absent from the connection. */
     JUMP_TARGET_NOT_FOUND,
     /** The source equals the target. */

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpValidator.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/JumpValidator.java
@@ -1,5 +1,7 @@
 package com.becon.opencelium.backend.execution.jump;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +20,7 @@ import java.util.stream.Collectors;
  *   <li>a method cannot jump into a loop or if body it is not part of;</li>
  *   <li>a method may escape outward through enclosing ifs, up to the nearest loop;</li>
  *   <li>the target must be at a reachable level and run strictly after the source;</li>
+ *   <li>no method that still executes may consume output of a method the jump would skip.</li>
  * </ul>
  * plus the two structural guards for an absent target and a jump to self.
  *
@@ -113,7 +116,33 @@ public final class JumpValidator {
                     source, target);
         }
 
-        return List.of();
+        // No method the jump would skip may be referenced by a method that still executes.
+        // Because a forward jump only deletes the skipped range and keeps the survivors in order,
+        // a reference breaks exactly when the method it points at falls inside that range.
+        Set<String> skippedColors = new HashSet<>();
+        for (JumpNode skipped : graph.methodsBetween(source, target)) {
+            if (skipped.color() != null) {
+                skippedColors.add(skipped.color());
+            }
+        }
+        if (skippedColors.isEmpty()) {
+            return List.of();
+        }
+        List<JumpViolation> violations = new ArrayList<>();
+        for (JumpNode consumer : graph.executablesAtOrAfter(target)) {
+            for (String referenced : consumer.referencedColors()) {
+                if (skippedColors.contains(referenced)) {
+                    violations.add(new JumpViolation(
+                            JumpValidationCode.JUMP_SKIPS_REFERENCED_METHOD,
+                            "'" + name(consumer) + "' uses data from '" + referenced
+                                    + "', which the jump '" + source.index() + "' → '"
+                                    + target.index() + "' would skip. "
+                                    + "Remove that reference or choose a different target.",
+                            source.color(), source.index(), target.color(), target.index()));
+                }
+            }
+        }
+        return violations;
     }
 
     /**
@@ -138,5 +167,9 @@ public final class JumpValidator {
                 code, message,
                 source.color(), source.index(),
                 target.color(), target.index()));
+    }
+
+    private static String name(JumpNode node) {
+        return node.color() != null ? node.color() : node.index();
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/MongoJumpGraphBuilder.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/jump/MongoJumpGraphBuilder.java
@@ -1,26 +1,68 @@
 package com.becon.opencelium.backend.execution.jump;
 
+import com.becon.opencelium.backend.database.mongodb.entity.BodyMng;
 import com.becon.opencelium.backend.database.mongodb.entity.ConnectorMng;
+import com.becon.opencelium.backend.database.mongodb.entity.FieldBindingMng;
+import com.becon.opencelium.backend.database.mongodb.entity.LinkedFieldMng;
 import com.becon.opencelium.backend.database.mongodb.entity.MethodMng;
 import com.becon.opencelium.backend.database.mongodb.entity.OperatorMng;
+import com.becon.opencelium.backend.database.mongodb.entity.RequestMng;
+import com.becon.opencelium.backend.execution.oc721.Loop;
+import com.becon.opencelium.backend.ocel.ExpressionProcessor;
+import com.becon.opencelium.backend.ocel.ExpressionProcessorFactory;
+import com.becon.opencelium.backend.reference.ReferenceParser;
+import com.becon.opencelium.backend.reference.model.DirectReference;
+import com.becon.opencelium.backend.reference.model.Reference;
+import com.becon.opencelium.backend.reference.model.WrappedDirectReference;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Builds a pure {@link JumpGraph} from the persistence model of a single connector.
+ *
+ * <p>Resolves each element's referenced colors — needed to detect a jump that would skip a method it
+ * depends on — from:
+ * <ul>
+ *   <li>direct references embedded in a method's request ({@code #color.(response|request)...}),</li>
+ *   <li>field bindings whose {@code to} side is the method — its referenced colors are the
+ *       {@code from} colors,</li>
+ *   <li>direct references inside an operator's if/loop {@code expression} (e.g.
+ *       {@code forin {%#color.(response).body.$.[*]%}}), which loop/if bodies consume.</li>
+ * </ul>
  */
 public final class MongoJumpGraphBuilder {
+
+    /**
+     * Matches a direct reference and captures the method color <b>including</b> its leading
+     * {@code #}, so it lines up with {@code MethodMng.color} (which is stored as {@code #RRGGBB}).
+     */
+    private static final Pattern DIRECT_REF_COLOR =
+            Pattern.compile("(#[a-zA-Z0-9]{6})\\.\\((?:response|request)\\)");
+
+    /**
+     * Owns OCEL expression parsing; used to pull references out of if expressions.
+     */
+    private static final ExpressionProcessor EXPRESSION_PROCESSOR = ExpressionProcessorFactory.get();
 
     private MongoJumpGraphBuilder() {
     }
 
-    public static JumpGraph build(ConnectorMng connector) {
+    public static JumpGraph build(ConnectorMng connector, List<FieldBindingMng> fieldBindings) {
         List<JumpNode> nodes = new ArrayList<>();
 
         if (connector.getMethods() != null) {
             for (MethodMng method : connector.getMethods()) {
-                nodes.add(JumpNode.method(method.getIndex(), method.getColor()));
+                nodes.add(JumpNode.method(
+                        method.getIndex(),
+                        method.getColor(),
+                        referencedColors(method, fieldBindings)));
             }
         }
 
@@ -28,10 +70,161 @@ public final class MongoJumpGraphBuilder {
             for (OperatorMng operator : connector.getOperators()) {
                 nodes.add(JumpNode.operator(
                         operator.getIndex(),
-                        NodeKind.ofOperatorType(operator.getType())));
+                        NodeKind.ofOperatorType(operator.getType()),
+                        referencedColors(operator)));
             }
         }
 
         return new JumpGraph(nodes);
+    }
+
+    /**
+     * Colors an operator consumes, parsed from the {@code expression} the executor evaluates. A loop
+     * iterates over a single reference, resolved via {@link Loop} (which owns loop-expression
+     * parsing); an if consumes the references in its boolean expression, resolved via the
+     * {@link ExpressionProcessor}.
+     */
+    private static Set<String> referencedColors(OperatorMng operator) {
+        Set<String> colors = new HashSet<>();
+        if (NodeKind.ofOperatorType(operator.getType()) == NodeKind.LOOP) {
+            addColor(loopReference(operator), colors);
+        } else {
+            List<String> refs = EXPRESSION_PROCESSOR.extractReferences(operator.getExpression());
+            if (refs != null) {
+                refs.forEach(x -> addColor(x, colors));
+            }
+        }
+        return colors;
+    }
+
+    /**
+     * Reference a loop iterates over, extracted with the executor's own {@link Loop} parser.
+     */
+    private static String loopReference(OperatorMng operator) {
+        try {
+            return Loop.fromExpression(operator.getExpression()).getRef();
+        } catch (RuntimeException e) {
+            return null; // malformed / unsupported loop expression — nothing to resolve
+        }
+    }
+
+    private static void addColor(String reference, Set<String> colors) {
+        String color = colorOf(reference);
+        if (color != null) {
+            colors.add(color);
+        }
+    }
+
+    /**
+     * Resolves a raw reference to the method color it points at, or {@code null} if it names no method.
+     */
+    private static String colorOf(String reference) {
+        if (reference == null) {
+            return null;
+        }
+        try {
+            Reference parsed = ReferenceParser.parse(reference);
+            if (parsed instanceof WrappedDirectReference wrapped) {
+                return wrapped.getDirectReference().getColor();
+            }
+            if (parsed instanceof DirectReference direct) {
+                return direct.getColor();
+            }
+        } catch (RuntimeException ignored) {
+            // not a color-bearing reference (webhook / request-data / enhancement / malformed)
+        }
+        return null;
+    }
+
+    private static Set<String> referencedColors(MethodMng method, List<FieldBindingMng> fieldBindings) {
+        Set<String> colors = new HashSet<>();
+
+        // 1) direct references inside the method's request
+        List<String> requestStrings = new ArrayList<>();
+        collectRequestStrings(method.getRequest(), requestStrings);
+        for (String s : requestStrings) {
+            addDirectRefColors(s, colors);
+        }
+
+        // 2) field bindings feeding this method (from-colors)
+        if (fieldBindings != null && method.getColor() != null) {
+            for (FieldBindingMng fb : fieldBindings) {
+                if (consumes(fb, method.getColor())) {
+                    addFromColors(fb, colors);
+                }
+            }
+        }
+
+        colors.remove(method.getColor()); // a method never "skips" itself
+        return colors;
+    }
+
+    /**
+     * Adds every direct-reference color (with its leading {@code #}) found in {@code text}.
+     */
+    private static void addDirectRefColors(String text, Set<String> colors) {
+        if (text == null) {
+            return;
+        }
+        Matcher matcher = DIRECT_REF_COLOR.matcher(text);
+        while (matcher.find()) {
+            colors.add(matcher.group(1));
+        }
+    }
+
+    private static boolean consumes(FieldBindingMng fb, String methodColor) {
+        if (fb.getTo() == null) {
+            return false;
+        }
+        for (LinkedFieldMng to : fb.getTo()) {
+            if (methodColor.equals(to.getColor())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addFromColors(FieldBindingMng fb, Set<String> colors) {
+        if (fb.getFrom() == null) {
+            return;
+        }
+        for (LinkedFieldMng from : fb.getFrom()) {
+            if (from.getColor() != null) {
+                colors.add(from.getColor());
+            }
+        }
+    }
+
+    private static void collectRequestStrings(RequestMng request, List<String> out) {
+        if (request == null) {
+            return;
+        }
+        if (request.getEndpoint() != null) {
+            out.add(request.getEndpoint());
+        }
+        if (request.getHeader() != null) {
+            out.addAll(request.getHeader().values());
+        }
+        BodyMng body = request.getBody();
+        if (body != null) {
+            if (body.getData() != null) {
+                out.add(body.getData());
+            }
+            collectValues(body.getFields(), out);
+        }
+    }
+
+    private static void collectValues(Object value, List<String> out) {
+        if (value instanceof String s) {
+            out.add(s);
+        } else if (value instanceof Map<?, ?> map) {
+            for (Object v : map.values()) {
+                collectValues(v, out);
+            }
+        } else if (value instanceof Collection<?> collection) {
+            for (Object v : collection) {
+                collectValues(v, out);
+            }
+        }
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/Loop.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/Loop.java
@@ -18,13 +18,17 @@ public class Loop {
     private RelationalOperator operator;
 
     public static Loop fromOperator(OperatorEx operatorEx) {
-        String expression = operatorEx.getExpression();
-        if (expression == null || expression.isBlank()) {
-            throw new RuntimeException("LOOP operator cannot have null or blank expression");
-        }
-
-        Loop loop = new Loop();
+        Loop loop = fromExpression(operatorEx.getExpression());
         loop.setIterator(operatorEx.getIterator());
+        return loop;
+    }
+
+    /**
+     * Builds a {@link Loop} from a loop {@code expression} alone (no iterator). Useful where only the
+     * iterated reference is needed — e.g. save-time validation — without an {@link OperatorEx}.
+     */
+    public static Loop fromExpression(String expression) {
+        Loop loop = new Loop();
 
         String wrappedDirectRef = ReferenceUtility.extractReference(expression, RegExpression.wrappedDirectRef);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/ExpressionProcessor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/ExpressionProcessor.java
@@ -5,10 +5,20 @@ import com.becon.opencelium.backend.execution.logger.msg.ExecutionLog;
 import com.becon.opencelium.backend.execution.masking.MaskingService;
 import com.becon.opencelium.backend.ocel.exception.InvalidExpressionException;
 
+import java.util.List;
 import java.util.function.Function;
 
 public interface ExpressionProcessor {
     Object evaluate(String expression) throws InvalidExpressionException;
     Object evaluate(String expression, Function<String, Object> refExtractor) throws InvalidExpressionException;
     Object evaluate(String expression, Function<String, Object> refExtractor, OcLogger<ExecutionLog> logger, MaskingService masking);
+
+    /**
+     * Extracts the raw reference lexemes an expression consumes — wrapped direct references
+     * ({@code {%#color.(response)...%}}), enhancement references, webhook and request-data
+     * references, and direct references embedded inside literals — by tokenizing the expression the
+     * same way it is evaluated. Callers interpret each reference (e.g. resolve its color) via the
+     * reference package. Best-effort: a malformed expression yields whatever could be tokenized.
+     */
+    List<String> extractReferences(String expression);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/PostfixExpressionProcessor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/PostfixExpressionProcessor.java
@@ -7,7 +7,15 @@ import com.becon.opencelium.backend.ocel.Evaluator;
 import com.becon.opencelium.backend.ocel.ExpressionProcessor;
 import com.becon.opencelium.backend.ocel.Validator;
 import com.becon.opencelium.backend.ocel.exception.InvalidExpressionException;
+import com.becon.opencelium.backend.ocel.token.Token;
+import com.becon.opencelium.backend.ocel.token.TokenType;
+import com.becon.opencelium.backend.ocel.token.Tokenizer;
+import com.becon.opencelium.backend.ocel.utils.ReferenceUtils;
+import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 public class PostfixExpressionProcessor implements ExpressionProcessor {
@@ -32,5 +40,42 @@ public class PostfixExpressionProcessor implements ExpressionProcessor {
     @Override
     public Object evaluate(String expression, Function<String, Object> refExtractor, OcLogger<ExecutionLog> logger, MaskingService masking) {
         return evaluator.evaluate(validator.validateAndTokenize(expression), refExtractor, logger, masking);
+    }
+
+    @Override
+    public List<String> extractReferences(String expression) {
+        List<String> references = new ArrayList<>();
+        if (StringUtils.isBlank(expression)) {
+            return references;
+        }
+        try {
+            collectReferences(Tokenizer.splitTokens(expression), references);
+        } catch (RuntimeException e) {
+            // best-effort: a malformed expression yields whatever could be tokenized
+        }
+        return references;
+    }
+
+    private void collectReferences(List<Token> tokens, List<String> references) {
+        for (Token token : tokens) {
+            if (token.getType() == TokenType.OPERAND) {
+                String lexeme = token.getLexeme();
+                if (lexeme == null) {
+                    continue;
+                }
+                if (ReferenceUtils.isDirectReference(lexeme)) {
+                    references.add(lexeme);
+                } else {
+                    // direct references embedded inside a larger literal
+                    for (int[] loc : PathAndReferenceUtility.extractReferenceIndexes(lexeme)) {
+                        references.add(lexeme.substring(loc[0], loc[1]));
+                    }
+                }
+            } else if (token.getType() == TokenType.FUNCTION && token.getFunctionParameters() != null) {
+                for (List<Token> parameter : token.getFunctionParameters()) {
+                    collectReferences(parameter, references);
+                }
+            }
+        }
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ReferenceUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ReferenceUtils.java
@@ -28,4 +28,8 @@ public class ReferenceUtils {
                 || token.matches(RegExpression.requestData)
                 || token.matches(RegExpression.webhook);
     }
+
+    public static boolean isDirectReference(String token) {
+        return token.matches(RegExpression.wrappedDirectRef);
+    }
 }


### PR DESCRIPTION
## What
Adds the **skipped-referenced-method** rule to jump validation: a jump is rejected when an element that still executes depends on the output of a method the jump would skip.

> Stacked on **#237 / `feature/OC-1478`** — review/merge that first.

- New code **`JUMP_SKIPS_REFERENCED_METHOD`** (8th `JumpValidationCode`).
- `JumpNode` gains `referencedColors` — the method colors an element consumes.
- `MongoJumpGraphBuilder` now resolves each element's referenced colors from:
  - direct references in a method's request (`#color.(response|request)...`, endpoint, headers, body — deduped so a ref in both body and field binding counts once, and multiple refs in a single value are all captured),
  - **field bindings** whose `to` side is the method (its `from` colors),
  - references inside an operator's **if/loop expression**.
- OCEL expression parsing is **encapsulated in the OCEL module** rather than re-implemented:
  - `ExpressionProcessor.extractReferences(String)` + `PostfixExpressionProcessor` implementation (tokenizes the expression, collects direct references — including ones embedded in literals and inside function parameters — best-effort on malformed input),
  - `ReferenceUtils.isDirectReference(...)`,
  - `Loop.fromExpression(String)` — builds a `Loop` from a loop expression alone so save-time validation can read the iterated reference without an `OperatorEx`.
- `ConnectionMngServiceImp.validateJumps` now threads `fieldBindings` into the builder.

## Why
Implements the reference-validation step of OC-1478.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No duplicate violations when a reference is in both request body and field binding
- [x] No secrets, debug logs, or commented-out code
