### PR TITLE
OC-1498: Excluded test schedulers on get-all endpoint & Encapsulated test titles logic

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/configuration/StorageConfiguration.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/configuration/StorageConfiguration.java
@@ -143,7 +143,7 @@ public class StorageConfiguration {
             changeSetDao.createAll(YAMLMigrator.getChangeSetsToSave());
         }
 
-        // removes connections that contain prefix in their names !*test_connection_
+        // removes all test connections
         connectionService.cleanupAllTestConnections(Set.of());
 
         // deleting old version zip files

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/RegExpression.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/RegExpression.java
@@ -17,4 +17,5 @@ public interface RegExpression {
     String array = "\\[.*\\]";
     String referencePath = "(body\\.\\$\\..+)|(header\\.\\$\\..+)|(path)";
     String TEST_CONNECTION_REGEX = "^!\\*test_connection_\\d+_.+";
+    String TEST_SCHEDULE_REGEX = "^!\\*test_schedule_\\d+_.+";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -16,7 +16,6 @@
 
 package com.becon.opencelium.backend.controller;
 
-import com.becon.opencelium.backend.commons.FileDescriptor;
 import com.becon.opencelium.backend.configuration.cutomizer.RestCustomizer;
 import com.becon.opencelium.backend.constant.AppYamlPath;
 import com.becon.opencelium.backend.constant.Constant;
@@ -46,7 +45,7 @@ import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.becon.opencelium.backend.resource.request.SchedulerRequestResource;
 import com.becon.opencelium.backend.resource.schedule.SchedulerResource;
 import com.becon.opencelium.backend.resource.webhook.WebhookParamDTO;
-import com.becon.opencelium.backend.utility.LogFileUtility;
+import com.becon.opencelium.backend.utility.TestNameUtils;
 import com.becon.opencelium.backend.utility.patch.PatchHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -429,14 +428,14 @@ public class ConnectionController {
         // check if there is no running job for given connection
         schedulerService.getAllRunningJobs().forEach(job -> {
             String schedulerTitle = job.getTitle();
-            if (schedulerTitle.startsWith("!*test_schedule_") && schedulerTitle.endsWith(connectionOldDTO.getTitle())) {
+            if (TestNameUtils.isTestScheduler(schedulerTitle, connectionOldDTO.getTitle())) {
                 throw new ConcurrentTestIsForbidden(0L);
             }
         });
 
-        // create temporary connection, will be deleted after execution finished
-        String postfix = System.currentTimeMillis() + "_" + connectionOldDTO.getTitle();
-        connectionOldDTO.setTitle("!*test_connection_" + postfix);
+        String title = connectionOldDTO.getTitle();
+
+        connectionOldDTO.setTitle(TestNameUtils.generateTestConnectionName(title));
         ConnectionDTO connectionDTO = connectionOldDTOMapper.toEntity(connectionOldDTO);
         Connection connection = connectionMapper.toEntity(connectionDTO);
         ConnectionMng connectionMng = connectionMngMapper.toEntity(connectionDTO);
@@ -445,7 +444,7 @@ public class ConnectionController {
         // create temporary scheduler for above connection, will be deleted after execution finished
         SchedulerRequestResource resource = new SchedulerRequestResource();
         resource.setConnectionId(connectionId);
-        resource.setTitle("!*test_schedule_" + postfix);
+        resource.setTitle(TestNameUtils.generateTestSchedulerName(title));
         resource.setStatus(true);
         resource.setCronExp(Constant.NEVER_TRIGGERED_CRON);
         resource.setDebugMode(true);
@@ -751,8 +750,7 @@ public class ConnectionController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Removes all leftover test connections (titles prefixed with !*test_connection_). " +
-            "Any test connection currently running is excluded from deletion.")
+    @Operation(summary = "Removes all leftover test connections. Any test connection currently running is excluded from deletion.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
                     description = "Test connections have been cleaned up",

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/SchedulerController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/SchedulerController.java
@@ -75,7 +75,7 @@ public class SchedulerController {
     })
     @GetMapping("/all")
     public ResponseEntity<List<SchedulerResource>> getAll() throws Exception {
-        List<Scheduler> schedulers = schedulerService.findAll();
+        List<Scheduler> schedulers = schedulerService.excludeTestSchedulers(schedulerService.findAll());
         List<SchedulerResource> scheduleList = schedulers.stream()
             .map(s -> schedulerService.toResource(s)).collect(Collectors.toList());
 
@@ -100,7 +100,7 @@ public class SchedulerController {
     })
     @PostMapping("/all/by-ids")
     public ResponseEntity<List<SchedulerResource>> getAllByIds(@RequestBody IdentifiersDTO<Integer> ids) {
-        List<Scheduler> schedulers = schedulerService.findAllById(ids.getIdentifiers());
+        List<Scheduler> schedulers = schedulerService.excludeTestSchedulers(schedulerService.findAllById(ids.getIdentifiers()));
 
         List<SchedulerResource> scheduleList = schedulers.stream()
                 .map(s -> schedulerService.toResource(s, Boolean.FALSE))
@@ -464,7 +464,7 @@ public class SchedulerController {
     @PostMapping(value = "/list/get", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<SchedulerResource>> getSchedulersByIds(@RequestBody IdentifiersDTO<Integer> payload){
         ArrayList<Integer> schedulerIds = payload.getIdentifiers();
-        List<Scheduler> schedulers = schedulerService.findAllById(schedulerIds);
+        List<Scheduler> schedulers = schedulerService.excludeTestSchedulers(schedulerService.findAllById(schedulerIds));
         List<SchedulerResource> scheduleList = schedulers.stream()
                 .map(sch -> schedulerService.toResource(sch)).collect(Collectors.toList());
         return ResponseEntity.ok(scheduleList);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
@@ -47,8 +47,7 @@ public interface ConnectionService {
     List<Connection> findAll();
 
     /**
-     * @param includeTest when {@code false}, test connections (titles matching
-     *                    {@code !*test_connection_...}) are excluded from the result
+     * @param includeTest when {@code false}, test connections are excluded from the result
      */
     List<Connection> findAll(Boolean includeTest);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -41,6 +41,7 @@ import com.becon.opencelium.backend.resource.connection.ConnectorDTO;
 import com.becon.opencelium.backend.resource.connection.masking.RuleDTO;
 import com.becon.opencelium.backend.resource.webhook.WebhookParamDTO;
 import com.becon.opencelium.backend.utility.LogFileUtility;
+import com.becon.opencelium.backend.utility.TestNameUtils;
 import com.becon.opencelium.backend.utility.patch.PatchHelper;
 import com.becon.opencelium.backend.versionmanager.EntityUpdater;
 import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
@@ -521,7 +522,7 @@ public class ConnectionServiceImp implements ConnectionService {
 
         for (Long id : ids) {
             Connection connection = getById(id);
-            if (Utils.compare(targetVersion, connection.getOcVersion()) > 0 && !isTestConnection(connection.getTitle())) {
+            if (Utils.compare(targetVersion, connection.getOcVersion()) > 0 && TestNameUtils.isNotTestConnection(connection.getTitle())) {
 
                 List<ConnectionMng> connections = connectionMngService.getAllByConnectionIdRaw(connection.getId());
                 if (connections.isEmpty()) {
@@ -677,15 +678,14 @@ public class ConnectionServiceImp implements ConnectionService {
     }
 
     /**
-     * Returns {@code connections} as-is when {@code includeTest} is true; otherwise drops every test
-     * connection (title matching {@code !*test_connection_...}).
+     * Returns {@code connections} as-is when {@code includeTest} is true; otherwise drops every test connection
      */
     private List<Connection> excludeTestIfNeeded(List<Connection> connections, Boolean includeTest) {
         if (Boolean.TRUE.equals(includeTest) || connections == null || connections.isEmpty()) {
             return connections;
         }
         return connections.stream()
-                .filter(c -> !isTestConnection(c.getTitle()))
+                .filter(c -> TestNameUtils.isNotTestConnection(c.getTitle()))
                 .toList();
     }
 
@@ -714,7 +714,7 @@ public class ConnectionServiceImp implements ConnectionService {
                 log.info("Skipping deletion of connection id={}: already removed", id);
                 continue;
             }
-            if (running.contains(id) && isTestConnection(connection.get().getTitle())) {
+            if (running.contains(id) && TestNameUtils.isTestConnection(connection.get().getTitle())) {
                 log.info("Skipping deletion of running test connection id={}", id);
                 continue;
             }
@@ -742,10 +742,6 @@ public class ConnectionServiceImp implements ConnectionService {
     // --------------------------------------------------------------------------------------------------------------------------------------------------------
     // private methods
     // --------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    private boolean isTestConnection(String title) {
-        return title != null && title.matches(RegExpression.TEST_CONNECTION_REGEX);
-    }
 
     private String resolveVersion(Connection connection) {
         return connection.getToConnector() == null

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerService.java
@@ -48,6 +48,8 @@ public interface SchedulerService {
     List<Scheduler> findAllById(ArrayList<Integer> ids);
     List<Scheduler> findAllByTitleContains(String title);
 
+    List<Scheduler> excludeTestSchedulers(List<Scheduler> schedulers);
+
     Scheduler toEntity(SchedulerRequestResource resource);
     SchedulerResource toResource(Scheduler entity);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/SchedulerServiceImp.java
@@ -36,6 +36,7 @@ import com.becon.opencelium.backend.resource.request.SchedulerRequestResource;
 import com.becon.opencelium.backend.resource.schedule.RunningJob;
 import com.becon.opencelium.backend.resource.schedule.RunningJobsResource;
 import com.becon.opencelium.backend.resource.schedule.SchedulerResource;
+import com.becon.opencelium.backend.utility.TestNameUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.NonNull;
@@ -145,6 +146,13 @@ public class SchedulerServiceImp implements SchedulerService {
     @Override
     public List<Scheduler> findAllByTitleContains(String title) {
         return schedulerRepository.findAllByTitleContains(title);
+    }
+
+    @Override
+    public List<Scheduler> excludeTestSchedulers(List<Scheduler> schedulers) {
+        return schedulers.stream()
+                .filter(s -> TestNameUtils.isNotTestScheduler(s.getTitle()))
+                .toList();
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/gc/connection/ConnectionGCRunner.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/gc/connection/ConnectionGCRunner.java
@@ -6,6 +6,7 @@ import com.becon.opencelium.backend.gc.base.GCRunner;
 import com.becon.opencelium.backend.gc.base.RunGCEvent;
 import com.becon.opencelium.backend.gc.base.strategy.StrategyConfig;
 import com.becon.opencelium.backend.gc.base.strategy.TriggerStrategyFactory;
+import com.becon.opencelium.backend.utility.TestNameUtils;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
@@ -62,8 +63,7 @@ public class ConnectionGCRunner extends GCRunner<ConnectionForGC> {
 
     private Criteria<ConnectionForGC> setCriteria() {
         return Criteria.<ConnectionForGC>builder()
-                .and(c -> c.getConnection().getTitle() != null)
-                .and(c -> !c.getConnection().getTitle().matches("!\\*test_connection_[0-9]{13}.*"))
+                .and(x -> TestNameUtils.isNotTestConnection(x.getConnection().getTitle()))
                 .build();
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/quartz/JobExecutor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/quartz/JobExecutor.java
@@ -27,6 +27,7 @@ import com.becon.opencelium.backend.execution.service.ExecutionObjectServiceImp;
 import com.becon.opencelium.backend.execution.socket.WebSocketNotificationService;
 import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.becon.opencelium.backend.resource.execution.ExecutionObj;
+import com.becon.opencelium.backend.utility.TestNameUtils;
 import org.quartz.InterruptableJob;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -106,7 +107,7 @@ public class JobExecutor extends QuartzJobBean implements InterruptableJob {
 
             // increments current_usage in subscription and saves entity in current_usage_history.
             String connectionName = executionObj.getConnection().getConnectionName();
-            if (connectionName != null && !connectionName.contains("!*test_connection_") && data.getExecType() != QuartzJobScheduler.TriggerType.SUPPORT_FILE) {
+            if (TestNameUtils.isNotTestConnection(connectionName) && data.getExecType() != QuartzJobScheduler.TriggerType.SUPPORT_FILE) {
                 long operationUsage = executor.getOperations().stream().mapToInt(o -> o.getRequests().size()).sum();
                 logger.info("Operation usage for Connection {} is {}", connectionName, operationUsage);
                 subscriptionService.updateUsage(activeSub.getId(), executionObj.getConnection(), operationUsage, startTime);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/TestNameUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/TestNameUtils.java
@@ -1,0 +1,42 @@
+package com.becon.opencelium.backend.utility;
+
+import com.becon.opencelium.backend.constant.RegExpression;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
+
+public class TestNameUtils {
+
+    private static final String TEST_CONN_PREFIX = "!*test_connection_";
+    private static final String TEST_SCHEDULE_PREFIX = "!*test_schedule_";
+    private static final String TEST_SCHEDULE_PREFIX_RGX = "^!\\*test_schedule_\\d+_";
+    private static final Pattern TEST_CONNECTION_PATTERN = Pattern.compile(RegExpression.TEST_CONNECTION_REGEX);
+    private static final Pattern TEST_SCHEDULER_PATTERN = Pattern.compile(RegExpression.TEST_SCHEDULE_REGEX);
+
+    private TestNameUtils() {
+    }
+
+    public static String generateTestConnectionName(String title) {
+        return TEST_CONN_PREFIX + System.currentTimeMillis() + "_" + (title == null ? StringUtils.EMPTY : title);
+    }
+
+    public static String generateTestSchedulerName(String title) {
+        return TEST_SCHEDULE_PREFIX + System.currentTimeMillis() + "_" + (title == null ? StringUtils.EMPTY : title);
+    }
+
+    public static boolean isTestConnection(String title) {
+        return title != null && TEST_CONNECTION_PATTERN.matcher(title).matches();
+    }
+
+    public static boolean isNotTestConnection(String title) {
+        return title != null && !TEST_CONNECTION_PATTERN.matcher(title).matches();
+    }
+
+    public static boolean isTestScheduler(String title, String postfix) {
+        return title != null && title.matches(TEST_SCHEDULE_PREFIX_RGX + postfix);
+    }
+
+    public static boolean isNotTestScheduler(String title) {
+        return title != null && !TEST_SCHEDULER_PATTERN.matcher(title).matches();
+    }
+}


### PR DESCRIPTION
## What
Hide test **schedulers** from the scheduler list endpoints, and centralize all test-connection / test-scheduler naming logic in one utility.

- **Scheduler lists exclude test schedulers.** `GET /scheduler/all`, `POST /scheduler/all/by-ids` and `POST /scheduler/list/get` now drop schedulers whose title matches the test-schedule pattern, via the new `SchedulerService.excludeTestSchedulers(...)`. Fetching a single scheduler by id (`GET /scheduler/{id}`) is unchanged.
- **New `TestNameUtils` utility** encapsulates both *generating* and *detecting* test names.
- New `RegExpression.TEST_SCHEDULE_REGEX` (`^!\*test_schedule_\d+_.+`).
- Replaced the scattered, hand-rolled checks with `TestNameUtils` across the codebase:

## Why
Closes OC-1498.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed