### PR TITLE
OC-1499: Change default fixed-delay for connection sweeper

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/TestConnectionSweeper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/TestConnectionSweeper.java
@@ -42,7 +42,7 @@ public class TestConnectionSweeper {
     }
 
     @Scheduled(
-            fixedDelayString = "${opencelium.sweeper.test-connection.fixed-delay:300000}",
+            fixedDelayString = "${opencelium.sweeper.test-connection.fixed-delay:900000}",
             initialDelayString = "${opencelium.sweeper.test-connection.initial-delay:0}"
     )
     public void sweep() {

--- a/src/backend/src/main/resources/application_default.yml
+++ b/src/backend/src/main/resources/application_default.yml
@@ -222,7 +222,7 @@ opencelium:
   sweeper:
     test-connection:
       enabled: true
-      fixed-delay: 300000
+      fixed-delay: 900000
       initial-delay: 0
   ###########################################################################
   #                                                                         #

--- a/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
+++ b/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
@@ -238,7 +238,7 @@ versions:
         path: opencelium.sweeper.test-connection.enabled
       - changeset: 6
         operation: add
-        value: 300000
+        value: 900000
         path: opencelium.sweeper.test-connection.fixed-delay
       - changeset: 7
         operation: add


### PR DESCRIPTION
## What
- Changed default `fixed-delay` for `TestConnectionSweeper` from `5 min` to `15 min`

## Why
Part of OC-1499


## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed