### PR TITLE
OC-1499: add scheduled TestConnectionSweeper to permanently delete leftover test connections

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/configuration/StorageConfiguration.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/configuration/StorageConfiguration.java
@@ -143,9 +143,6 @@ public class StorageConfiguration {
             changeSetDao.createAll(YAMLMigrator.getChangeSetsToSave());
         }
 
-        // removes connections that contain prefix in their names !*test_connection_
-        connectionService.cleanupAllTestConnections(Set.of());
-
         // deleting old version zip files
         cleanOldFiles(PathConstant.ASSISTANT + PathConstant.VERSIONS, File::isDirectory, "");
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/TestConnectionSweeper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/TestConnectionSweeper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.scheduler;
+
+import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectionServiceImp.CleanupResult;
+import com.becon.opencelium.backend.database.mysql.service.SchedulerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Periodic sweeper that permanently removes leftover <em>test</em> connections.
+ */
+@Component
+public class TestConnectionSweeper {
+    private static final Logger log = LoggerFactory.getLogger(TestConnectionSweeper.class);
+
+    private final ConnectionService connectionService;
+    private final SchedulerService schedulerService;
+    private final boolean enabled;
+
+    public TestConnectionSweeper(
+            @Qualifier("connectionServiceImp") ConnectionService connectionService,
+            @Qualifier("schedulerServiceImp") SchedulerService schedulerService,
+            @Value("${opencelium.sweeper.test-connection.enabled:true}") boolean enabled
+    ) {
+        this.connectionService = connectionService;
+        this.schedulerService = schedulerService;
+        this.enabled = enabled;
+    }
+
+    @Scheduled(
+            fixedDelayString = "${opencelium.sweeper.test-connection.fixed-delay:300000}",
+            initialDelayString = "${opencelium.sweeper.test-connection.initial-delay:0}"
+    )
+    public void sweep() {
+        if (!enabled) {
+            return;
+        }
+        Set<Long> running = schedulerService.getRunningConnectionIds();
+        CleanupResult result = connectionService.cleanupAllTestConnections(running);
+        log.info(
+                "Test connection sweep completed: candidates={}, mongoDeleted={}, sqlDeleted={}",
+                result.candidateSqlIds(),
+                result.mongoDeleted(),
+                result.sqlDeleted()
+        );
+    }
+}

--- a/src/backend/src/main/resources/application_default.yml
+++ b/src/backend/src/main/resources/application_default.yml
@@ -211,6 +211,21 @@ opencelium:
       keep: 10
   ###########################################################################
   #                                                                         #
+  #   Sweepers                                                              #
+  #                                                                         #
+  #   test-connection — permanently removes leftover test connections       #
+  #     enabled       — turn the sweeper on/off (default: true)             #
+  #     fixed-delay   — ms between runs, non-overlapping (default: 1h)      #
+  #     initial-delay — ms before the first run; 0 also cleans at startup   #
+  #                                                                         #
+  ###########################################################################
+  sweeper:
+    test-connection:
+      enabled: true
+      fixed-delay: 300000
+      initial-delay: 0
+  ###########################################################################
+  #                                                                         #
   #   Is customizable                                                       #
   #                                                                         #
   ###########################################################################

--- a/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
+++ b/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
@@ -232,3 +232,15 @@ versions:
         operation: add
         value: 10
         path: opencelium.config.backup.keep
+      - changeset: 5
+        operation: add
+        value: true
+        path: opencelium.sweeper.test-connection.enabled
+      - changeset: 6
+        operation: add
+        value: 300000
+        path: opencelium.sweeper.test-connection.fixed-delay
+      - changeset: 7
+        operation: add
+        value: 0
+        path: opencelium.sweeper.test-connection.initial-delay

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/scheduler/TestConnectionSweeperTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/scheduler/TestConnectionSweeperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.scheduler;
+
+import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectionServiceImp.CleanupResult;
+import com.becon.opencelium.backend.database.mysql.service.SchedulerService;
+import com.becon.opencelium.backend.scheduler.TestConnectionSweeper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestConnectionSweeperTest {
+
+    @Mock
+    private ConnectionService connectionService;
+
+    @Mock
+    private SchedulerService schedulerService;
+
+    @Test
+    void sweepDelegatesToCleanupWithRunningIds() {
+        // GIVEN two tests are currently running
+        Set<Long> running = Set.of(100L, 101L);
+        when(schedulerService.getRunningConnectionIds()).thenReturn(running);
+        when(connectionService.cleanupAllTestConnections(running)).thenReturn(new CleanupResult(3, 3, 3));
+
+        // WHEN the scheduled sweep fires
+        new TestConnectionSweeper(connectionService, schedulerService, true).sweep();
+
+        // THEN cleanup runs with exactly the running-ids guard, so active tests are never deleted
+        verify(schedulerService).getRunningConnectionIds();
+        verify(connectionService).cleanupAllTestConnections(running);
+    }
+
+    @Test
+    void sweepDoesNothingWhenDisabled() {
+        new TestConnectionSweeper(connectionService, schedulerService, false).sweep();
+
+        verifyNoInteractions(connectionService, schedulerService);
+    }
+}


### PR DESCRIPTION
## What
Added `TestConnectionSweeper`, a scheduled job that permanently deletes leftover test connections and everything they own — Mongo documents, schedulers, and the schedulers' Quartz jobs and triggers. It delegates to the existing `ConnectionService.cleanupAllTestConnections(runningIds)` and passes `SchedulerService.getRunningConnectionIds()` as the guard, so a test that is still running is never deleted. The run interval is configurable and it also runs once shortly after startup to clean leftovers from a crash or restart.

Removed `connectionService.cleanupAllTestConnections(Set.of())` statement on `StorageConfiguration` since it is no longer needed(`TestConnectionSweeper` does it)

### How it works
- **Trigger** — `@Scheduled(fixedDelay, initialDelay)`. `fixed-delay` keeps runs non-overlapping; `initial-delay: 0` gives the startup pass.
- **Config** — `opencelium.sweeper.test-connection.{enabled,fixed-delay,initial-delay}` in `application_default.yml`, seeded via  `application_changelog.yml` (changesets 5–7). Defaults: enabled, 300000 ms (5 min), 0.

## Why
Closes OC-1499.

## How to test
```bash
# Unit test
./gradlew test --tests "*.TestConnectionSweeperTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `TestConnectionSweeperTest`
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed