### PR TITLE
OC-1486: template-driven incoming-webhook body with per-messenger requestStructure

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/configuration/AppConfiguration.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/configuration/AppConfiguration.java
@@ -40,6 +40,18 @@ public class AppConfiguration {
                 .setReadTimeout(Duration.ofMillis(SecurityConstant.READ_TIMEOUT)).build();
     }
 
+    /**
+     * Dedicated client for outgoing incoming-webhook notifications. Kept separate from the shared
+     * {@link #restTemplate()} used by connector execution so its connect/read timeouts never affect it.
+     */
+    @Bean(name = "webhookRestTemplate")
+    public RestTemplate webhookRestTemplate() {
+        return new RestTemplateBuilder()
+                .setConnectTimeout(Duration.ofMillis(SecurityConstant.CONN_TIMEOUT))
+                .setReadTimeout(Duration.ofMillis(SecurityConstant.READ_TIMEOUT))
+                .build();
+    }
+
 //    @Bean
 //    public YamlPropertiesFactoryBean getYamlProps() {
 //        YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/notification/IncomingWebhookService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/notification/IncomingWebhookService.java
@@ -1,8 +1,16 @@
 package com.becon.opencelium.backend.execution.notification;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -10,34 +18,207 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class IncomingWebhookService implements CommunicationTool {
 
-    @Autowired
-    private RestTemplate restTemplate;
+    private static final Logger log = LoggerFactory.getLogger(IncomingWebhookService.class);
+
+    private static final String TEMPLATE_DIR = "notification/";
+    private static final String DEFAULT_TEMPLATE = "default";
+
+    // Matches a leading [tool] prefix; group(1)=tool, group(2)=the rest of the destination.
+    private static final Pattern PREFIX = Pattern.compile("^\\[(\\w+)]\\s*(.*)$", Pattern.DOTALL);
+    // Matches ${name} placeholders inside template string leaves.
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{(\\w+)}");
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+    // Base names of the templates shipped under notification/ (excluding "default"), longest first so a
+    // more specific name wins when a URL happens to contain several. Enumerated once and cached.
+    private volatile List<String> templateNames;
+
+    public IncomingWebhookService(@Qualifier("webhookRestTemplate") RestTemplate webhookRestTemplate,
+                                  ObjectMapper objectMapper) {
+        this.restTemplate = webhookRestTemplate;
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public boolean sendMessage(String destination, String subject, String text) {
-        HttpMethod method = HttpMethod.POST;
-        String body = "{" +
-                            "\"text\": \"" + subject +
-                                      "\n" + text + "\"\n" +
-                      "}";
-        Objects.requireNonNull(destination);
+        Objects.requireNonNull(destination, "destination");
+
+        Selection selection = select(destination);
+
+        // Parse the (prefix-stripped) destination into a URI and fail fast on anything RestTemplate can't use.
+        URI uri;
+        try {
+            uri = URI.create(selection.url());
+            if (!uri.isAbsolute() || uri.getScheme() == null || uri.getHost() == null) {
+                throw new IllegalArgumentException("URL must be an absolute http(s) URI");
+            }
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid incoming-webhook URL after prefix stripping: '{}'", selection.url(), e);
+            return false;
+        }
+
+        // Build the request body from the resolved template via Jackson (never by string concatenation).
+        String body;
+        try {
+            JsonNode template = loadTemplate(selection.templateName());
+            JsonNode rendered = substitute(template, Map.of(
+                    "subject", subject == null ? "" : subject,
+                    "text", text == null ? "" : text));
+            body = objectMapper.writeValueAsString(rendered);
+        } catch (Exception e) {
+            log.error("Failed to build incoming-webhook body from template '{}.json'", selection.templateName(), e);
+            return false;
+        }
+
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-        HttpEntity<Object> httpEntity = new HttpEntity <Object> (body, httpHeaders);
-        URI uri = URI.create(destination);
-        restTemplate.exchange(uri, method, httpEntity, String.class);
+        HttpEntity<Object> httpEntity = new HttpEntity<>(body, httpHeaders);
 
-        return true;
+        try {
+            restTemplate.exchange(uri, HttpMethod.POST, httpEntity, String.class);
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to send incoming webhook to {}", uri, e);
+            return false;
+        }
     }
 
     @Override
     public void sendMessageUsingTemplate(String destination, String subject, String templateModel) {
 
+    }
+
+    /**
+     * Resolves the template name and the real target URL from the destination string.
+     * An explicit {@code [tool]} prefix wins over keyword matching; keyword matching is case-insensitive.
+     */
+    private Selection select(String destination) {
+        String trimmed = destination.trim();
+
+        Matcher prefixMatcher = PREFIX.matcher(trimmed);
+        if (prefixMatcher.matches()) {
+            String tool = prefixMatcher.group(1).toLowerCase();
+            String url = prefixMatcher.group(2).trim();
+            return new Selection(tool, url);
+        }
+
+        // No prefix: use the first template whose file name appears in the URL, else the default.
+        String lower = trimmed.toLowerCase();
+        String template = availableTemplateNames().stream()
+                .filter(lower::contains)
+                .findFirst()
+                .orElse(DEFAULT_TEMPLATE);
+        return new Selection(template, trimmed);
+    }
+
+    /**
+     * Lists the base names of the templates under {@code notification/} (excluding {@code default}),
+     * ordered longest-first. Enumerated from the classpath once and cached for the lifetime of the bean.
+     */
+    private List<String> availableTemplateNames() {
+        List<String> names = templateNames;
+        if (names == null) {
+            synchronized (this) {
+                names = templateNames;
+                if (names == null) {
+                    names = loadTemplateNames();
+                    templateNames = names;
+                }
+            }
+        }
+        return names;
+    }
+
+    private List<String> loadTemplateNames() {
+        try {
+            Resource[] resources = resolver.getResources("classpath*:" + TEMPLATE_DIR + "*.json");
+            return Arrays.stream(resources)
+                    .map(Resource::getFilename)
+                    .filter(Objects::nonNull)
+                    .map(name -> name.substring(0, name.length() - ".json".length()).toLowerCase())
+                    .filter(name -> !DEFAULT_TEMPLATE.equals(name))
+                    .distinct()
+                    .sorted(Comparator.comparingInt(String::length).reversed())
+                    .toList();
+        } catch (IOException e) {
+            log.warn("Could not enumerate webhook templates under {}; only prefix/default selection will work", TEMPLATE_DIR, e);
+            return List.of();
+        }
+    }
+
+    /**
+     * Loads and parses the template at {@code notification/<name>.json}. A missing non-default template
+     * falls back to {@code default.json}; a missing default template is a hard error.
+     */
+    private JsonNode loadTemplate(String name) throws IOException {
+        ClassPathResource resource = new ClassPathResource(TEMPLATE_DIR + name + ".json");
+        if (!resource.exists()) {
+            if (!DEFAULT_TEMPLATE.equals(name)) {
+                log.warn("Webhook template '{}.json' not found; falling back to {}.json", name, DEFAULT_TEMPLATE);
+                return loadTemplate(DEFAULT_TEMPLATE);
+            }
+            throw new FileNotFoundException("Missing default webhook template " + TEMPLATE_DIR + DEFAULT_TEMPLATE + ".json");
+        }
+        try (InputStream in = resource.getInputStream()) {
+            return objectMapper.readTree(in);
+        }
+    }
+
+    /**
+     * Walks the parsed template tree and substitutes placeholders in every textual leaf. Objects and arrays
+     * are rebuilt recursively; numbers/booleans/nulls pass through untouched. Substituted values are stored
+     * as JSON text nodes, so Jackson escapes them correctly when the tree is re-serialised.
+     */
+    private JsonNode substitute(JsonNode node, Map<String, String> values) {
+        if (node.isObject()) {
+            ObjectNode result = objectMapper.createObjectNode();
+            node.fields().forEachRemaining(entry -> result.set(entry.getKey(), substitute(entry.getValue(), values)));
+            return result;
+        }
+        if (node.isArray()) {
+            ArrayNode result = objectMapper.createArrayNode();
+            node.forEach(child -> result.add(substitute(child, values)));
+            return result;
+        }
+        if (node.isTextual()) {
+            return TextNode.valueOf(replacePlaceholders(node.textValue(), values));
+        }
+        return node;
+    }
+
+    /**
+     * Replaces {@code ${name}} placeholders in a single pass so a substituted value can never itself be
+     * re-interpreted as a placeholder. Unknown placeholders are left verbatim.
+     */
+    private String replacePlaceholders(String text, Map<String, String> values) {
+        Matcher matcher = PLACEHOLDER.matcher(text);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            String replacement = values.getOrDefault(matcher.group(1), matcher.group(0));
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private record Selection(String templateName, String url) {
     }
 }

--- a/src/backend/src/main/resources/notification/default.json
+++ b/src/backend/src/main/resources/notification/default.json
@@ -1,0 +1,3 @@
+{
+  "text": "${subject}\n${text}"
+}

--- a/src/backend/src/main/resources/notification/slack.json
+++ b/src/backend/src/main/resources/notification/slack.json
@@ -1,0 +1,18 @@
+{
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": "${subject}"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "${text}"
+      }
+    }
+  ]
+}

