### PR TITLE
OC-1492: Reject connections with empty IF/LOOP operator expressions at save time

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionConstant.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionConstant.java
@@ -53,6 +53,7 @@ public interface ExceptionConstant {
     // ----------------------------------------- Connection ----------------------------------------------- //
     String CONNECTION_NOT_FOUND = "CONNECTION_NOT_FOUND";
     String CONCURRENT_TEST_IS_FORBIDDEN = "CONCURRENT_TEST_IS_FORBIDDEN";
+    String OPERATOR_EXPRESSION_IS_EMPTY = "OPERATOR_EXPRESSION_IS_EMPTY";
 
     // ----------------------------------------- Enhancement ----------------------------------------------- //
     String ENHANCEMENT_NOT_FOUND = "ENHANCEMENT_NOT_FOUND";

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
@@ -16,6 +16,7 @@ public interface ExceptionMessages {
     String ONLY_OWNER_CAN_PERFORM_ACTION = "Only owner can perform this action";
     String ONLY_OWNER_OR_ADMIN_CAN_PERFORM_ACTION = "Only owner or admin can perform this action";
     String FROM_CONNECTOR_IS_NULL = "fromConnector is null";
+    String OPERATOR_EXPRESSION_IS_EMPTY = "Operator (index=%s, type=%s) has null or empty expression";
     String METHOD_NAME_MUST_BE_NON_NULL = "Method name must not be null";
     String SCHEDULER_NOT_FOUND = "Scheduler not found";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
@@ -32,18 +32,20 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
     private final OpenceliumProps ocProps;
     private final ConnectionMngMapper connectionMngMapper;
     private final EntityUpdater<ConnectionMng> connectionMngEntityUpdater;
+    private final OperatorMngService operatorMngService;
 
     public ConnectionMngServiceImp(
             ConnectionMngRepository connectionMngRepository,
             @Qualifier("fieldBindingMngServiceImp") FieldBindingMngService fieldBindingMngService,
             OpenceliumProps ocProps, ConnectionMngMapper connectionMngMapper,
-            EntityVersionManager entityVersionManager
+            EntityVersionManager entityVersionManager, OperatorMngService operatorMngService
     ) {
         this.connectionMngRepository = connectionMngRepository;
         this.fieldBindingMngService = fieldBindingMngService;
         this.ocProps = ocProps;
         this.connectionMngMapper = connectionMngMapper;
         this.connectionMngEntityUpdater = entityVersionManager.getUpdater(ConnectionMng.class);
+        this.operatorMngService = operatorMngService;
     }
 
     @Override
@@ -201,6 +203,20 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
 
         if (connectionMng.getToConnector() != null && connectionMng.getToConnector().getMethods() != null) {
             validateMethods(connectionMng.getToConnector().getMethods());
+        }
+
+        if (connectionMng.getFromConnector() != null && connectionMng.getFromConnector().getOperators() != null) {
+            validateOperators(connectionMng.getFromConnector().getOperators());
+        }
+
+        if (connectionMng.getToConnector() != null && connectionMng.getToConnector().getOperators() != null) {
+            validateOperators(connectionMng.getToConnector().getOperators());
+        }
+    }
+
+    private void validateOperators(List<OperatorMng> operators) {
+        for (OperatorMng operator : operators) {
+            operatorMngService.validate(operator);
         }
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/OperatorMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/OperatorMngServiceImp.java
@@ -1,8 +1,12 @@
 package com.becon.opencelium.backend.database.mongodb.service;
 
+import com.becon.opencelium.backend.constant.ExceptionConstant;
+import com.becon.opencelium.backend.constant.ExceptionMessages;
 import com.becon.opencelium.backend.database.mongodb.entity.OperatorMng;
+import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.ocel.OCExpressionHelper;
 import com.becon.opencelium.backend.ocel.Validator;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +24,7 @@ public class OperatorMngServiceImp implements OperatorMngService {
 
     @Override
     public void validate(OperatorMng operator) {
-        validateExpression(operator.getExpression(), operator.getType());
+        validateExpression(operator);
     }
 
     @Override
@@ -35,11 +39,18 @@ public class OperatorMngServiceImp implements OperatorMngService {
         mongoTemplate.dropCollection("operator");
     }
 
-    private void validateExpression(String exp, String type) {
-        if ("if".equals(type)) {
-            ocelValidator.validate(exp);
+    private void validateExpression(OperatorMng operator) {
+        if (StringUtils.isBlank(operator.getExpression())) {
+            throw new GeneralServiceException(
+                    ExceptionConstant.OPERATOR_EXPRESSION_IS_EMPTY,
+                    String.format(ExceptionMessages.OPERATOR_EXPRESSION_IS_EMPTY, operator.getIndex(), operator.getType())
+            );
+        }
+
+        if ("if".equals(operator.getType())) {
+            ocelValidator.validate(operator.getExpression());
         } else {
-            OCExpressionHelper.validateLoopExp(exp);
+            OCExpressionHelper.validateLoopExp(operator.getExpression());
         }
     }
 }


### PR DESCRIPTION
## What
Validate operator expressions when a connection is created:
`ConnectionMngServiceImp.create()` now walks every operator of both connectors and delegates to `OperatorMngService.validate()`.
A null, empty or whitespace-only expression is rejected whose message names the offending operator's index and type. Non-blank expressions are then syntax-checked: OCEL validator for IF operators, `validateLoopExp` for LOOP operators.

## Why
Closes OC-1492.

## How to test
```bash
./gradlew test

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed