### PR TITLE
[OC 1399] Tests for SubscriptionServiceImpl

### DIFF
--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/ActivationRequestRepositoryTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/ActivationRequestRepositoryTest.java
@@ -4,12 +4,12 @@ import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
 import com.becon.opencelium.backend.database.mysql.repository.ActivationRequestRepository;
 import com.becon.opencelium.backend.enums.ActivReqStatus;
 import com.becon.opencelium.backend.testutil.annotation.SliceTest;
+import com.becon.opencelium.backend.testutil.fixture.ActivationRequestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -116,7 +116,7 @@ class ActivationRequestRepositoryTest {
     @Test
     void findFirstByHmacReturnsActivationRequestWhenMatchExists() {
         // GIVEN
-        ActivationRequest request = persistAndFlush(ActivReqStatus.PENDING,false);
+        ActivationRequest request = persistAndFlush(ActivReqStatus.PENDING, false);
         String id = request.getId();
         String hmac = request.getHmac();
 
@@ -198,17 +198,8 @@ class ActivationRequestRepositoryTest {
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private ActivationRequest persistAndFlush(ActivReqStatus status, boolean active) {
-        String hmac = "hmac-" + status + (active ? "-active" : "-inactive");
-
-        ActivationRequest request = new ActivationRequest();
-
-        request.setId(UUID.randomUUID().toString());
-        request.setHmac(hmac);
-        request.setStatus(status);
-        request.setActive(active);
-        request.setTtl(3600);
-        request.setCreatedAt(LocalDateTime.now());
-
-        return em.persistAndFlush(request);
+        return em.persistAndFlush(
+                ActivationRequestFixture.anActivationRequest(status, active)
+        );
     }
 }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/SubscriptionRepositoryTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/SubscriptionRepositoryTest.java
@@ -1,0 +1,230 @@
+package com.becon.opencelium.backend.slice.database.mysql.repository;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.database.mysql.entity.Subscription;
+import com.becon.opencelium.backend.database.mysql.repository.SubscriptionRepository;
+import com.becon.opencelium.backend.enums.ActivReqStatus;
+import com.becon.opencelium.backend.testutil.annotation.SliceTest;
+import com.becon.opencelium.backend.testutil.fixture.ActivationRequestFixture;
+import com.becon.opencelium.backend.testutil.fixture.SubscriptionFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * JPA slice tests for {@link SubscriptionRepository}.
+ * <p>
+ * These tests run against H2 because the repository contains custom JPQL and
+ * native queries for subscription actions that cannot be verified with mocks.
+ * <p>
+ * Run with: ./gradlew test --tests "*.SubscriptionRepositoryTest"
+ */
+@SliceTest
+@DisplayName("SubscriptionRepository — JPA slice")
+class SubscriptionRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private SubscriptionRepository repository;
+
+    // ── deactivateAll ────────────────────────────────────────────────────────
+
+    @Test
+    void deactivateAllMarksEverySubscriptionInactive() {
+        // GIVEN
+        persistAndFlush("license-1", true);
+        persistAndFlush("license-2", true);
+        persistAndFlush("license-3", false);
+
+        // WHEN
+        repository.deactivateAll();
+        em.flush();
+        em.clear();
+
+        // THEN
+        assertThat(repository.findAll())
+                .extracting(Subscription::isActive)
+                .containsOnly(false);
+    }
+
+    // ── deleteByLicenseId ────────────────────────────────────────────────────
+
+    @Test
+    void deleteByLicenseIdDeletesSubscriptionWhenLicenseIdMatches() {
+        // GIVEN
+        persistAndFlush("license-1", true);
+        persistAndFlush("license-2", true);
+
+        // WHEN
+        repository.deleteByLicenseId("license-1");
+        em.flush();
+        em.clear();
+
+        // THEN
+        assertThat(repository.findByLicenseId("license-1")).isEmpty();
+        assertThat(repository.findByLicenseId("license-2")).isPresent();
+    }
+
+    // ── deleteBySubId ────────────────────────────────────────────────────────
+
+    @Test
+    void deleteBySubIdDeletesSubscriptionWhenSubIdMatches() {
+        // GIVEN
+        Subscription subscription1 = persistAndFlush("license-1", true);
+        Subscription subscription2 = persistAndFlush("license-2", true);
+
+        String subId1 = subscription1.getSubId();
+        String subId2 = subscription2.getSubId();
+
+        // WHEN
+        repository.deleteBySubId(subId1);
+        em.flush();
+        em.clear();
+
+        // THEN
+        assertThat(repository.findBySubId(subId1)).isEmpty();
+        assertThat(repository.findBySubId(subId2)).isPresent();
+    }
+
+    // ── findFirstByActiveTrue ────────────────────────────────────────────────
+
+    @Test
+    void findFirstByActiveTrueReturnsSubscriptionWhenActiveEntryExists() {
+        // GIVEN
+        persistAndFlush("license-inactive", false);
+        Subscription active = persistAndFlush("license-active", true);
+
+        // WHEN
+        Optional<Subscription> result = repository.findFirstByActiveTrue();
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(active.getId());
+        assertThat(result.get().isActive()).isTrue();
+    }
+
+    @Test
+    void findFirstByActiveTrueReturnsEmptyWhenNoSubscriptionIsActive() {
+        // GIVEN
+        persistAndFlush("license-1", false);
+        persistAndFlush("license-2", false);
+
+        // WHEN-THEN
+        assertThat(repository.findFirstByActiveTrue()).isEmpty();
+    }
+
+    // ── findBySubId ──────────────────────────────────────────────────────────
+
+    @Test
+    void findBySubIdReturnsSubscriptionWhenMatchExists() {
+        // GIVEN
+        Subscription subscription = persistAndFlush("license-1", true);
+
+        // WHEN
+        Optional<Subscription> result = repository.findBySubId(subscription.getSubId());
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(subscription.getId());
+    }
+
+    @Test
+    void findBySubIdReturnsEmptyWhenMatchDoesNotExist() {
+        // GIVEN
+        persistAndFlush("license-1", true);
+        String nonExistingSubId = UUID.randomUUID().toString();
+
+        // WHEN-THEN
+        assertThat(repository.findBySubId(nonExistingSubId)).isEmpty();
+    }
+
+    // ── existsBySubId ────────────────────────────────────────────────────────
+
+    @Test
+    void existsBySubIdReturnsTrueWhenSubscriptionExists() {
+        // GIVEN
+        Subscription subscription = persistAndFlush("license-1", true);
+
+        String subId = subscription.getSubId();
+
+        // WHEN-THEN
+        assertThat(repository.existsBySubId(subId)).isTrue();
+    }
+
+    @Test
+    void existsBySubIdReturnsFalseWhenSubscriptionDoesNotExist() {
+        // GIVEN
+        String nonExistingSubId = UUID.randomUUID().toString();
+
+        // WHEN-THEN
+        assertThat(repository.existsBySubId(nonExistingSubId)).isFalse();
+    }
+
+    // ── findByLicenseId ──────────────────────────────────────────────────────
+
+    @Test
+    void findByLicenseIdReturnsSubscriptionWhenMatchExists() {
+        // GIVEN
+        Subscription subscription = persistAndFlush("license-1", true);
+
+        // WHEN
+        Optional<Subscription> result = repository.findByLicenseId("license-1");
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(subscription.getId());
+    }
+
+    @Test
+    void findByLicenseIdReturnsEmptyWhenMatchDoesNotExist() {
+        // GIVEN
+        persistAndFlush("license-1", true);
+
+        // WHEN-THEN
+        assertThat(repository.findByLicenseId("missing-license")).isEmpty();
+    }
+
+    // ── findAndLockById ──────────────────────────────────────────────────────
+
+    @Test
+    void findAndLockByIdReturnsSubscriptionWhenIdExists() {
+        // GIVEN
+        Subscription subscription = persistAndFlush("license-1", true);
+
+        // WHEN
+        Optional<Subscription> result = repository.findAndLockById(subscription.getId());
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(subscription.getId());
+    }
+
+    @Test
+    void findAndLockByIdReturnsEmptyWhenIdDoesNotExist() {
+        // WHEN-THEN
+        assertThat(repository.findAndLockById("missing-id")).isEmpty();
+    }
+
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private Subscription persistAndFlush(String licenseId, boolean active) {
+        ActivationRequest activationRequest = em.persist(
+                ActivationRequestFixture.anActivationRequest(ActivReqStatus.PROCESSED, true)
+        );
+
+        String subscriptionId = UUID.randomUUID().toString();
+
+        return em.persistAndFlush(
+                SubscriptionFixture.aSubscription(subscriptionId, licenseId, active, activationRequest)
+        );
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/ActivationRequestFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/ActivationRequestFixture.java
@@ -3,6 +3,8 @@ package com.becon.opencelium.backend.testutil.fixture;
 import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
 import com.becon.opencelium.backend.enums.ActivReqStatus;
 
+import java.util.UUID;
+
 /**
  * Object mother for {@link ActivationRequest} test data.
  */
@@ -15,15 +17,7 @@ public final class ActivationRequestFixture {
      * license activation. Mirrors the default bundled activation request.
      */
     public static ActivationRequest aPendingActivationRequest() {
-        ActivationRequest request = new ActivationRequest();
-
-        request.setId("eff042a1-b9db-43b3-855d-b62d712ce4c9");
-        request.setHmac("Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=");
-        request.setStatus(ActivReqStatus.PENDING);
-        request.setActive(false);
-        request.setTtl(3600);
-
-        return request;
+        return anActivationRequest(ActivReqStatus.PENDING, false);
     }
 
     /**
@@ -31,15 +25,7 @@ public final class ActivationRequestFixture {
      * Used to pin expiry-related validation branches.
      */
     public static ActivationRequest aExpiredActivationRequest() {
-        ActivationRequest request = new ActivationRequest();
-
-        request.setId("eff042a1-b9db-43b3-855d-b62d712ce4c9");
-        request.setHmac("Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=");
-        request.setStatus(ActivReqStatus.EXPIRED);
-        request.setActive(false);
-        request.setTtl(3600);
-
-        return request;
+        return anActivationRequest(ActivReqStatus.EXPIRED, false);
     }
 
     /**
@@ -47,12 +33,19 @@ public final class ActivationRequestFixture {
      * activated on the current machine.
      */
     public static ActivationRequest aProcessedActivationRequest() {
+        return anActivationRequest(ActivReqStatus.PROCESSED, true);
+    }
+
+    /**
+     * Activation request with given status and state.
+     */
+    public static ActivationRequest anActivationRequest(ActivReqStatus status, boolean active) {
         ActivationRequest request = new ActivationRequest();
 
-        request.setId("eff042a1-b9db-43b3-855d-b62d712ce4c9");
+        request.setId(UUID.randomUUID().toString());
         request.setHmac("Aymga2vvpFZQm0JzWqV8K7zP0K0mTQ5l0V7i4S3n8XQ=");
-        request.setStatus(ActivReqStatus.PROCESSED);
-        request.setActive(true);
+        request.setStatus(status);
+        request.setActive(active);
         request.setTtl(3600);
 
         return request;

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/SubscriptionFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/SubscriptionFixture.java
@@ -1,0 +1,34 @@
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.database.mysql.entity.Subscription;
+
+import java.util.UUID;
+
+/**
+ * Object mother for {@link Subscription} test data.
+ */
+public final class SubscriptionFixture {
+
+    private SubscriptionFixture() {}
+
+    public static Subscription aSubscription(
+            String subId,
+            String licenseId,
+            boolean active,
+            ActivationRequest activationRequest
+    ) {
+        Subscription subscription = new Subscription();
+
+        subscription.setId(UUID.randomUUID().toString());
+        subscription.setSubId(subId);
+        subscription.setLicenseId(licenseId);
+        subscription.setLicenseKey("license-key-" + licenseId);
+        subscription.setCurrentUsage(0);
+        subscription.setCurrentUsageHmac("usage-hmac-" + subId);
+        subscription.setActive(active);
+        subscription.setActivationRequest(activationRequest);
+
+        return subscription;
+    }
+}


### PR DESCRIPTION
## What
- Add `SubscriptionRepositoryTest` — 13 slice tests. No inline data creation, uses helper methods.
- 

## Why
Resolves: [[OC-1397] Tests for SubscriptionRepositoryTest](https://becon.atlassian.net/browse/OC-1397)

## How to test
```bash
./gradlew test --tests "*.SubscriptionRepositoryTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code