### PR TITLE
OC-1512: Modification on connnector/connection audit fields

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectionController.java
@@ -87,6 +87,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -203,18 +204,7 @@ public class ConnectionController {
     public ResponseEntity<?> getAllMeta(@RequestParam(name = "includeTest", defaultValue = "false") Boolean includeTest) {
         List<Connection> connections = connectionService.findAll(includeTest);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
-        //unnecessary fields
-        connectionResources.forEach(c -> {
-            c.getFromConnector().setRequestData(null);
-            c.getFromConnector().getInvoker().setOperations(null);
-            c.getFromConnector().getInvoker().setRequiredData(null);
-
-            if (c.getToConnector() != null) {
-                c.getToConnector().setRequestData(null);
-                c.getToConnector().getInvoker().setOperations(null);
-                c.getToConnector().getInvoker().setRequiredData(null);
-            }
-        });
+        prepareForList(connections, connectionResources);
         return ResponseEntity.ok(connectionResources);
     }
 
@@ -235,8 +225,22 @@ public class ConnectionController {
                                             @RequestParam(name = "includeTest", defaultValue = "false") boolean includeTest) {
         List<Connection> connections = connectionService.findAllByIds(ids, includeTest);
         List<ConnectionResource> connectionResources = connectionResourceMapper.toDTOAll(connections);
-        //unnecessary fields
+        prepareForList(connections, connectionResources);
+        return ResponseEntity.ok(connectionResources);
+    }
+
+    /**
+     * Trims the parts that a connection list never renders and adds the last version of every
+     * connection, which lives in MongoDB and therefore is not filled in by the mapper.
+     */
+    private void prepareForList(List<Connection> connections, List<ConnectionResource> connectionResources) {
+        if (connectionResources.isEmpty()) {
+            return;
+        }
+
+        Map<Long, ConnectionVersionedDTO> lastVersions = connectionService.getLastVersions(connections);
         connectionResources.forEach(c -> {
+            //unnecessary fields
             c.getFromConnector().setRequestData(null);
             c.getFromConnector().getInvoker().setOperations(null);
             c.getFromConnector().getInvoker().setRequiredData(null);
@@ -246,8 +250,9 @@ public class ConnectionController {
                 c.getToConnector().getInvoker().setOperations(null);
                 c.getToConnector().getInvoker().setRequiredData(null);
             }
+
+            c.setLastVersion(lastVersions.get(c.getId()));
         });
-        return ResponseEntity.ok(connectionResources);
     }
 
     @Operation(summary = "Retrieves a connection from database by provided connection ID")

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/repository/ConnectionMngRepository.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/repository/ConnectionMngRepository.java
@@ -3,12 +3,10 @@ package com.becon.opencelium.backend.database.mongodb.repository;
 import com.becon.opencelium.backend.database.mongodb.entity.ConnectionMng;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ConnectionMngRepository extends MongoRepository<ConnectionMng,String> {
@@ -16,6 +14,11 @@ public interface ConnectionMngRepository extends MongoRepository<ConnectionMng,S
     void deleteById(String id);
 
     List<ConnectionMng> findAllByConnectionIdOrderByConnectionIdDesc(Long id);
+
+    @Query(value = "{'_id' : {$in : ?0}}",
+            fields = "{'connection_id' : 1, 'comment' : 1, 'createdAt' : 1, 'createdBy' : 1}")
+    List<ConnectionMng> findVersionMetaByIdIn(Collection<String> snapshotIds);
+
     long deleteByConnectionIdIn(Collection<Long> connectionIds);
 
     void deleteAllByConnectionId(Long id);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngService.java
@@ -3,6 +3,7 @@ package com.becon.opencelium.backend.database.mongodb.service;
 import com.becon.opencelium.backend.database.mongodb.entity.ConnectionMng;
 import com.becon.opencelium.backend.resource.connection.ConnectionVersionUpdateRequest;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ConnectionMngService {
@@ -17,6 +18,8 @@ public interface ConnectionMngService {
     List<ConnectionMng> getAllByConnectionId(Long id);
 
     List<ConnectionMng> getAllByConnectionIdRaw(Long id);
+
+    List<ConnectionMng> getVersionMetaByIds(Collection<String> snapshotIds);
 
     long deleteByConnectionIdIn(List<Long> chunk);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mongodb/service/ConnectionMngServiceImp.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -113,6 +114,14 @@ public class ConnectionMngServiceImp implements ConnectionMngService {
     @Override
     public List<ConnectionMng> getAllByConnectionIdRaw(Long id) {
         return connectionMngRepository.findAllByConnectionIdOrderByConnectionIdDesc(id);
+    }
+
+    @Override
+    public List<ConnectionMng> getVersionMetaByIds(Collection<String> snapshotIds) {
+        if (snapshotIds == null || snapshotIds.isEmpty()) {
+            return List.of();
+        }
+        return connectionMngRepository.findVersionMetaByIdIn(snapshotIds);
     }
 
     /**

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connection.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connection.java
@@ -64,8 +64,8 @@ public class Connection {
 
     @CreationTimestamp
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "created_on", updatable = false)
-    private Date createdOn;
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
 
     @LastModifiedBy
     @Column(name = "modified_by")
@@ -73,8 +73,8 @@ public class Connection {
 
     @UpdateTimestamp
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "modified_on")
-    private Date modifiedOn;
+    @Column(name = "modified_at")
+    private Date modifiedAt;
 
     @Column(name = "icon")
     private String icon;
@@ -150,12 +150,12 @@ public class Connection {
         this.createdBy = createdBy;
     }
 
-    public Date getCreatedOn() {
-        return createdOn;
+    public Date getCreatedAt() {
+        return createdAt;
     }
 
-    public void setCreatedOn(Date createdOn) {
-        this.createdOn = createdOn;
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
     }
 
     public Integer getModifiedBy() {
@@ -166,12 +166,12 @@ public class Connection {
         this.modifiedBy = modifiedBy;
     }
 
-    public Date getModifiedOn() {
-        return modifiedOn;
+    public Date getModifiedAt() {
+        return modifiedAt;
     }
 
-    public void setModifiedOn(Date modifiedOn) {
-        this.modifiedOn = modifiedOn;
+    public void setModifiedAt(Date modifiedAt) {
+        this.modifiedAt = modifiedAt;
     }
 
     public String getIcon() {
@@ -223,9 +223,9 @@ public class Connection {
                 ", fromConnector=" + fromConnector +
                 ", toConnector=" + toConnector +
                 ", createdBy=" + createdBy +
-                ", createdOn=" + createdOn +
+                ", createdAt=" + createdAt +
                 ", modifiedBy=" + modifiedBy +
-                ", modifiedOn=" + modifiedOn +
+                ", modifiedAt=" + modifiedAt +
                 ", schedulers=" + schedulers +
                 ", businessLayout=" + businessLayout +
                 ", icon=" + icon +

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
@@ -58,8 +58,8 @@ public class Connector {
 
     @CreationTimestamp
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "created_on", updatable = false)
-    private Date createdOn;
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
 
     @LastModifiedBy
     @Column(name = "modified_by")
@@ -67,8 +67,8 @@ public class Connector {
 
     @UpdateTimestamp
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "modified_on")
-    private Date modifiedOn;
+    @Column(name = "modified_at")
+    private Date modifiedAt;
 
     @Column(name = "icon")
     private String icon;
@@ -136,12 +136,12 @@ public class Connector {
         this.createdBy = createdBy;
     }
 
-    public Date getCreatedOn() {
-        return createdOn;
+    public Date getCreatedAt() {
+        return createdAt;
     }
 
-    public void setCreatedOn(Date createdOn) {
-        this.createdOn = createdOn;
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
     }
 
     public Integer getModifiedBy() {
@@ -152,12 +152,12 @@ public class Connector {
         this.modifiedBy = modifiedBy;
     }
 
-    public Date getModifiedOn() {
-        return modifiedOn;
+    public Date getModifiedAt() {
+        return modifiedAt;
     }
 
-    public void setModifiedOn(Date modifiedOn) {
-        this.modifiedOn = modifiedOn;
+    public void setModifiedAt(Date modifiedAt) {
+        this.modifiedAt = modifiedAt;
     }
 
     public String getIcon() {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionService.java
@@ -30,6 +30,7 @@ import com.github.fge.jsonpatch.JsonPatch;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public interface ConnectionService {
@@ -123,6 +124,8 @@ public interface ConnectionService {
     void deleteByIds(List<Long> ids, Set<Long> runningConnectionIds);
 
     List<ConnectionVersionedDTO> getConnectionVersions(Long connectionId);
+
+    Map<Long, ConnectionVersionedDTO> getLastVersions(List<Connection> connections);
 
     void deleteSnapshot(Long connectionId, String snapshotId);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -48,6 +48,7 @@ import com.github.fge.jsonpatch.JsonPatch;
 import jakarta.persistence.EntityNotFoundException;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -616,17 +617,40 @@ public class ConnectionServiceImp implements ConnectionService {
         List<ConnectionMng> connections = connectionMngService.getAllByConnectionId(connectionId);
 
         return connections.stream()
-                .map(x -> {
-                    ConnectionVersionedDTO versionedDTO = new ConnectionVersionedDTO();
-                    versionedDTO.setConnectionId(connection.getId());
-                    versionedDTO.setTitle(connection.getTitle());
-                    versionedDTO.setSnapshotId(x.getId());
-                    versionedDTO.setCreatedAt(x.getCreatedAt() != null ? x.getCreatedAt().toEpochMilli() : null);
-                    versionedDTO.setCurrent(Objects.equals(connection.getSnapshotId(), x.getId()));
-                    versionedDTO.setAuthor(x.getCreatedBy());
-                    versionedDTO.setComment(x.getComment());
-                    return versionedDTO;
-                }).toList();
+                .map(x -> toVersionedDTO(connection, x))
+                .toList();
+    }
+
+    @Override
+    public Map<Long, ConnectionVersionedDTO> getLastVersions(List<Connection> connections) {
+        if (CollectionUtils.isEmpty(connections)) {
+            return Map.of();
+        }
+
+        Map<String, Connection> connectionBySnapshotId = connections.stream()
+                .filter(c -> c.getId() != null && StringUtils.isNotBlank(c.getSnapshotId()))
+                .collect(Collectors.toMap(Connection::getSnapshotId, Function.identity(), (a, b) -> a));
+
+        Map<Long, ConnectionVersionedDTO> lastVersions = new HashMap<>();
+        for (ConnectionMng snapshot : connectionMngService.getVersionMetaByIds(connectionBySnapshotId.keySet())) {
+            Connection connection = connectionBySnapshotId.get(snapshot.getId());
+            if (connection != null) {
+                lastVersions.put(connection.getId(), toVersionedDTO(connection, snapshot));
+            }
+        }
+        return lastVersions;
+    }
+
+    private ConnectionVersionedDTO toVersionedDTO(Connection connection, ConnectionMng snapshot) {
+        ConnectionVersionedDTO versionedDTO = new ConnectionVersionedDTO();
+        versionedDTO.setConnectionId(connection.getId());
+        versionedDTO.setTitle(connection.getTitle());
+        versionedDTO.setSnapshotId(snapshot.getId());
+        versionedDTO.setCreatedAt(snapshot.getCreatedAt() != null ? snapshot.getCreatedAt().toEpochMilli() : null);
+        versionedDTO.setCurrent(Objects.equals(connection.getSnapshotId(), snapshot.getId()));
+        versionedDTO.setAuthor(snapshot.getCreatedBy());
+        versionedDTO.setComment(snapshot.getComment());
+        return versionedDTO;
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectionResourceMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectionResourceMapper.java
@@ -27,6 +27,9 @@ public interface ConnectionResourceMapper extends Mapper<Connection, ConnectionR
             @Mapping(target = "fromConnector", source = "fromConnector.connectorId"),
             @Mapping(target = "toConnector", source = "toConnector.connectorId"),
             @Mapping(target = "icon", expression = "java(StringUtility.findImageFromUrl(dto.getIcon()))"),
+            // audit fields are maintained by the persistence layer, never taken from the request
+            @Mapping(target = "modifiedBy", ignore = true),
+            @Mapping(target = "modifiedAt", ignore = true)
     })
     Connection toEntity(ConnectionResource dto);
 
@@ -35,7 +38,11 @@ public interface ConnectionResourceMapper extends Mapper<Connection, ConnectionR
             @Mapping(target = "fromConnector", qualifiedByName = {"helperMapper","getConnectorResourceById"}),
             @Mapping(target = "toConnector", qualifiedByName = {"helperMapper","getConnectorResourceById"}),
             @Mapping(target = "icon", expression = "java(StringUtility.resolveImagePath(entity.getIcon()))"),
-            @Mapping(target = "enhancements", ignore = true)
+            @Mapping(target = "enhancements", ignore = true),
+            @Mapping(target = "modifiedBy", source = "modifiedBy"),
+            @Mapping(target = "modifiedAt", expression = "java(entity.getModifiedAt() != null ? entity.getModifiedAt().getTime() : null)"),
+            // resolved separately, it lives in MongoDB
+            @Mapping(target = "lastVersion", ignore = true)
     })
     ConnectionResource toDTO(Connection entity);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
@@ -1,6 +1,5 @@
 package com.becon.opencelium.backend.mapper.mysql;
 
-
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.mapper.utils.HelperMapper;
@@ -38,7 +37,9 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
             @Mapping(target = "sslCert", source = "trustCertificate"),
             @Mapping(target = "status", source = "status"),
             @Mapping(target = "lastTestError", source = "lastTestError"),
-            @Mapping(target = "lastCheckedAt", source = "lastCheckedAt", qualifiedByName = "dateToEpochMillis")
+            @Mapping(target = "lastCheckedAt", source = "lastCheckedAt", qualifiedByName = "dateToEpochMillis"),
+            @Mapping(target = "modifiedBy", source = "modifiedBy"),
+            @Mapping(target = "modifiedAt", expression = "java(entity.getModifiedAt() != null ? entity.getModifiedAt().getTime() : null)")
     })
     ConnectorResource toDTO(Connector entity);
 
@@ -80,7 +81,11 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
             @Mapping(target = "trustCertificate", source = "sslCert"),
             // Health fields are written only by the backend's own check flow, never from client input.
             @Mapping(target = "status", ignore = true),
-            @Mapping(target = "lastCheckedAt", ignore = true)
+            @Mapping(target = "lastCheckedAt", ignore = true),
+            // audit fields are maintained by the persistence layer, never taken from the request
+            @Mapping(target = "modifiedBy", ignore = true),
+            @Mapping(target = "modifiedAt", ignore = true)
+
     })
     Connector toEntity(ConnectorResource dto);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/ConnectionResource.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connection/ConnectionResource.java
@@ -34,6 +34,12 @@ public class ConnectionResource {
     private ConnectorResource toConnector;
     private List<EnhancementDTO> enhancements;
     private Integer categoryId;
+    // ID of the user who modified the connection last.
+    private Integer modifiedBy;
+    // Timestamp of the last modification, in epoch millis.
+    private Long modifiedAt;
+    // Most recently created version (snapshot) of the connection; null when it has no snapshots yet.
+    private ConnectionVersionedDTO lastVersion;
 
     public Long getId() {
         return id;
@@ -97,5 +103,29 @@ public class ConnectionResource {
 
     public void setCategoryId(Integer categoryId) {
         this.categoryId = categoryId;
+    }
+
+    public Integer getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(Integer modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+
+    public Long getModifiedAt() {
+        return modifiedAt;
+    }
+
+    public void setModifiedAt(Long modifiedAt) {
+        this.modifiedAt = modifiedAt;
+    }
+
+    public ConnectionVersionedDTO getLastVersion() {
+        return lastVersion;
+    }
+
+    public void setLastVersion(ConnectionVersionedDTO lastVersion) {
+        this.lastVersion = lastVersion;
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorResource.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorResource.java
@@ -40,6 +40,10 @@ public class ConnectorResource {
     private String lastTestError;
     // Epoch millis of the most recent health check; null = never checked.
     private Long lastCheckedAt;
+    // ID of the user who modified the connector last.
+    private Integer modifiedBy;
+    // Timestamp of the last modification, in epoch millis.
+    private Long modifiedAt;
 
     public int getConnectorId() {
         return connectorId;
@@ -127,5 +131,21 @@ public class ConnectorResource {
 
     public void setLastTestError(String lastTestError) {
         this.lastTestError = lastTestError;
+    }
+
+    public Integer getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(Integer modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+
+    public Long getModifiedAt() {
+        return modifiedAt;
+    }
+
+    public void setModifiedAt(Long modifiedAt) {
+        this.modifiedAt = modifiedAt;
     }
 }

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -741,3 +741,9 @@ UPDATE `connector` SET `status` = CASE WHEN `last_test_passed` = 1 THEN 'UP'
                                        WHEN `last_test_passed` = 0 THEN 'DOWN'
                                        ELSE 'UNKNOWN' END;
 ALTER TABLE `connector` DROP COLUMN IF EXISTS `last_test_passed`;
+
+--changeset 5.0:9 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `connection` CHANGE COLUMN IF EXISTS `created_on` `created_at` TIMESTAMP NULL DEFAULT NULL;
+ALTER TABLE `connection` CHANGE COLUMN IF EXISTS `modified_on` `modified_at` TIMESTAMP NULL DEFAULT NULL;
+ALTER TABLE `connector` CHANGE COLUMN IF EXISTS `created_on` `created_at` TIMESTAMP NULL DEFAULT NULL;
+ALTER TABLE `connector` CHANGE COLUMN IF EXISTS `modified_on` `modified_at` TIMESTAMP NULL DEFAULT NULL;


### PR DESCRIPTION

## What
Rename the audit timestamp columns of the `connection` and `connector` tables from `created_on`/`modified_on` to `created_at`/`modified_at`and extend the list resources:

- `ConnectorResource` — adds `modifiedBy` (user id, `Integer`) and `modifiedAt` (epoch millis).
- `ConnectionResource` — adds `modifiedBy`, `modifiedAt` and `lastVersion`, the latest entry in the existing `ConnectionVersionedDTO` shape (`snapshotId`, `comment`, `createdAt`, `author`).

The new fields are populated in the endpoints the tables consume — `GET /connection/all/meta`, `POST /connection/all/by-ids` and `GET /connector/all` — and survive the field stripping those two connection endpoints apply.

## Why
Closes OC-1512.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed