### PR TITLE
OC-1481: coerce primitive operands in OCEL Like/Matches/RegEx/MatchesInList/DenyList

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/DenyList.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/DenyList.java
@@ -5,38 +5,10 @@ import com.becon.opencelium.backend.ocel.operator.BinaryOperator;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
 
-import java.util.List;
-
 class DenyList implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
-        if (o2 instanceof String) {
-            String[] split = ((String) o2).replaceAll("\n", ",").split(",");
-            Like like = new Like();
-
-            for (String value : split) {
-                Object result = like.apply(o1.toString(), value);
-                if (Boolean.TRUE.equals(result)) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        if (o1 instanceof String && o2 instanceof List<?> list) {
-            Like like = new Like();
-
-            for (Object value : list) {
-                Object result = like.apply(o1.toString(), value);
-                if (Boolean.TRUE.equals(result)) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-        throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
+        return !(Boolean) new MatchesInList().apply(o1, o2);
     }
 
     @Override
@@ -46,29 +18,11 @@ class DenyList implements BinaryOperator {
 
     @Override
     public boolean isValidOperand(SidesType side, Object operand) {
-        if (operand == null) return false;
-        if (side == SidesType.LEFT) {
-            return operand instanceof String;
-        }
-        if (operand instanceof String) {
-            return true;
-        }
-        if (operand instanceof List<?> list) {
-            for (Object o : list) {
-                if (!(o instanceof String)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-        return false;
+        return new MatchesInList().isValidOperand(side, operand);
     }
 
     @Override
     public boolean isValidType(SidesType side, Class<?> type) {
-        if (side == SidesType.LEFT)
-            return type.equals(String.class);
-
-        return type.equals(String.class) || type.equals(List.class);
+        return new MatchesInList().isValidType(side, type);
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/IsEmpty.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/IsEmpty.java
@@ -3,6 +3,7 @@ package com.becon.opencelium.backend.ocel.operator.operators;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
 import com.becon.opencelium.backend.ocel.operator.UnaryOperator;
+import com.becon.opencelium.backend.ocel.utils.ValueUtils;
 
 import java.util.List;
 
@@ -10,6 +11,9 @@ class IsEmpty implements UnaryOperator {
 
     @Override
     public Object apply(Object o) throws ApplyOperatorException {
+        // Normalize: convert String operands that contain arrays into real Lists
+        o = ValueUtils.normalizeArray(o);
+
         if (!(o instanceof List)) {
             throw ApplyOperatorException.invalidTypeException(getOperatorType(), o);
         }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/Like.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/Like.java
@@ -4,20 +4,20 @@ import com.becon.opencelium.backend.ocel.operator.BinaryOperator;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
 import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.utils.Utils;
 
 import java.util.regex.Pattern;
 
 class Like implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
-//        if (!(o1 instanceof String s1) || !(o2 instanceof String s2))
-//            throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
-//
-//        String regex = "(?i)^" + s2.replace("%", ".*") + "$";
-//        return Pattern.compile(regex, Pattern.DOTALL).matcher(s1).find();
-
-        if (!(o1 instanceof String s1) || !(o2 instanceof String s2))
+        // Accept any primitive scalar on both sides and coerce via toString();
+        // null remains invalid.
+        if (!Utils.isPrimitiveType(o1) || !Utils.isPrimitiveType(o2))
             throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
+
+        String s1 = o1.toString();
+        String s2 = o2.toString();
 
         // 1. Escape all regex special characters first
         String escaped = Pattern.quote(s2);
@@ -28,7 +28,7 @@ class Like implements BinaryOperator {
                 .replace("%", "\\E.*\\Q")  // Close quote, add wildcard, reopen quote
                 .replace("_", "\\E.\\Q");   // Close quote, add single char wildcard, reopen quote
 
-        // 3. Clean up empty quotes and wrap in anchors
+        // 3. Wrap in anchors
         regex = "^" + regex + "$";
 
         // Use CASE_INSENSITIVE for SQL-like behavior
@@ -39,12 +39,12 @@ class Like implements BinaryOperator {
 
     @Override
     public boolean isValidOperand(SidesType sidesType, Object operand) {
-        return operand instanceof String;
+        return Utils.isPrimitiveType(operand);
     }
 
     @Override
     public boolean isValidType(SidesType side, Class<?> type) {
-        return type.equals(String.class);
+        return Utils.isPrimitiveType(type);
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/Matches.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/Matches.java
@@ -4,26 +4,36 @@ import com.becon.opencelium.backend.ocel.operator.BinaryOperator;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
 import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.utils.Utils;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 class Matches implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
-        if (!(o1 instanceof String value) || !(o2 instanceof String regex))
+        // Accept any primitive scalar on both sides and coerce via toString().
+        if (!Utils.isPrimitiveType(o1) || !Utils.isPrimitiveType(o2))
             throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
 
-        return Pattern.matches(regex, value);
+        String value = o1.toString();
+        String regex = o2.toString();
+
+        try {
+            return Pattern.matches(regex, value);
+        } catch (PatternSyntaxException e) {
+            throw ApplyOperatorException.invalidOperandValueException(getOperatorType(), o1, o2);
+        }
     }
 
     @Override
     public boolean isValidOperand(SidesType sidesType, Object operand) {
-        return operand instanceof String;
+        return Utils.isPrimitiveType(operand);
     }
 
     @Override
     public boolean isValidType(SidesType side, Class<?> type) {
-        return type.equals(String.class);
+        return Utils.isPrimitiveType(type);
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/MatchesInList.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/MatchesInList.java
@@ -4,38 +4,52 @@ import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
 import com.becon.opencelium.backend.ocel.operator.BinaryOperator;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
+import com.becon.opencelium.backend.ocel.utils.ValueUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 class MatchesInList implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
-        if (o2 instanceof String) {
-            String[] values = o2.toString().replace("\n", ",").split(",");
-            Like like = new Like();
-
-            for (String value : values) {
-                Object result = like.apply(o1.toString(), value);
-                if (Boolean.TRUE.equals(result)) {
-                    return true;
-                }
-            }
-
+        // A null left operand can never match any pattern.
+        if (o1 == null) {
             return false;
         }
 
-        if (o1 instanceof String && o2 instanceof List<?> list) {
-            Like like = new Like();
-            for (Object value : list) {
-                Object result = like.apply(o1.toString(), value);
-                if (Boolean.TRUE.equals(result)) {
-                    return true;
+        List<String> patterns = toPatterns(o2);
+        if (patterns == null) {
+            throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
+        }
+
+        String left = o1.toString();
+        Like like = new Like();
+        for (String pattern : patterns) {
+            if (Boolean.TRUE.equals(like.apply(left, pattern))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> toPatterns(Object o2) {
+        Object normalized = ValueUtils.normalizeArray(o2);
+        if (normalized instanceof List<?> list) {
+            List<String> result = new ArrayList<>();
+            for (Object o : list) {
+                if (o != null) {
+                    result.add(o.toString());
                 }
             }
-
-            return false;
+            return result;
         }
-        throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
+        if (o2 instanceof String s) {
+            List<String> result = new ArrayList<>();
+            Collections.addAll(result, s.replace("\n", ",").split(","));
+            return result;
+        }
+        return null;
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/NotLike.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/NotLike.java
@@ -8,21 +8,17 @@ import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
 class NotLike implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
-        try {
-            return !(Boolean) new Like().apply(o1, o2);
-        } catch (ApplyOperatorException e) {
-            throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
-        }
+        return !(Boolean) new Like().apply(o1, o2);
     }
 
     @Override
     public boolean isValidOperand(SidesType sidesType, Object operand) {
-        return operand instanceof String;
+        return new Like().isValidOperand(sidesType, operand);
     }
 
     @Override
     public boolean isValidType(SidesType side, Class<?> type) {
-        return type.equals(String.class);
+        return new Like().isValidType(side, type);
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/RegEx.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operator/operators/RegEx.java
@@ -4,26 +4,36 @@ import com.becon.opencelium.backend.ocel.operator.BinaryOperator;
 import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
 import com.becon.opencelium.backend.ocel.operator.SidesType;
 import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.utils.Utils;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 class RegEx implements BinaryOperator {
     @Override
     public Object apply(Object o1, Object o2) throws ApplyOperatorException {
-        if (!(o1 instanceof String input) || !(o2 instanceof String regex))
+        // Accept any primitive scalar on both sides and coerce via toString().
+        if (!Utils.isPrimitiveType(o1) || !Utils.isPrimitiveType(o2))
             throw ApplyOperatorException.invalidTypePairsException(getOperatorType(), o1, o2);
 
-        return Pattern.matches(regex, input);
+        String input = o1.toString();
+        String regex = o2.toString();
+
+        try {
+            return Pattern.matches(regex, input);
+        } catch (PatternSyntaxException e) {
+            throw ApplyOperatorException.invalidOperandValueException(getOperatorType(), o1, o2);
+        }
     }
 
     @Override
     public boolean isValidOperand(SidesType sidesType, Object operand) {
-        return operand instanceof String;
+        return Utils.isPrimitiveType(operand);
     }
 
     @Override
     public boolean isValidType(SidesType side, Class<?> type) {
-        return type.equals(String.class);
+        return Utils.isPrimitiveType(type);
     }
 
     @Override

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/DenyListTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/DenyListTest.java
@@ -1,0 +1,75 @@
+package com.becon.opencelium.backend.unit.ocel.operator.operators;
+
+import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.operator.Operator;
+import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
+import com.becon.opencelium.backend.ocel.operator.SidesType;
+import com.becon.opencelium.backend.ocel.operator.operators.OperatorFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the {@code DenyList} operator.
+ *
+ * No Spring context is loaded — operators are obtained from
+ * {@link OperatorFactory} and exercised through the public {@link Operator} API.
+ */
+@DisplayName("DenyList — unit")
+class DenyListTest {
+
+    private static final Operator denyList = OperatorFactory.getOperator(OperatorEnum.DENY_LIST);
+    private static final Operator matchesInList = OperatorFactory.getOperator(OperatorEnum.MATCHES_IN_LIST);
+
+    @Test
+    void applyReturnsTrueWhenNoPatternMatches() throws ApplyOperatorException {
+        assertThat(denyList.apply("hello", List.of("world", "foo"))).isEqualTo(true);
+    }
+
+    @Test
+    void applyReturnsFalseWhenAnyPatternMatches() throws ApplyOperatorException {
+        assertThat(denyList.apply("hello", List.of("world", "hel%"))).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("string-encoded array behaves like a real list")
+    void applyReturnsFalseWhenStringEncodedArrayMatches() throws ApplyOperatorException {
+        assertThat(denyList.apply("hello", "[world, hel%]")).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsExpectedResultWhenNumberLeftOperandIsCoerced() throws ApplyOperatorException {
+        assertThat(denyList.apply(123, List.of("12%"))).isEqualTo(false);
+        assertThat(denyList.apply(123, List.of("99%"))).isEqualTo(true);
+    }
+
+    @Test
+    void applyReturnsTrueWhenLeftOperandIsNull() throws ApplyOperatorException {
+        assertThat(denyList.apply(null, List.of("hel%"))).isEqualTo(true);
+    }
+
+    @Test
+    void applyReturnsExactNegationOfMatchesInListForIdenticalInputs() throws ApplyOperatorException {
+        Object[][] inputs = {
+                {"hello", List.of("world", "hel%")},
+                {"hello", List.of("foo")},
+                {"hello", "world,hel%"},
+                {123, List.of("12%")},
+        };
+        for (Object[] in : inputs) {
+            boolean allow = (Boolean) matchesInList.apply(in[0], in[1]);
+            boolean deny = (Boolean) denyList.apply(in[0], in[1]);
+            assertThat(deny).isEqualTo(!allow);
+        }
+    }
+
+    @Test
+    void isValidOperandDelegatesToMatchesInList() {
+        assertThat(denyList.isValidOperand(SidesType.LEFT, null)).isTrue();
+        assertThat(denyList.isValidOperand(SidesType.RIGHT, "x")).isTrue();
+        assertThat(denyList.isValidOperand(SidesType.RIGHT, List.of("x"))).isTrue();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/LikeTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/LikeTest.java
@@ -1,0 +1,96 @@
+package com.becon.opencelium.backend.unit.ocel.operator.operators;
+
+import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.operator.Operator;
+import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
+import com.becon.opencelium.backend.ocel.operator.SidesType;
+import com.becon.opencelium.backend.ocel.operator.operators.OperatorFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the {@code Like} and {@code NotLike} operators.
+ *
+ * No Spring context is loaded — operators are obtained directly from
+ * {@link OperatorFactory} and exercised through the public {@link Operator} API.
+ */
+@DisplayName("Like / NotLike — unit")
+class LikeTest {
+
+    private static final Operator like = OperatorFactory.getOperator(OperatorEnum.LIKE);
+    private static final Operator notLike = OperatorFactory.getOperator(OperatorEnum.NOT_LIKE);
+
+    @Test
+    void applyReturnsExpectedResultWhenPatternUsesPercentWildcard() throws ApplyOperatorException {
+        assertThat(like.apply("hello", "hel%")).isEqualTo(true);
+        assertThat(like.apply("hello", "%llo")).isEqualTo(true);
+        assertThat(like.apply("hello", "world")).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsExpectedResultWhenPatternUsesUnderscoreWildcard() throws ApplyOperatorException {
+        assertThat(like.apply("hello", "h_llo")).isEqualTo(true);
+        assertThat(like.apply("hello", "h_lo")).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsTrueWhenMatchIsCaseInsensitive() throws ApplyOperatorException {
+        assertThat(like.apply("Hello", "hel%")).isEqualTo(true);
+    }
+
+    @Test
+    void applyReturnsExpectedResultWhenNumberOperandsAreCoerced() throws ApplyOperatorException {
+        assertThat(like.apply(123, "12%")).isEqualTo(true);
+        assertThat(like.apply(123, 123)).isEqualTo(true);
+        assertThat(like.apply("123", 12)).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsExpectedResultWhenBooleanOperandsAreCoerced() throws ApplyOperatorException {
+        assertThat(like.apply(true, "tr%")).isEqualTo(true);
+        assertThat(like.apply(true, false)).isEqualTo(false);
+    }
+
+    @Test
+    void applyThrowsWhenEitherOperandIsNull() {
+        assertThatThrownBy(() -> like.apply(null, "x"))
+                .isInstanceOf(ApplyOperatorException.class);
+        assertThatThrownBy(() -> like.apply("x", null))
+                .isInstanceOf(ApplyOperatorException.class);
+    }
+
+    @Test
+    void isValidOperandReturnsTrueWhenOperandIsPrimitive() {
+        assertThat(like.isValidOperand(SidesType.LEFT, "x")).isTrue();
+        assertThat(like.isValidOperand(SidesType.RIGHT, 1)).isTrue();
+        assertThat(like.isValidOperand(SidesType.LEFT, true)).isTrue();
+    }
+
+    @Test
+    void isValidOperandReturnsFalseWhenOperandIsNull() {
+        assertThat(like.isValidOperand(SidesType.LEFT, null)).isFalse();
+    }
+
+    @Test
+    void isValidTypeReturnsTrueWhenTypeIsPrimitive() {
+        assertThat(like.isValidType(SidesType.LEFT, Number.class)).isTrue();
+        assertThat(like.isValidType(SidesType.RIGHT, Boolean.class)).isTrue();
+    }
+
+    @Test
+    void applyReturnsNegationOfLikeWhenOperatorIsNotLike() throws ApplyOperatorException {
+        assertThat(notLike.apply("hello", "hel%")).isEqualTo(false);
+        assertThat(notLike.apply("hello", "world")).isEqualTo(true);
+        assertThat(notLike.apply(123, "12%")).isEqualTo(false);
+    }
+
+    @Test
+    void isValidOperandDelegatesToLikeWhenOperatorIsNotLike() {
+        assertThat(notLike.isValidOperand(SidesType.LEFT, 1)).isTrue();
+        assertThat(notLike.isValidOperand(SidesType.LEFT, null)).isFalse();
+        assertThat(notLike.isValidType(SidesType.RIGHT, Number.class)).isTrue();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/MatchesInListTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/MatchesInListTest.java
@@ -1,0 +1,69 @@
+package com.becon.opencelium.backend.unit.ocel.operator.operators;
+
+import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.operator.Operator;
+import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
+import com.becon.opencelium.backend.ocel.operator.SidesType;
+import com.becon.opencelium.backend.ocel.operator.operators.OperatorFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the {@code MatchesInList} (AllowList) operator.
+ *
+ * No Spring context is loaded — the operator is obtained from
+ * {@link OperatorFactory} and exercised through the public {@link Operator} API.
+ */
+@DisplayName("MatchesInList (AllowList) — unit")
+class MatchesInListTest {
+
+    private static final Operator matchesInList = OperatorFactory.getOperator(OperatorEnum.MATCHES_IN_LIST);
+
+    @Test
+    void applyReturnsExpectedResultWhenRightOperandIsRealList() throws ApplyOperatorException {
+        assertThat(matchesInList.apply("hello", List.of("world", "hel%"))).isEqualTo(true);
+        assertThat(matchesInList.apply("hello", List.of("world", "foo"))).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsExpectedResultWhenRightOperandIsCommaOrNewlineSeparatedString() throws ApplyOperatorException {
+        assertThat(matchesInList.apply("hello", "world,hel%")).isEqualTo(true);
+        assertThat(matchesInList.apply("hello", "world\nhel%")).isEqualTo(true);
+        assertThat(matchesInList.apply("hello", "world,foo")).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("string-encoded array behaves like a real list")
+    void applyReturnsSameResultWhenRightOperandIsStringEncodedArray() throws ApplyOperatorException {
+        assertThat(matchesInList.apply("hello", "[world, hel%]")).isEqualTo(true);
+        assertThat(matchesInList.apply("hello", "[world, hel%]"))
+                .isEqualTo(matchesInList.apply("hello", List.of("world", "hel%")));
+    }
+
+    @Test
+    void applyReturnsTrueWhenNumberLeftOperandIsCoerced() throws ApplyOperatorException {
+        assertThat(matchesInList.apply(123, List.of("12%", "foo"))).isEqualTo(true);
+    }
+
+    @Test
+    void applyReturnsTrueWhenNonStringListElementsAreCoerced() throws ApplyOperatorException {
+        assertThat(matchesInList.apply("12", List.of(12, 34))).isEqualTo(true);
+    }
+
+    @Test
+    void applyReturnsFalseWhenLeftOperandIsNull() throws ApplyOperatorException {
+        assertThat(matchesInList.apply(null, List.of("hel%"))).isEqualTo(false);
+        assertThat(matchesInList.apply(null, "hel%")).isEqualTo(false);
+    }
+
+    @Test
+    void isValidOperandReturnsExpectedResultWhenSideAndTypeVary() {
+        assertThat(matchesInList.isValidOperand(SidesType.LEFT, null)).isTrue();
+        assertThat(matchesInList.isValidOperand(SidesType.RIGHT, "x")).isTrue();
+        assertThat(matchesInList.isValidOperand(SidesType.RIGHT, List.of("x"))).isTrue();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/MatchesTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/MatchesTest.java
@@ -1,0 +1,56 @@
+package com.becon.opencelium.backend.unit.ocel.operator.operators;
+
+import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.operator.Operator;
+import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
+import com.becon.opencelium.backend.ocel.operator.SidesType;
+import com.becon.opencelium.backend.ocel.operator.operators.OperatorFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the {@code Matches} operator.
+ *
+ * No Spring context is loaded — the operator is obtained from
+ * {@link OperatorFactory} and exercised through the public {@link Operator} API.
+ */
+@DisplayName("Matches — unit")
+class MatchesTest {
+
+    private static final Operator matches = OperatorFactory.getOperator(OperatorEnum.MATCHES);
+
+    @Test
+    void applyReturnsExpectedResultWhenValueIsMatchedAgainstRegex() throws ApplyOperatorException {
+        assertThat(matches.apply("hello123", "[a-z]+\\d+")).isEqualTo(true);
+        assertThat(matches.apply("abc", "\\d+")).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsExpectedResultWhenNumberOperandsAreCoerced() throws ApplyOperatorException {
+        assertThat(matches.apply(123, "\\d+")).isEqualTo(true);
+        assertThat(matches.apply(123, "\\d{2}")).isEqualTo(false);
+    }
+
+    @Test
+    void applyThrowsApplyOperatorExceptionWhenRegexIsInvalid() {
+        assertThatThrownBy(() -> matches.apply("abc", "["))
+                .isInstanceOf(ApplyOperatorException.class);
+    }
+
+    @Test
+    void applyThrowsWhenOperandIsNull() {
+        assertThatThrownBy(() -> matches.apply(null, "\\d+"))
+                .isInstanceOf(ApplyOperatorException.class);
+    }
+
+    @Test
+    void isValidOperandReturnsExpectedResultWhenOperandIsPrimitiveOrNull() {
+        assertThat(matches.isValidOperand(SidesType.LEFT, 1)).isTrue();
+        assertThat(matches.isValidOperand(SidesType.RIGHT, "x")).isTrue();
+        assertThat(matches.isValidOperand(SidesType.LEFT, null)).isFalse();
+        assertThat(matches.isValidType(SidesType.LEFT, Number.class)).isTrue();
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/RegExTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/ocel/operator/operators/RegExTest.java
@@ -1,0 +1,54 @@
+package com.becon.opencelium.backend.unit.ocel.operator.operators;
+
+import com.becon.opencelium.backend.ocel.exception.ApplyOperatorException;
+import com.becon.opencelium.backend.ocel.operator.Operator;
+import com.becon.opencelium.backend.ocel.operator.OperatorEnum;
+import com.becon.opencelium.backend.ocel.operator.SidesType;
+import com.becon.opencelium.backend.ocel.operator.operators.OperatorFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the {@code RegEx} operator.
+ *
+ * No Spring context is loaded — the operator is obtained from
+ * {@link OperatorFactory} and exercised through the public {@link Operator} API.
+ */
+@DisplayName("RegEx — unit")
+class RegExTest {
+
+    private static final Operator regEx = OperatorFactory.getOperator(OperatorEnum.REGEX);
+
+    @Test
+    void applyReturnsExpectedResultWhenInputIsMatchedAgainstRegex() throws ApplyOperatorException {
+        assertThat(regEx.apply("hello123", "[a-z]+\\d+")).isEqualTo(true);
+        assertThat(regEx.apply("abc", "\\d+")).isEqualTo(false);
+    }
+
+    @Test
+    void applyReturnsTrueWhenNumberOperandIsCoerced() throws ApplyOperatorException {
+        assertThat(regEx.apply(123, "\\d+")).isEqualTo(true);
+    }
+
+    @Test
+    void applyThrowsApplyOperatorExceptionWhenRegexIsInvalid() {
+        assertThatThrownBy(() -> regEx.apply("abc", "("))
+                .isInstanceOf(ApplyOperatorException.class);
+    }
+
+    @Test
+    void applyThrowsWhenOperandIsNull() {
+        assertThatThrownBy(() -> regEx.apply(null, "\\d+"))
+                .isInstanceOf(ApplyOperatorException.class);
+    }
+
+    @Test
+    void isValidOperandReturnsExpectedResultWhenOperandIsPrimitiveOrNull() {
+        assertThat(regEx.isValidOperand(SidesType.LEFT, 1)).isTrue();
+        assertThat(regEx.isValidOperand(SidesType.LEFT, null)).isFalse();
+        assertThat(regEx.isValidType(SidesType.RIGHT, Boolean.class)).isTrue();
+    }
+}


### PR DESCRIPTION
## What
Loosened the remaining ocel binary operators so they accept any primitive scalar (`String`/`Number`/`Boolean`), coerce via `toString()`, and normalize string-encoded arrays through the shared `ValueUtils` helpers — the same pattern already applied to `Contains`/`ContainsSubStr`.

- `Like` — accepts any primitive on both sides and coerces via `toString()`; `null` stays invalid; validation now uses `Utils.isPrimitiveType`.
- `NotLike` — validation delegates to `Like` (removed the duplicated String-only gates that had drifted).
- `Matches` / `RegEx` — coerce primitive operands and wrap regex compilation failures in `ApplyOperatorException` (previously an invalid pattern escaped as an unchecked `PatternSyntaxException`, bypassing operator error handling).
- `MatchesInList` — normalizes the right operand via `ValueUtils.normalizeArray` so a string-encoded `"[a, b]"` behaves like a real list instead of comma-splitting into garbage patterns; coerces the left operand and list elements; a `null` left operand now returns `false` instead of throwing an NPE.
- `DenyList` — reimplemented as the exact negation of `MatchesInList`

## Why
Closes OC-1481.

## How to test
```bash
# Unit tests
./gradlew test --tests "com.becon.opencelium.backend.unit.ocel.operator.operators.*"

# Regression — the existing validator / postfix suites still pass
./gradlew test --tests "com.becon.opencelium.backend.unit.ocel.*"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally for the affected suites
- [x] Tests added or updated — `LikeTest`, `MatchesTest`, `RegExTest`, `MatchesInListTest`, `DenyListTest` (`src/test/.../unit/ocel/operator/operators/`)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