--- a/src/backend/src/main/resources/notification/teams.json
+++ b/src/backend/src/main/resources/notification/teams.json
@@ -1,0 +1,27 @@
+{
+  "type": "message",
+  "attachments": [
+    {
+      "contentType": "application/vnd.microsoft.card.adaptive",
+      "content": {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": "${subject}",
+            "wrap": true
+          },
+          {
+            "type": "TextBlock",
+            "text": "${text}",
+            "wrap": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/notification/IncomingWebhookServiceTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/notification/IncomingWebhookServiceTest.java
@@ -1,0 +1,217 @@
+package com.becon.opencelium.backend.unit.execution.notification;
+
+import com.becon.opencelium.backend.execution.notification.IncomingWebhookService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Unit tests for {@link IncomingWebhookService}.
+ * <p>
+ * The service is constructed directly with a plain {@link RestTemplate} bound to a
+ * {@link MockRestServiceServer}; template files are read from {@code src/main/resources/notification}
+ * which is on the test classpath. No Spring context is loaded.
+ */
+@DisplayName("IncomingWebhookService — unit")
+class IncomingWebhookServiceTest {
+
+    private MockRestServiceServer server;
+    private IncomingWebhookService service;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.createServer(restTemplate);
+        service = new IncomingWebhookService(restTemplate, new ObjectMapper());
+    }
+
+    @Nested
+    @DisplayName("template selection")
+    class TemplateSelection {
+
+        @Test
+        @DisplayName("no prefix and no keyword uses default.json ({\"text\": ...})")
+        void sendMessageUsesDefaultTemplateWhenNoPrefixOrKeyword() {
+            server.expect(requestTo("https://hooks.example.com/generic"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(jsonPath("$.text").value("Subject\nBody"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://hooks.example.com/generic", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("URL containing 'slack' selects slack.json")
+        void sendMessageUsesSlackTemplateWhenUrlContainsSlack() {
+            server.expect(requestTo("https://hooks.slack.com/services/T000/B000/xxxx"))
+                    .andExpect(jsonPath("$.blocks[0].text.text").value("Subject"))
+                    .andExpect(jsonPath("$.blocks[1].text.text").value("Body"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://hooks.slack.com/services/T000/B000/xxxx", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("URL containing 'teams' selects teams.json")
+        void sendMessageUsesTeamsTemplateWhenUrlContainsTeams() {
+            server.expect(requestTo("https://outlook.office.com/webhook/teams/abc"))
+                    .andExpect(jsonPath("$.attachments[0].content.body[0].text").value("Subject"))
+                    .andExpect(jsonPath("$.attachments[0].content.body[1].text").value("Body"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://outlook.office.com/webhook/teams/abc", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("URL with a keyword that has no matching template file falls back to default.json")
+        void sendMessageUsesDefaultTemplateWhenKeywordHasNoMatchingTemplateFile() {
+            // 'microsoft' is not a shipped template file name, so this must NOT select teams.json.
+            server.expect(requestTo("https://mydomain.webhook.office.microsoft.com/hook"))
+                    .andExpect(jsonPath("$.text").value("Subject\nBody"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://mydomain.webhook.office.microsoft.com/hook", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("[teams] prefix selects teams.json and is stripped before the POST")
+        void sendMessageStripsPrefixAndUsesTeamsTemplateWhenDestinationHasTeamsPrefix() {
+            // The URL has no 'teams'/'microsoft' keyword, so only the prefix can select teams.json.
+            server.expect(requestTo("https://hooks.example.com/generic"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(jsonPath("$.attachments[0].content.body[0].text").value("Subject"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("[teams]https://hooks.example.com/generic", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("prefix wins over a conflicting keyword in the URL")
+        void sendMessageUsesPrefixTemplateWhenPrefixConflictsWithUrlKeyword() {
+            // URL contains 'slack' but the [teams] prefix must win.
+            server.expect(requestTo("https://hooks.slack.com/services/xxx"))
+                    .andExpect(jsonPath("$.attachments[0].content.body[0].text").value("Subject"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("[teams]https://hooks.slack.com/services/xxx", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("missing template for [foo] prefix falls back to default.json")
+        void sendMessageFallsBackToDefaultTemplateWhenPrefixedTemplateFileMissing() {
+            server.expect(requestTo("https://hooks.example.com/generic"))
+                    .andExpect(jsonPath("$.text").value("Subject\nBody"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("[foo]https://hooks.example.com/generic", "Subject", "Body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("substitution")
+    class Substitution {
+
+        @Test
+        @DisplayName("special characters stay valid JSON with the default template")
+        void sendMessageProducesValidJsonWhenValuesContainSpecialCharsWithDefaultTemplate() {
+            String subject = "he said \"hi\"";
+            String body = "path\\to\\file\nnew line";
+
+            server.expect(requestTo("https://hooks.example.com/generic"))
+                    // jsonPath parsing only succeeds if the delivered body is valid JSON.
+                    .andExpect(jsonPath("$.text").value(subject + "\n" + body))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://hooks.example.com/generic", subject, body);
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("special characters stay valid JSON with the slack template")
+        void sendMessageProducesValidJsonWhenValuesContainSpecialCharsWithSlackTemplate() {
+            String subject = "quote \" and backslash \\";
+            String body = "line1\nline2 — unicode ✓";
+
+            server.expect(requestTo("https://hooks.slack.com/services/xxx"))
+                    .andExpect(jsonPath("$.blocks[0].text.text").value(subject))
+                    .andExpect(jsonPath("$.blocks[1].text.text").value(body))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://hooks.slack.com/services/xxx", subject, body);
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("a subject that itself looks like a placeholder is not re-substituted")
+        void sendMessageDoesNotReSubstituteWhenValueLooksLikePlaceholder() {
+            server.expect(requestTo("https://hooks.example.com/generic"))
+                    .andExpect(jsonPath("$.text").value("${text}\nActual body"))
+                    .andRespond(withSuccess());
+
+            boolean sent = service.sendMessage("https://hooks.example.com/generic", "${text}", "Actual body");
+
+            assertThat(sent).isTrue();
+            server.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("invalid destinations")
+    class InvalidDestinations {
+
+        @Test
+        @DisplayName("a destination that is not a valid URI is handled without reaching RestTemplate")
+        void sendMessageReturnsFalseWhenUriIsInvalidAfterPrefixStripping() {
+            // No server expectation registered: any HTTP call would fail the test.
+            boolean sent = service.sendMessage("[teams]http://has a space/hook", "Subject", "Body");
+
+            assertThat(sent).isFalse();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("a relative URL (no scheme/host) after stripping is rejected")
+        void sendMessageReturnsFalseWhenUrlIsRelativeAfterPrefixStripping() {
+            boolean sent = service.sendMessage("[teams]not-a-url", "Subject", "Body");
+
+            assertThat(sent).isFalse();
+            server.verify();
+        }
+    }
+}


### PR DESCRIPTION
## What

- `IncomingWebhookService` no longer hand-concatenates JSON. It loads a body template from the classpath (`resources/notification/<name>.json`).
- **Template selection from the destination**:
  1. Explicit `[tool]` prefix (e.g. `[teams]https://…`) → `<tool>.json`; the prefix is **stripped** before the POST.
  2. No prefix → the URL is scanned against the **names of the template files that actually exist** under `notification/` 

## Why
Closes OC-1486.

## How to test
```bash
# The change under test — unit tests, no Docker
./gradlew test --tests "*.IncomingWebhookServiceTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `IncomingWebhookServiceTest`
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
