### PR TITLE
Fix name conflict of connection_history's fk on connection table

### DIFF
--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -387,7 +387,7 @@ alter table enhancement change expert_var variables text;
 alter table connection change name title varchar(128);
 
 --changeset 4.0:9 runOnChange:true stripComments:true splitStatements:true endDelimiter:;
-create table connection_history(
+create table if not exists connection_history(
     id BIGINT AUTO_INCREMENT PRIMARY KEY ,
     connection_id INT(11) NOT NULL ,
     user_id INT(11) NOT NULL,
@@ -395,21 +395,12 @@ create table connection_history(
     created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     json_patch JSON,
     action  VARCHAR(45),
-    FOREIGN KEY (connection_id) REFERENCES connection(id),
+    CONSTRAINT fk_connection_history_connection FOREIGN KEY (connection_id) REFERENCES connection(id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES user(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --changeset 4.0:10 runOnChange:true stripComments:true splitStatements:true endDelimiter:;
 alter table enhancement change variables args text;
-
---changeset 4.0:11 runOnChange:true stripComments:true splitStatements:true endDelimiter:;
-alter table connection_history
-    drop foreign key connection_history_ibfk_1;
-
-alter table connection_history
-    add constraint connection_history_ibfk_1
-        foreign key (connection_id) references connection (id)
-            on delete cascade;
 
 --changeset 4.0:12 runOnChange:true stripComments:true splitStatements:true endDelimiter:;
 CREATE TABLE category (


### PR DESCRIPTION
## What
Create the `connection_history.connection_id` foreign key with `ON DELETE CASCADE` directly in its table-creation changeset, and drop the follow-up changeset that used to add the cascade afterwards.

- `4.0:9` — `connection_history` is now created with `FOREIGN KEY (connection_id) REFERENCES connection(id) ON DELETE CASCADE`, and the statement is guarded with `CREATE TABLE IF NOT EXISTS`.
- `4.0:11` — removed. It previously did `drop foreign key connection_history_ibfk_1;` + re-add with cascade; it is no longer needed and was unsafe (see Why).

## Why
`connection_history` is an audit table that JPA does not map on `Connection`, so its rows are only ever removed by a database-level `ON DELETE CASCADE`. Without it, deleting a connection that has history rows fails with:

```
Cannot delete or update a parent row: a foreign key constraint fails
(`opencelium`.`connection_history`, CONSTRAINT `...` FOREIGN KEY (`connection_id`) REFERENCES `connection` (`id`))
```

**Root cause — engine-dependent foreign-key names**. The FK in `4.0:9` is declared **without an explicit `CONSTRAINT` name**, so the database engine invents one. That generated name is not defined by the SQL standard and is **not portable across engine versions**:

- MySQL / older MariaDB name it `connection_history_ibfk_1` (the classic InnoDB `<table>_ibfk_<N>` convention).
- Newer MariaDB names it `1`.

**Scope — fresh installs.** `CREATE TABLE IF NOT EXISTS` makes the `runOnChange` re-execution of `4.0:9` a harmless no-op on existing databases (their table already exists), and existing installs already have `4.0:11` recorded in `DATABASECHANGELOG`, so removing it neither re-runs nor reverts anything for them. Existing databases that currently lack the cascade are intentionally **not** modified by this change.

## Checklist
- [x] Self-reviewed the diff
- [x] Migration applies cleanly on a fresh schema
- [x] Safe for existing installs (`IF NOT EXISTS` no-op; removed changeset already recorded)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed