### PR TITLE
[OC-1514] Rename ssl_validation to trust_certificate in Connector entity and DB schema

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
@@ -104,11 +104,7 @@ public class ConnectorController {
     @GetMapping
     public ResponseEntity<?> getByTitle(@RequestParam String title) {
         return connectorService.findAllByTitle(title)
-                .map(c -> {
-                    ConnectorResource resource = connectorResourceMapper.toDTO(c);
-                    resource.setSslCert(resource.isSslCert());
-                    return ResponseEntity.ok().body(resource);
-                })
+                .map(c -> ResponseEntity.ok().body(connectorResourceMapper.toDTO(c)))
                 .orElseThrow(() -> new ConnectorNotFoundException(title));
     }
 
@@ -137,11 +133,7 @@ public class ConnectorController {
     @GetMapping(path = "/{id}")
     public ResponseEntity<?> get(@PathVariable int id) {
         return connectorService.findById(id)
-                .map(c -> {
-                    ConnectorResource resource = connectorResourceMapper.toDTO(c);
-                    resource.setSslCert(resource.isSslCert());
-                    return ResponseEntity.ok().body(resource);
-                })
+                .map(c -> ResponseEntity.ok().body(connectorResourceMapper.toDTO(c)))
                 .orElseThrow(() -> new ConnectorNotFoundException(id));
     }
 
@@ -169,10 +161,6 @@ public class ConnectorController {
     @GetMapping("/all")
     public ResponseEntity<List<ConnectorResource>> getAll() {
         List<ConnectorResource> connectorResources = connectorResourceMapper.toDTOAll(connectorService.findAll());
-        connectorResources.stream().forEach(ctor -> {
-            boolean validationSslDisabled = !ctor.isSslCert();
-            ctor.setSslCert(validationSslDisabled);
-        });
         return ResponseEntity.ok(connectorResources);
     }
 
@@ -195,8 +183,6 @@ public class ConnectorController {
         connectorResources.forEach(x -> {
             x.getInvoker().setOperations(null);
             x.getInvoker().setRequiredData(null);
-            boolean validationSslDisabled = !x.isSslCert();
-            x.setSslCert(validationSslDisabled);
         });
 
         return ResponseEntity.ok(connectorResources);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
@@ -202,12 +202,6 @@ public class ConnectorController {
     })
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> add(@RequestBody ConnectorResource connectorResource) {
-        // TODO: fix naming.
-        // to prevent confusion.
-//        SSL Validation is activated:   false
-//        SSL Validation is deactivated: true
-//        boolean enableSllValidation = !connectorResource.isSslCert();
-//        connectorResource.setSslCert(enableSllValidation);
         if (connectorService.existByTitle(connectorResource.getTitle())) {
             throw new ConnectorAlreadyExistsException("CONNECTOR_ALREADY_EXISTS");
         }
@@ -232,12 +226,6 @@ public class ConnectorController {
     })
     @PutMapping(path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ConnectorResource> update(@PathVariable Integer id, @RequestBody ConnectorResource connectorResource) {
-        // TODO: fix naming.
-        // to prevent confusion.
-//        SSL Validation is activated:   false
-//        SSL Validation is deactivated: true
-//        boolean enableSllValidation = !connectorResource.isSslCert();
-//        connectorResource.setSslCert(enableSllValidation);
         return ResponseEntity.ok(
                 connectorResourceMapper.toDTO(
                         connectorService.update(id, connectorResource)
@@ -385,14 +373,6 @@ public class ConnectorController {
     @PostMapping(path = "/check", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> checkCommunication(@RequestBody ConnectorResource connectorResource) throws JsonProcessingException, IOException {
         Connector connector = connectorResourceMapper.toEntity(connectorResource);
-
-        // TODO: fix naming.
-        // to prevent confusion.
-        // commented due to a frontend sends as it was before.
-//        SSL Validation is activated:   false
-//        SSL Validation is deactivated: true
-//        boolean enableSllValidation = !connectorResource.isSslCert();
-//        connectorResource.setSslCert(enableSllValidation);
 //        Invoker invoker = invokerService.findByName(connector.getInvoker());
 //        AuthFactory authFactory = new AuthFactory();
 //        ApiAuth authenticationType = authFactory.generateAuth(invoker);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
@@ -73,7 +73,7 @@ public class Connector {
     private String icon;
 
     @Column(name = "trust_certificate")
-    private boolean sslValidation;
+    private boolean trustCertificate;
 
     // millisecond
     @Column(name = "timeout")
@@ -162,12 +162,12 @@ public class Connector {
         this.icon = icon;
     }
 
-    public boolean isSslValidation() {
-        return sslValidation;
+    public boolean isTrustCertificate() {
+        return trustCertificate;
     }
 
-    public void setSslValidation(boolean sslValidation) {
-        this.sslValidation = sslValidation;
+    public void setTrustCertificate(boolean trustCertificate) {
+        this.trustCertificate = trustCertificate;
     }
 
     public int getTimeout() {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
@@ -72,7 +72,7 @@ public class Connector {
     @Column(name = "icon")
     private String icon;
 
-    @Column(name = "ssl_validation")
+    @Column(name = "trust_certificate")
     private boolean sslValidation;
 
     // millisecond

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -27,7 +27,6 @@ import com.becon.opencelium.backend.exception.ConnectorAlreadyExistsException;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.exception.StorageException;
-import com.becon.opencelium.backend.execution.logger.mapper.ParsedLogLineMapper;
 import com.becon.opencelium.backend.execution.rdata.RequiredDataService;
 import com.becon.opencelium.backend.execution.rdata.RequiredDataServiceImp;
 import com.becon.opencelium.backend.invoker.InvokerRequestBuilder;
@@ -222,7 +221,7 @@ public class ConnectorServiceImp implements ConnectorService {
                 .setProxyUser(user)
                 .setProxyPass(password)
                 .setTimeout(connector.getTimeout())
-                .setSslCert(connector.isSslValidation())
+                .setSslCert(connector.isTrustCertificate())
                 .sendRequest();
     }
 
@@ -279,7 +278,7 @@ public class ConnectorServiceImp implements ConnectorService {
         // prepended twice when the entity is mapped back to a DTO (icon path doubling on update).
         connector.setIcon(StringUtility.findImageFromUrl(connectorResource.getIcon()));
         connector.setDescription(connectorResource.getDescription());
-        connector.setSslValidation(connectorResource.isSslCert());
+        connector.setTrustCertificate(connectorResource.isSslCert());
         connector.setTimeout(connectorResource.getTimeout());
 
         connectorRepository.save(connector);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/rdata/RequiredDataServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/rdata/RequiredDataServiceImp.java
@@ -32,7 +32,7 @@ public class RequiredDataServiceImp implements RequiredDataService {
         return extractor
                 .setRequestData(requestData)
                 .setFunctions(functionInvokerList)
-                .disableSslValidation(connector.isSslValidation())
+                .disableSslValidation(connector.isTrustCertificate())
                 .getValue(rqsd.getField());
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/ConnectorExMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/ConnectorExMapper.java
@@ -63,7 +63,7 @@ public class ConnectorExMapper {
             Map<String, String> map = new HashMap<>();
             requestData.forEach(r -> map.put(r.getField(), r.getValue()));
 
-            connectorEx.setSslCert(connector.isSslValidation());
+            connectorEx.setSslCert(connector.isTrustCertificate());
             connectorEx.setInvoker(connector.getInvoker());
             connectorEx.setRequiredData(map);
 
@@ -117,7 +117,7 @@ public class ConnectorExMapper {
                     MethodConnectorEx mcEx = new MethodConnectorEx();
                     mcEx.setId(connector.getId());
                     mcEx.setTitle(connector.getTitle());
-                    mcEx.setSslCert(connector.isSslValidation());
+                    mcEx.setSslCert(connector.isTrustCertificate());
                     mcEx.setTimeout(connector.getTimeout());
                     mcEx.setInvoker(connector.getInvoker());
                     mcEx.setRequiredData(requiredDataMap);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorMapper.java
@@ -31,7 +31,7 @@ public interface ConnectorMapper extends Mapper<Connector, ConnectorDTO> {
             @Mapping(target = "id", source = "connectorId"),
             @Mapping(target = "invoker", source = "invoker.name"),
             @Mapping(target = "icon", expression = "java(StringUtility.findImageFromUrl(dto.getIcon()))"),
-            @Mapping(target = "sslValidation", source = "sslCert")
+            @Mapping(target = "trustCertificate", source = "sslCert")
     })
     Connector toEntity(ConnectorDTO dto);
 
@@ -41,7 +41,7 @@ public interface ConnectorMapper extends Mapper<Connector, ConnectorDTO> {
             @Mapping(target = "connectorId", source = "id"),
             @Mapping(target = "icon", expression = "java(StringUtility.resolveImagePath(entity.getIcon()))"),
             @Mapping(target = "invoker", qualifiedByName = {"helperMapper", "getInvokerDTO"}),
-            @Mapping(target = "sslCert", source = "sslValidation")
+            @Mapping(target = "sslCert", source = "trustCertificate")
     })
     ConnectorDTO toDTO(Connector entity);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
@@ -31,7 +31,7 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
             @Mapping(target = "icon", expression = "java(StringUtility.resolveImagePath(entity.getIcon()))"),
             @Mapping(target = "invoker", qualifiedByName = {"helperMapper", "getInvokerDTO"}),
             @Mapping(target = "requestData", qualifiedByName = {"requestDataMapper", "toDTO"}),
-            @Mapping(target = "sslCert", source = "sslValidation"),
+            @Mapping(target = "sslCert", source = "trustCertificate"),
             @Mapping(target = "lastTestPassed", source = "lastTestPassed"),
             @Mapping(target = "lastTestError", source = "lastTestError")
     })
@@ -42,7 +42,7 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
             @Mapping(target = "invoker", source = "invoker.name"),
             @Mapping(target = "icon", expression = "java(StringUtility.findImageFromUrl(dto.getIcon()))"),
             @Mapping(target = "requestData", expression = "java(helperMapper.processRequestData(dto))"),
-            @Mapping(target = "sslValidation", source = "sslCert")
+            @Mapping(target = "trustCertificate", source = "sslCert")
     })
     Connector toEntity(ConnectorResource dto);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/utils/HelperMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/utils/HelperMapper.java
@@ -76,7 +76,7 @@ public abstract class HelperMapper {
         if (connector != null) {
             connectorDTO.setIcon(connector.getIcon());
             connectorDTO.setTimeout(connector.getTimeout());
-            connectorDTO.setSslCert(connector.isSslValidation());
+            connectorDTO.setSslCert(connector.isTrustCertificate());
             connectorDTO.setInvoker(getInvokerDTO(connector.getInvoker()));
         }
         return connectorDTO;

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -731,3 +731,6 @@ ALTER TABLE `execution` ADD CONSTRAINT `fk_execution_scheduler1` FOREIGN KEY (`s
 
 --changeset 5.0:6 stripComments:true splitStatements:true endDelimiter:;
 INSERT IGNORE INTO role_has_permission (role_id,component_id,permission_id) VALUES (2,7,1),(2,7,2),(2,7,3),(2,7,4);
+
+--changeset 5.0:7 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE connector CHANGE ssl_validation trust_certificate TINYINT(4) DEFAULT NULL;


### PR DESCRIPTION
## What
- Renamed column `connector.ssl_validation` → `connector.trust_certificate` with data preserved;
- Reverted sslCert related changes in ConnectorController (keep it as prod branch).

## Why
Resolves: [[OC-1514] Rename ssl_validation to trust_certificate in Connector entity and DB schema](https://becon.atlassian.net/browse/OC-1514)

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets, debug logs, or commented-out code
- [x] No occurrence of `ssl_validation` / `sslValidation` remains in **src/main/java** or in the entity's column mapping
- [x] REST request/response JSON for connectors still uses the field name `sslCert` (DTO classes unchanged)
- [x] Application starts with `ddl-auto=validate` against a migrated database
- [x] `./gradlew build` and `./gradlew test` pass