### PR TITLE
[Fixed]: OC-1506: websocket log streaming dies after test execution w…

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/Execution2MetadataMapping.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/Execution2MetadataMapping.java
@@ -18,6 +18,10 @@ public class Execution2MetadataMapping {
     private final ConcurrentMap<Long, Metadata> mapping = new ConcurrentHashMap<>();
     private static final Logger logger = LoggerFactory.getLogger(Execution2MetadataMapping.class);
 
+    public boolean exists(long executionId) {
+        return mapping.containsKey(executionId);
+    }
+
     public long getConnectionId(Long executionId) {
         return require(executionId).connectionId;
     }
@@ -78,7 +82,9 @@ public class Execution2MetadataMapping {
     private Metadata require(long executionId) {
         Metadata metadata = mapping.get(executionId);
         if (metadata == null) {
-            logger.error("Execution metadata not found for id=" + executionId);
+            // fail loudly instead of returning null: callers dereference the result,
+            // and a bare NPE hides which execution the lookup was for
+            throw new IllegalStateException("Execution metadata not found for id=" + executionId);
         }
 
         return metadata;

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/ExecutionEventConsumer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/ExecutionEventConsumer.java
@@ -4,12 +4,16 @@ import com.becon.opencelium.backend.execution.logger.pubsub.event.ExecutionEvent
 import com.becon.opencelium.backend.execution.logger.pubsub.handler.ExecutionEventHandler;
 import com.becon.opencelium.backend.execution.logger.pubsub.transport.ExecutionEventTransport;
 import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 public class ExecutionEventConsumer {
+    private static final Logger logger = LoggerFactory.getLogger(ExecutionEventConsumer.class);
+
     private final List<ExecutionEventHandler> handlers;
     private final ExecutionEventTransport transport;
 
@@ -25,8 +29,16 @@ public class ExecutionEventConsumer {
 
     public void dispatch(ExecutionEvent event) {
         for (ExecutionEventHandler handler : handlers) {
-            if (handler.supports(event)) {
+            if (!handler.supports(event)) {
+                continue;
+            }
+
+            try {
                 handler.handle(event);
+            } catch (Exception e) {
+                // isolate handlers from each other: one failing handler must not
+                // prevent the remaining handlers from seeing the event
+                logger.error("Handler {} failed for event {}", handler.getClass().getSimpleName(), event, e);
             }
         }
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/handler/ExecutionLifecycleEventHandler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/handler/ExecutionLifecycleEventHandler.java
@@ -68,36 +68,57 @@ public class ExecutionLifecycleEventHandler implements ExecutionEventHandler {
         if (event instanceof ExecutionStartedEvent e) {
             metadata.create(e.executionId(), e.connectionId(), e.schedulerId(), e.timestamp());
         } else if (event instanceof ExecutionFinishedEvent e) {
-            handleFinish(e);
-            metadata.remove(e.executionId());
+            try {
+                handleFinish(e);
+            } finally {
+                // the mapping entry and its open file channel must be released even
+                // when finish handling fails, otherwise they leak until restart
+                metadata.remove(e.executionId());
+            }
         }
     }
 
 
     private void handleFinish(ExecutionFinishedEvent event) {
         long executionId = event.executionId();
+        if (!metadata.exists(executionId)) {
+            logger.warn("Skipping finish handling for unknown executionId = {}", executionId);
+            return;
+        }
+
         long connectionId = metadata.getConnectionId(executionId);
         int schedulerId = metadata.getSchedulerId(executionId);
         String timestamp = metadata.getTimestamp(executionId);
         String result = event.result();
 
         boolean logExists = hasLogFile(executionId, connectionId, timestamp) && hasDbRecords(executionId);
-        if (!logExists) {
-            return;
-        }
 
         if (EXECUTION_TEST == event.type()) {
-            schedulerService.deleteById(schedulerId);
-            connectionService.deleteById(connectionId);
+            // temporary test artifacts are removed unconditionally — leaving them behind
+            // because the log is missing would leak the connection, scheduler and mapping
+            runQuietly(() -> schedulerService.deleteById(schedulerId), "delete test scheduler " + schedulerId);
+            runQuietly(() -> connectionService.deleteById(connectionId), "delete test connection " + connectionId);
             connection2ChannelMapping.remove(connectionId);
 
-            moveLogFile(connectionId, executionId, timestamp, result);
+            if (logExists) {
+                moveLogFile(connectionId, executionId, timestamp, result);
+            }
         } else if (SUPPORT_FILE == event.type()) {
-            schedulerService.deleteById(schedulerId);
+            runQuietly(() -> schedulerService.deleteById(schedulerId), "delete support-file scheduler " + schedulerId);
 
-            supportFileService.collectFiles(connectionId, executionId, timestamp, result);
-        } else {
+            if (logExists) {
+                supportFileService.collectFiles(connectionId, executionId, timestamp, result);
+            }
+        } else if (logExists) {
             moveLogFile(connectionId, executionId, timestamp, result);
+        }
+    }
+
+    private void runQuietly(Runnable action, String description) {
+        try {
+            action.run();
+        } catch (RuntimeException e) {
+            logger.warn("Failed to {}", description, e);
         }
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/handler/ExecutionLogAppendedEventHandler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/handler/ExecutionLogAppendedEventHandler.java
@@ -40,6 +40,13 @@ public class ExecutionLogAppendedEventHandler implements ExecutionEventHandler {
 
         long executionId = e.executionId();
 
+        if (!metadata.exists(executionId)) {
+            // e.g. a line published after the execution finished and its metadata was
+            // removed — nothing to route it to, but it must not poison the consumer
+            logger.warn("Skipping log line for unknown executionId = {}", executionId);
+            return;
+        }
+
         String line = readLine(executionId, e.startOffset(), e.endOffset());
 
         Optional<LogDataDTO> logData = metadata.getDispatcher(executionId).dispatch(line, e.startOffset(), e.endOffset());
@@ -63,8 +70,10 @@ public class ExecutionLogAppendedEventHandler implements ExecutionEventHandler {
 
             return StandardCharsets.UTF_8.decode(buffer).toString();
         } catch (IOException e) {
-            logger.warn("Failed to read log line: executionId: {}, startOffset: {}, endOffset: {}", executionId, startOffset, endOffset);
-            throw new RuntimeException("Failed to read log line", e);
+            // an unreadable line (file moved, channel closed concurrently) costs one
+            // log entry; rethrowing would cost the whole event pipeline
+            logger.warn("Failed to read log line: executionId: {}, startOffset: {}, endOffset: {}", executionId, startOffset, endOffset, e);
+            return "";
         }
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/transport/local/AsyncQueueExecutionEventTransport.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/pubsub/transport/local/AsyncQueueExecutionEventTransport.java
@@ -4,6 +4,8 @@ import com.becon.opencelium.backend.execution.logger.pubsub.event.ExecutionEvent
 import com.becon.opencelium.backend.execution.logger.pubsub.transport.AbstractExecutionEventTransport;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +17,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 @Primary
 @Component
 public class AsyncQueueExecutionEventTransport extends AbstractExecutionEventTransport {
+    private static final Logger logger = LoggerFactory.getLogger(AsyncQueueExecutionEventTransport.class);
+
     private final BlockingQueue<ExecutionEvent> queue = new LinkedBlockingQueue<>(100_000);
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -38,7 +42,13 @@ public class AsyncQueueExecutionEventTransport extends AbstractExecutionEventTra
         while (running) {
             try {
                 ExecutionEvent event = queue.take();
-                super.consume(event);
+                try {
+                    super.consume(event);
+                } catch (Exception e) {
+                    // a failing event must never kill the consumer thread: it is the only
+                    // reader of the queue, so its death silences all executions until restart
+                    logger.error("Failed to process execution event {}; event skipped", event, e);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/logger/service/LogDataServiceImp.java
@@ -240,26 +240,17 @@ public class LogDataServiceImp implements LogDataService {
     @Override
     public synchronized void bufferAndFlush(LogDataMng block) {
         LogDataMng toPersist = prepareForPersist(block);
-        List<LogDataMng> batchToFlush = buffer.buffer(toPersist);
-        boolean executionComplete = isExecutionComplete(toPersist);
-        if (executionComplete) {
-            // 1) put this block into the buffer first
-            List<LogDataMng> fromThreshold = buffer.buffer(toPersist);
 
-            // 2) flush everything that is still in memory (including this block)
-            List<LogDataMng> allRemaining = buffer.flushAll();
+        // buffer exactly once; a non-empty result means the size threshold was reached
+        List<LogDataMng> batchToFlush = new ArrayList<>(buffer.buffer(toPersist));
 
-            // merge both (fromThreshold is usually empty, but keep it correct)
-            if (!fromThreshold.isEmpty() || !allRemaining.isEmpty()) {
-                batchToFlush = new ArrayList<>(fromThreshold.size() + allRemaining.size());
-                batchToFlush.addAll(fromThreshold);
-                batchToFlush.addAll(allRemaining);
-            }
-        } else {
-            // normal path: only flush when threshold is reached
-            batchToFlush = buffer.buffer(toPersist);
+        if (isExecutionComplete(toPersist)) {
+            // execution is over: drain whatever is still in memory (including this block,
+            // unless the threshold flush above already carried it out)
+            batchToFlush.addAll(buffer.flushAll());
         }
-        if (!batchToFlush.isEmpty() ) {
+
+        if (!batchToFlush.isEmpty()) {
             metaDataLogRepository.saveAll(batchToFlush);
         }
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/quartz/QuartzJobScheduler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/quartz/QuartzJobScheduler.java
@@ -22,6 +22,8 @@ import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -36,6 +38,11 @@ import java.util.stream.Collectors;
 import static org.quartz.TriggerBuilder.newTrigger;
 
 public class QuartzJobScheduler implements SchedulingStrategy {
+    private static final Logger logger = LoggerFactory.getLogger(QuartzJobScheduler.class);
+
+    private static final int DELETE_JOB_MAX_ATTEMPTS = 3;
+    private static final long DELETE_JOB_RETRY_DELAY_MS = 200;
+
     private final org.quartz.Scheduler quartzScheduler;
 
     public QuartzJobScheduler(org.quartz.Scheduler quartzScheduler) {
@@ -90,14 +97,34 @@ public class QuartzJobScheduler implements SchedulingStrategy {
         final String jobName = getJobName(scheduler);
         JobKey jobKey = new JobKey(jobName, "connection");
 
-        try {
-            boolean deleted = quartzScheduler.deleteJob(jobKey); //Deleting a job and unScheduling all of its Triggers
+        SchedulerException lastFailure = null;
+        for (int attempt = 1; attempt <= DELETE_JOB_MAX_ATTEMPTS; attempt++) {
+            try {
+                boolean deleted = quartzScheduler.deleteJob(jobKey); //Deleting a job and unScheduling all of its Triggers
 
-            if (!deleted) {
-                System.err.println("JOB_NOT_FOUND");
+                if (!deleted) {
+                    logger.warn("JOB_NOT_FOUND: {}", jobKey);
+                }
+                return;
+            } catch (SchedulerException e) {
+                // right after a fire-once trigger completes, quartz's own cleanup of the
+                // trigger row races this delete ("Record has changed since last read");
+                // the conflict is transient, so retry before giving up
+                lastFailure = e;
+                logger.warn("Attempt {}/{} to delete quartz job {} failed: {}",
+                        attempt, DELETE_JOB_MAX_ATTEMPTS, jobKey, e.getMessage());
+                sleepQuietly(DELETE_JOB_RETRY_DELAY_MS);
             }
-        } catch (SchedulerException e) {
-            throw new RuntimeException(e);
+        }
+
+        throw new RuntimeException(lastFailure);
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/LogDataMngFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/LogDataMngFixture.java
@@ -70,6 +70,36 @@ public final class LogDataMngFixture {
     }
 
     /**
+     * LogDataMng for execution phase = EXECUTION and status = COMPLETE.
+     * Buffering this block marks the execution as finished and triggers
+     * a full flush of the log block buffer.
+     */
+    public static LogDataMng anExecutionCompletePhaseLogData() {
+        LogDataMng entity = new LogDataMng();
+
+        entity.setId("69fac335ee4ea82b347c51ef");
+
+        entity.setConnectionId(1L);
+        entity.setExecutionId("1");
+        // own flow id so the block never merges with buffered flowchart blocks
+        entity.setFlowId("7d3a1f42-9b0c-4e6d-8a15-0fe27ca2bf6b");
+
+        entity.setStatus(PhaseStatus.COMPLETE);
+        entity.setStartOffset(0L);
+        entity.setEndOffset(14411474L);
+
+        entity.setLogLineType(LogLineType.PHASE);
+        entity.setType(PhaseCategory.EXECUTION);
+
+        entity.setProperties(new HashMap<>());
+        entity.setSegments(new HashMap<>());
+
+        entity.setCreatedAt(Instant.parse("2026-05-06T04:31:58.000Z"));
+
+        return entity;
+    }
+
+    /**
      * LogDataMng for operation phase = OPERATION
      * and status = COMPLETE.
      */

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/logger/service/LogDataServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/logger/service/LogDataServiceImpTest.java
@@ -1,5 +1,6 @@
 package com.becon.opencelium.backend.unit.execution.logger.service;
 
+import com.becon.opencelium.backend.database.mongodb.entity.LogDataMng;
 import com.becon.opencelium.backend.database.mongodb.repository.MetaDataLogRepository;
 import com.becon.opencelium.backend.execution.logger.dto.LogDataDTO;
 import com.becon.opencelium.backend.execution.logger.mapper.LogDataMapper;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -34,7 +37,7 @@ import static org.mockito.Mockito.when;
  * Run with: ./gradlew test
  */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("UserRoleServiceImpl — unit")
+@DisplayName("LogDataServiceImp — unit")
 public class LogDataServiceImpTest {
     @Mock
     private MetaDataLogRepository repository;
@@ -111,5 +114,27 @@ public class LogDataServiceImpTest {
         // THEN
         assertNotNull(result);
         Assertions.assertEquals(1, result.size());
+    }
+
+    @Test
+    void bufferAndFlushSavesEachBlockExactlyOnceWhenExecutionCompletes() {
+        // GIVEN
+        var flowchart = LogDataMngFixture.aFlowchartPhaseLogData();
+        var operation = LogDataMngFixture.anOperationPhaseLogData();
+        var executionEnd = LogDataMngFixture.anExecutionCompletePhaseLogData();
+
+        // WHEN
+        service.bufferAndFlush(flowchart);
+        service.bufferAndFlush(operation);
+        service.bufferAndFlush(executionEnd);
+
+        // THEN: the completed execution flushes the buffer in a single batch
+        // that contains every block once, without duplicates
+        ArgumentCaptor<List<LogDataMng>> captor = ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+
+        List<LogDataMng> saved = captor.getValue();
+        Assertions.assertEquals(3, saved.size());
+        Assertions.assertEquals(3, saved.stream().distinct().count());
     }
 }


### PR DESCRIPTION
## What
Make the execution log pub/sub pipeline survive handler errors so websocket log
streaming no longer dies permanently after a test execution:

- `AsyncQueueExecutionEventTransport` — catch and log exceptions per event; a
  failing event is skipped instead of killing the single consumer thread.
- `ExecutionEventConsumer` — isolate handlers, so one failing handler does not
  hide the event from the remaining handlers.
- `Execution2MetadataMapping` — add `exists()`; `require()` now throws a
  descriptive `IllegalStateException` instead of returning `null` (callers NPE'd).
- `ExecutionLifecycleEventHandler` — release metadata in `finally`; delete test
  scheduler/connection tolerantly (`runQuietly`) and unconditionally, instead of
  skipping all cleanup when the log file is missing.
- `ExecutionLogAppendedEventHandler` — skip lines for unknown executions and
  unreadable lines instead of throwing.
- `LogDataServiceImp.bufferAndFlush` — buffer each block exactly once; the block
  was buffered twice per call, and a threshold-drain batch could be silently
  discarded (never saved to Mongo).
- `QuartzJobScheduler.deleteJob` — retry up to 3× (200 ms pause) on transient
  `qrtz_simple_triggers` row conflicts; replace `System.err` with a logger.

## Why
Starting a test execution while the previous run's log processing was still in
progress left the UI without any websocket log messages until app restart.

All log events (line appended, execution started/finished) flow through one
`LinkedBlockingQueue` drained by a single consumer thread that also persists
logs to Mongo, pushes them to the websocket, and performs finish cleanup. Its
loop only caught `InterruptedException`: any other exception escaped and killed
the thread silently (swallowed by `executor.submit`). The queue kept accepting
events with no reader — so every later execution produced zero websocket logs,
its log file stayed stuck in `uncategorized`, and test connections/schedulers
leaked. In practice the poison event was the finish-cleanup race with Quartz's
own trigger removal ("Record has changed since last read in table
'qrtz_simple_triggers'"), which fires exactly when an execution ends.

Worst case now: one log line is lost and a WARN is written, instead of the
whole log-streaming feature dying.

Closes OC-1506.

## How to test
```bash
# Unit tests — no Docker needed
./gradlew test --tests "*.AsyncQueueExecutionEventTransportTest" \
  --tests "*.ExecutionEventConsumerTest" \
  --tests "*.Execution2MetadataMappingTest" \
  --tests "*.ExecutionLifecycleEventHandlerTest" \
  --tests "*.ExecutionLogAppendedEventHandlerTest" \
  --tests "*.LogDataServiceImpTest" \
  --tests "*.QuartzJobSchedulerTest"
```

Manual repro of the original bug: run a connection test execution, wait for it
to finish, and start it again immediately (while the log file is still being
processed). Logs must stream over the websocket both times; no leftover
`!*test_connection_*` rows and nothing stuck in the `uncategorized` log folder.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `AsyncQueueExecutionEventTransportTest`,
      `ExecutionEventConsumerTest`, `Execution2MetadataMappingTest`,
      `ExecutionLifecycleEventHandlerTest`, `ExecutionLogAppendedEventHandlerTest`,
      `LogDataServiceImpTest.bufferAndFlushSavesEachBlockExactlyOnceWhenExecutionCompletes`,
      `QuartzJobSchedulerTest`
- [x] No secrets, debug logs, or commented-out code
- [ ] WIP commits squashed