### PR TITLE
OC-1503: Validate method connector and invoker before saving connection

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
@@ -19,4 +19,8 @@ public interface ExceptionMessages {
     String OPERATOR_EXPRESSION_IS_EMPTY = "Operator (index=%s, type=%s) has null or empty expression";
     String METHOD_NAME_MUST_BE_NON_NULL = "Method name must not be null";
     String SCHEDULER_NOT_FOUND = "Scheduler not found";
+    String METHOD_CONNECTOR_NOT_FOUND = "Connector (id=%s) referenced by Method (name=%s, index=%s) does not exist. Please select an existing connector.";
+    String METHOD_INVOKER_NOT_FOUND = "Invoker '%s' referenced by Method (name=%s, index=%s) was not found. Put the invoker XML file into '%s' and restart the application.";
+    String METHOD_CONNECTOR_REQUIRED = "Method (name=%s, index=%s) MUST have connector";
+    String METHOD_INVOKER_AND_CONNECTOR_NOT_MATCH = "Invoker '%s' and Connector '%s' referenced by Method (name=%s, index=%s) don't match each other";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
@@ -2,13 +2,14 @@ package com.becon.opencelium.backend.database.mongodb.service;
 
 import com.becon.opencelium.backend.constant.ExceptionConstant;
 import com.becon.opencelium.backend.constant.ExceptionMessages;
+import com.becon.opencelium.backend.constant.PathConstant;
 import com.becon.opencelium.backend.constant.props.OpenceliumProps;
-import com.becon.opencelium.backend.database.mongodb.entity.ConnectionMng;
-import com.becon.opencelium.backend.database.mongodb.entity.FieldBindingMng;
-import com.becon.opencelium.backend.database.mongodb.entity.MethodMng;
-import com.becon.opencelium.backend.database.mongodb.entity.OperatorMng;
+import com.becon.opencelium.backend.database.mongodb.entity.*;
 import com.becon.opencelium.backend.database.mongodb.repository.ConnectionMngRepository;
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
+import com.becon.opencelium.backend.invoker.service.InvokerService;
 import com.becon.opencelium.backend.mapper.mongo.ConnectionMngMapper;
 import com.becon.opencelium.backend.resource.connection.ConnectionVersionUpdateRequest;
 import com.becon.opencelium.backend.versionmanager.EntityUpdater;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 public class ConnectionMngServiceImp implements ConnectionMngService {
@@ -33,19 +35,26 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
     private final ConnectionMngMapper connectionMngMapper;
     private final EntityUpdater<ConnectionMng> connectionMngEntityUpdater;
     private final OperatorMngService operatorMngService;
+    private final ConnectorService connectorService;
+    private final InvokerService invokerService;
 
     public ConnectionMngServiceImp(
             ConnectionMngRepository connectionMngRepository,
             @Qualifier("fieldBindingMngServiceImp") FieldBindingMngService fieldBindingMngService,
-            OpenceliumProps ocProps, ConnectionMngMapper connectionMngMapper,
-            EntityVersionManager entityVersionManager, OperatorMngService operatorMngService
-    ) {
+            OpenceliumProps ocProps,
+            ConnectionMngMapper connectionMngMapper,
+            EntityVersionManager entityVersionManager,
+            OperatorMngService operatorMngService,
+            ConnectorService connectorService,
+            InvokerService invokerService) {
         this.connectionMngRepository = connectionMngRepository;
         this.fieldBindingMngService = fieldBindingMngService;
         this.ocProps = ocProps;
         this.connectionMngMapper = connectionMngMapper;
         this.connectionMngEntityUpdater = entityVersionManager.getUpdater(ConnectionMng.class);
         this.operatorMngService = operatorMngService;
+        this.connectorService = connectorService;
+        this.invokerService = invokerService;
     }
 
     @Override
@@ -222,9 +231,61 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
 
     private void validateMethods(List<MethodMng> methods) {
         for (MethodMng method : methods) {
-            if (StringUtils.isBlank(method.getName())) {
-                throw new GeneralServiceException(ExceptionConstant.INVALID_DATA, ExceptionMessages.METHOD_NAME_MUST_BE_NON_NULL);
-            }
+            validateMethod(method);
+        }
+    }
+
+    private void validateMethod(MethodMng method) {
+        if (StringUtils.isBlank(method.getName())) {
+            throw new GeneralServiceException(ExceptionConstant.INVALID_DATA, ExceptionMessages.METHOD_NAME_MUST_BE_NON_NULL);
+        }
+
+        validateMethodConnector(method);
+    }
+
+    /**
+     * Validates the connector reference carried by a single method before the connection is persisted.
+     */
+    private void validateMethodConnector(MethodMng method) {
+        MethodConnectorMng connector = method.getConnector();
+
+        // No connector: this is a plain HTTP request / webhook method, nothing to validate.
+        if (connector == null) {
+            return;
+        }
+
+        // A connector reference is present but nameless — it cannot be resolved to a real connector.
+        if (connector.getConnectorId() == null) {
+            throw new GeneralServiceException(
+                    ExceptionConstant.INVALID_DATA,
+                    String.format(ExceptionMessages.METHOD_CONNECTOR_REQUIRED, method.getName(), method.getIndex()));
+        }
+
+        Optional<Connector> connectorOpt = connectorService.findById(connector.getConnectorId());
+
+        // The referenced connector id does not exist locally.
+        if (connectorOpt.isEmpty()) {
+            throw new GeneralServiceException(
+                    ExceptionConstant.INVALID_DATA,
+                    String.format(ExceptionMessages.METHOD_CONNECTOR_NOT_FOUND, connector.getConnectorId(), method.getName(), method.getIndex()));
+        }
+
+        String invoker = connector.getInvoker();
+
+        // The invoker must be loaded in the container; if it is missing the user has to drop its XML into
+        // PathConstant.INVOKER and restart, which is what the error message tells them.
+        if (invoker == null || !invokerService.existsByName(invoker)) {
+            throw new GeneralServiceException(
+                    ExceptionConstant.INVALID_DATA,
+                    String.format(ExceptionMessages.METHOD_INVOKER_NOT_FOUND, invoker, method.getName(), method.getIndex(), PathConstant.INVOKER));
+        }
+
+        // Both sides exist but disagree: the method's invoker must be the one the chosen connector runs on,
+        // otherwise the connection would execute against a different invoker than the connector defines.
+        if (!Objects.equals(connectorOpt.get().getInvoker(), invoker)) {
+            throw new GeneralServiceException(
+                    ExceptionConstant.INVALID_DATA,
+                    String.format(ExceptionMessages.METHOD_INVOKER_AND_CONNECTOR_NOT_MATCH, invoker, connectorOpt.get().getInvoker(), method.getName(), method.getIndex()));
         }
     }
 }


### PR DESCRIPTION
## What
Validate the connector/invoker referenced by each method before a connection snapshot is persisted

The check runs on the methods and, for every method that
carries a connector reference, verifies in order:
1. a `connectorId` is present (`METHOD_CONNECTOR_REQUIRED`);
2. the connector exists in MariaDB (`METHOD_CONNECTOR_NOT_FOUND`);
3. the referenced invoker is loaded in the invoker container (`METHOD_INVOKER_NOT_FOUND`);
4. the method's invoker matches the connector's invoker (`METHOD_INVOKER_AND_CONNECTOR_NOT_MATCH`).

Methods with no connector reference (plain HTTP request / webhook) are skipped.

## Why
Closes OC-1503.

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed