### PR TITLE
Oc 1515 connector status

### DIFF
--- a/src/backend/src/integrationTest/resources/application-integration.yml
+++ b/src/backend/src/integrationTest/resources/application-integration.yml
@@ -1,0 +1,11 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  Spring profile: integration
+#
+#  Activated by the @IntegrationTest composed annotation. Database coordinates
+#  are injected per test class via @DynamicPropertySource from Testcontainers.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Background jobs are disabled so integration tests never fire real remote requests.
+opencelium:
+  connector-health:
+    enabled: false

--- a/src/backend/src/main/java/com/becon/opencelium/backend/configuration/ConnectorHealthConfiguration.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/configuration/ConnectorHealthConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.configuration;
+
+import com.becon.opencelium.backend.constant.AppYamlPath;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Executor for the background connector health monitor.
+ */
+@Configuration
+public class ConnectorHealthConfiguration {
+
+    /**
+     * Bounded pool dedicated to connector health checks. When the queue is full,
+     * further checks of a sweep are silently discarded — they are simply retried on
+     * the next sweep, so saturation never blocks the scheduler thread.
+     */
+    @Bean(name = "connectorHealthTaskExecutor")
+    public ThreadPoolTaskExecutor connectorHealthTaskExecutor(
+            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_PARALLELISM + ":4}") int parallelism) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(parallelism);
+        executor.setMaxPoolSize(parallelism);
+        executor.setQueueCapacity(1000);
+        executor.setThreadNamePrefix("connector-health-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        return executor;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/configuration/WebSocketConfig.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/configuration/WebSocketConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
+import static com.becon.opencelium.backend.execution.socket.SocketConstant.CONNECTOR_DESTINATION_PREFIX;
 import static com.becon.opencelium.backend.execution.socket.SocketConstant.EXECUTION_DESTINATION_PREFIX;
 import static com.becon.opencelium.backend.execution.socket.SocketConstant.NOTIFICATION_DESTINATION_PREFIX;
 import static com.becon.opencelium.backend.execution.socket.SocketConstant.PATH;
@@ -48,7 +49,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 EXECUTION_DESTINATION_PREFIX,
                 NOTIFICATION_DESTINATION_PREFIX,
                 SCHEDULER_DESTINATION_PREFIX,
-                USER_SESSION_DESTINATION_PREFIX
+                USER_SESSION_DESTINATION_PREFIX,
+                CONNECTOR_DESTINATION_PREFIX
         );
         registry.setApplicationDestinationPrefixes("/oc");
         registry.setUserDestinationPrefix("/user");

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/AppYamlPath.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/AppYamlPath.java
@@ -54,4 +54,21 @@ public interface AppYamlPath {
 
     // Default log (*.log) files limit for failed execution per connection is 3
     String LOG_FILE_FAIL_LIMIT = "opencelium.log.retention.per-connection.fail";
+
+    // Connector health monitor variables:
+    // Master switch for the periodic background health sweep. Default: true
+    String CONNECTOR_HEALTH_ENABLED = "opencelium.connector-health.enabled";
+
+    // Delay between two sweeps in milliseconds. Default: 300000 (5 minutes)
+    String CONNECTOR_HEALTH_INTERVAL = "opencelium.connector-health.interval";
+
+    // Delay before the first sweep after startup in milliseconds. Default: 60000
+    String CONNECTOR_HEALTH_INITIAL_DELAY = "opencelium.connector-health.initial-delay";
+
+    // Consecutive failed checks before a connector's status transitions to
+    // DOWN/AUTH_FAILED (flap damping). Recovery to UP needs a single success. Default: 3
+    String CONNECTOR_HEALTH_FAILURE_THRESHOLD = "opencelium.connector-health.failure-threshold";
+
+    // How many connectors are checked concurrently by the monitor. Default: 4
+    String CONNECTOR_HEALTH_PARALLELISM = "opencelium.connector-health.parallelism";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/AppYamlPath.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/AppYamlPath.java
@@ -71,4 +71,11 @@ public interface AppYamlPath {
 
     // How many connectors are checked concurrently by the monitor. Default: 4
     String CONNECTOR_HEALTH_PARALLELISM = "opencelium.connector-health.parallelism";
+
+    // Log every health-check request and its response (method, endpoint template,
+    // HTTP status, latency, truncated response body) at INFO level. Default: false
+    String CONNECTOR_HEALTH_LOG_ENABLED = "opencelium.connector-health.request-logging.enabled";
+
+    // Maximum number of response-body characters included in one log line. Default: 500
+    String CONNECTOR_HEALTH_LOG_MAX_BODY_LENGTH = "opencelium.connector-health.request-logging.max-body-length";
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
@@ -30,6 +30,7 @@ import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
 import com.becon.opencelium.backend.invoker.service.InvokerService;
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.resource.IdentifiersDTO;
 import com.becon.opencelium.backend.resource.application.ResultDTO;
@@ -385,7 +386,7 @@ public class ConnectorController {
             // The remote request could not be completed (e.g. host unreachable): record it as a
             // failed test on the saved connector before surfacing the error to the caller.
             if (connectorResource.getConnectorId() > 0 && connectorService.existsById(connectorResource.getConnectorId())) {
-                connectorService.updateTestResult(connectorResource.getConnectorId(), false, ex.getMessage());
+                connectorService.updateStatus(connectorResource.getConnectorId(), ConnectorStatus.DOWN, ex.getMessage());
             }
             throw new CommunicationFailedException();
         }
@@ -407,26 +408,26 @@ public class ConnectorController {
         }
 
         // Classify the outcome once, so it can be both persisted (for saved connectors) and returned.
-        boolean passed;
+        ConnectorStatus status;
         String remoteError = null;
         if ((responseEntity.getStatusCode() == HttpStatus.OK) && hasError(fail, response)) {
-            passed = false;
+            status = ConnectorStatus.AUTH_FAILED;
             remoteError = response;
         } else if (responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED) {
-            passed = false;
+            status = ConnectorStatus.AUTH_FAILED;
             remoteError = responseEntity.getBody() != null
                     ? responseEntity.getBody().toString()
                     : "Error in remote system";
         } else {
-            passed = true;
+            status = ConnectorStatus.UP;
         }
 
         // Persist the latest result only for a saved connector; an unsaved/new connector has no row.
         if (connectorResource.getConnectorId() > 0 && connectorService.existsById(connectorResource.getConnectorId())) {
-            connectorService.updateTestResult(connectorResource.getConnectorId(), passed, remoteError);
+            connectorService.updateStatus(connectorResource.getConnectorId(), status, remoteError);
         }
 
-        if ((responseEntity.getStatusCode() == HttpStatus.OK) && !passed) {
+        if ((responseEntity.getStatusCode() == HttpStatus.OK) && status != ConnectorStatus.UP) {
             return ResponseEntity.ok().body("{\"status\":\"401\", \"error\":\"401\"}");
         }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
@@ -26,10 +26,9 @@ import com.becon.opencelium.backend.exception.CommunicationFailedException;
 import com.becon.opencelium.backend.exception.ConnectorAlreadyExistsException;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
-import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
-import com.becon.opencelium.backend.invoker.service.InvokerService;
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
 import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.resource.IdentifiersDTO;
@@ -37,8 +36,6 @@ import com.becon.opencelium.backend.resource.application.ResultDTO;
 import com.becon.opencelium.backend.resource.connector.ConnectorResource;
 import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -65,18 +62,18 @@ import java.util.*;
 public class ConnectorController {
 
     private final ConnectorService connectorService;
-    private final InvokerService invokerService;
+    private final ConnectorHealthService connectorHealthService;
     private final ConnectionService connectionService;
     private final Mapper<Connector, ConnectorResource> connectorResourceMapper;
 
     public ConnectorController(
             @Qualifier("connectorServiceImp") ConnectorService connectorService,
-            @Qualifier("invokerServiceImp") InvokerService invokerService,
+            ConnectorHealthService connectorHealthService,
             @Qualifier("connectionServiceImp") ConnectionService connectionService,
             Mapper<Connector, ConnectorResource> connectorResourceMapper
     ) {
         this.connectorService = connectorService;
-        this.invokerService = invokerService;
+        this.connectorHealthService = connectorHealthService;
         this.connectionService = connectionService;
         this.connectorResourceMapper = connectorResourceMapper;
     }
@@ -374,122 +371,26 @@ public class ConnectorController {
     @PostMapping(path = "/check", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> checkCommunication(@RequestBody ConnectorResource connectorResource) throws JsonProcessingException, IOException {
         Connector connector = connectorResourceMapper.toEntity(connectorResource);
-//        Invoker invoker = invokerService.findByName(connector.getInvoker());
-//        AuthFactory authFactory = new AuthFactory();
-//        ApiAuth authenticationType = authFactory.generateAuth(invoker);
-//        authenticationType.getAccessCredentials(connector);
-        ResponseEntity<?> responseEntity;
-        try {
-            responseEntity = connectorService.checkCommunication(connector);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            // The remote request could not be completed (e.g. host unreachable): record it as a
-            // failed test on the saved connector before surfacing the error to the caller.
-            if (connectorResource.getConnectorId() > 0 && connectorService.existsById(connectorResource.getConnectorId())) {
-                connectorService.updateStatus(connectorResource.getConnectorId(), ConnectorStatus.DOWN, ex.getMessage());
-            }
-            throw new CommunicationFailedException();
-        }
-
-        FunctionInvoker functionInvoker = invokerService.getTestFunction(connector.getInvoker());
-
-        Map<String, Object> failBody = null;
-        String formatType = "";
-        if (functionInvoker.getResponse().getFail() != null && functionInvoker.getResponse().getFail().getBody() != null) {
-            formatType = functionInvoker.getResponse().getFail().getBody().getFormat();
-            failBody = functionInvoker.getResponse().getFail().getBody().getFields();
-        }
-
-        String response = "";
-        String fail = convertMapToJson(failBody);
-        if (formatType.equals("json")) {
-            System.out.println(responseEntity.getBody());
-            response = responseEntity.getBody().toString();
-        }
-
-        // Classify the outcome once, so it can be both persisted (for saved connectors) and returned.
-        ConnectorStatus status;
-        String remoteError = null;
-        if ((responseEntity.getStatusCode() == HttpStatus.OK) && hasError(fail, response)) {
-            status = ConnectorStatus.AUTH_FAILED;
-            remoteError = response;
-        } else if (responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED) {
-            status = ConnectorStatus.AUTH_FAILED;
-            remoteError = responseEntity.getBody() != null
-                    ? responseEntity.getBody().toString()
-                    : "Error in remote system";
-        } else {
-            status = ConnectorStatus.UP;
-        }
+        ConnectorHealthService.CheckResult result = connectorHealthService.check(connector);
 
         // Persist the latest result only for a saved connector; an unsaved/new connector has no row.
         if (connectorResource.getConnectorId() > 0 && connectorService.existsById(connectorResource.getConnectorId())) {
-            connectorService.updateStatus(connectorResource.getConnectorId(), status, remoteError);
+            connectorService.updateStatus(connectorResource.getConnectorId(), result.status(), result.error());
         }
 
-        if ((responseEntity.getStatusCode() == HttpStatus.OK) && status != ConnectorStatus.UP) {
+        if (result.status() == ConnectorStatus.DOWN) {
+            // The remote request could not be completed (e.g. host unreachable).
+            throw new CommunicationFailedException();
+        }
+
+        if ((result.httpStatus() == HttpStatus.OK) && result.status() != ConnectorStatus.UP) {
             return ResponseEntity.ok().body("{\"status\":\"401\", \"error\":\"401\"}");
         }
 
-        if (responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED) {
-            return ResponseEntity.ok().body("{\"status\":\"" + responseEntity.getStatusCode() + "\",\"error\":\"Error in remote system\"}");
+        if (result.httpStatus() == HttpStatus.UNAUTHORIZED) {
+            return ResponseEntity.ok().body("{\"status\":\"" + result.httpStatus() + "\",\"error\":\"Error in remote system\"}");
         }
         return ResponseEntity.ok().body("{\"status\":\"200\"}");
-    }
-
-    public static String convertMapToJson(Map<String, Object> map) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            return objectMapper.writeValueAsString(map);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    private boolean hasError(String failBody, String response) {
-        if (failBody == null || failBody.isEmpty()) {
-            return false;
-        }
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode invFailNode = objectMapper.readTree(failBody);
-            JsonNode responseNode = objectMapper.readTree(response);
-
-            return containsProperties(responseNode, invFailNode);
-
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private boolean containsProperties(JsonNode jsonNode1, JsonNode jsonNode2) {
-        if (jsonNode2.isObject()) {
-            for (String key : iterable(jsonNode2.fieldNames())) {
-                if (!jsonNode1.has(key)) {
-                    return false;
-                }
-                if (!containsProperties(jsonNode1.get(key), jsonNode2.get(key))) {
-                    return false;
-                }
-            }
-        } else if (jsonNode2.isArray()) {
-            if (!jsonNode1.isArray() || jsonNode1.size() < jsonNode2.size()) {
-                return false;
-            }
-            for (int i = 0; i < jsonNode2.size(); i++) {
-                if (!containsProperties(jsonNode1.get(i), jsonNode2.get(i))) {
-                    return false;
-                }
-            }
-        } else {
-            return jsonNode1.isValueNode() && jsonNode2.isValueNode();
-        }
-        return true;
-    }
-
-    private <T> Iterable<T> iterable(final java.util.Iterator<T> iterator) {
-        return () -> iterator;
     }
 
     @Operation(summary = "Verifies uniqueness of connector title")

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/ConnectorController.java
@@ -30,9 +30,10 @@ import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
 import com.becon.opencelium.backend.enums.ConnectorStatus;
-import com.becon.opencelium.backend.mapper.base.Mapper;
+import com.becon.opencelium.backend.mapper.mysql.ConnectorResourceMapper;
 import com.becon.opencelium.backend.resource.IdentifiersDTO;
 import com.becon.opencelium.backend.resource.application.ResultDTO;
+import com.becon.opencelium.backend.resource.connector.ConnectorMetaDTO;
 import com.becon.opencelium.backend.resource.connector.ConnectorResource;
 import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -64,13 +65,13 @@ public class ConnectorController {
     private final ConnectorService connectorService;
     private final ConnectorHealthService connectorHealthService;
     private final ConnectionService connectionService;
-    private final Mapper<Connector, ConnectorResource> connectorResourceMapper;
+    private final ConnectorResourceMapper connectorResourceMapper;
 
     public ConnectorController(
             @Qualifier("connectorServiceImp") ConnectorService connectorService,
             ConnectorHealthService connectorHealthService,
             @Qualifier("connectionServiceImp") ConnectionService connectionService,
-            Mapper<Connector, ConnectorResource> connectorResourceMapper
+            ConnectorResourceMapper connectorResourceMapper
     ) {
         this.connectorService = connectorService;
         this.connectorHealthService = connectorHealthService;
@@ -160,6 +161,47 @@ public class ConnectorController {
     public ResponseEntity<List<ConnectorResource>> getAll() {
         List<ConnectorResource> connectorResources = connectorResourceMapper.toDTOAll(connectorService.findAll());
         return ResponseEntity.ok(connectorResources);
+    }
+
+    @Operation(summary = "Retrieves the credential-free health/status view of all connectors")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Connector meta data has been successfully retrieved",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConnectorMetaDTO.class)))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+            @ApiResponse(responseCode = "500",
+                    description = "Internal Error",
+                    content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+    })
+    @GetMapping("/meta/all")
+    public ResponseEntity<List<ConnectorMetaDTO>> getAllMeta() {
+        // Raw read on purpose: the meta view carries no credentials, so decryption is skipped.
+        return ResponseEntity.ok(connectorResourceMapper.toMetaDTOAll(connectorService.findAllRaw()));
+    }
+
+    @Operation(summary = "Runs an immediate health check of the connector and returns its current status")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Current connector status; if a check is already in flight, the "
+                            + "stored state is returned without triggering another one",
+                    content = @Content(schema = @Schema(implementation = ConnectorMetaDTO.class))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+            @ApiResponse(responseCode = "500",
+                    description = "Internal Error",
+                    content = @Content(schema = @Schema(implementation = ErrorResource.class))),
+    })
+    @PostMapping("/{id}/status/refresh")
+    public ResponseEntity<ConnectorMetaDTO> refreshStatus(@PathVariable int id) {
+        // getById decrypts the request data the check needs and throws the usual
+        // not-found exception for unknown ids.
+        Connector connector = connectorService.getById(id);
+        connectorHealthService.runCheck(connector);
+        // Reload raw to reflect exactly what runCheck persisted.
+        return ResponseEntity.ok(connectorResourceMapper.toMetaDTO(connectorService.getByIdRaw(id)));
     }
 
     @Operation(summary = "Retrieves all connectors with IDs")

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/entity/Connector.java
@@ -16,6 +16,7 @@
 
 package com.becon.opencelium.backend.database.mysql.entity;
 
+import com.becon.opencelium.backend.enums.ConnectorStatus;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.CreationTimestamp;
@@ -79,9 +80,14 @@ public class Connector {
     @Column(name = "timeout")
     private int timeout;
 
-    // null = never tested, true = passed, false = failed.
-    @Column(name = "last_test_passed")
-    private Boolean lastTestPassed;
+    // Health status determined by the most recent communication check.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private ConnectorStatus status;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "last_checked_at")
+    private Date lastCheckedAt;
 
     // Remote error message from the last failed test; null when passed or never tested.
     @Column(name = "last_test_error", columnDefinition = "TEXT")
@@ -178,12 +184,20 @@ public class Connector {
         this.timeout = timeout;
     }
 
-    public Boolean getLastTestPassed() {
-        return lastTestPassed;
+    public ConnectorStatus getStatus() {
+        return status;
     }
 
-    public void setLastTestPassed(Boolean lastTestPassed) {
-        this.lastTestPassed = lastTestPassed;
+    public void setStatus(ConnectorStatus status) {
+        this.status = status;
+    }
+
+    public Date getLastCheckedAt() {
+        return lastCheckedAt;
+    }
+
+    public void setLastCheckedAt(Date lastCheckedAt) {
+        this.lastCheckedAt = lastCheckedAt;
     }
 
     public String getLastTestError() {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthService.java
@@ -1,0 +1,56 @@
+/*
+ * // Copyright (C) <2020> <becon GmbH>
+ * //
+ * // This program is free software: you can redistribute it and/or modify
+ * // it under the terms of the GNU General Public License as published by
+ * // the Free Software Foundation, version 3 of the License.
+ * //
+ * // This program is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * // GNU General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU General Public License
+ * // along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.becon.opencelium.backend.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import org.springframework.http.HttpStatusCode;
+
+import java.util.Date;
+
+/**
+ * Determines the health of a connector's remote API by sending the invoker's
+ * test request and classifying the outcome.
+ */
+public interface ConnectorHealthService {
+
+    /**
+     * Runs the invoker's test request against the connector's remote API and classifies
+     * the outcome. A request that cannot be completed (host unreachable, timeout, ...)
+     * yields {@link ConnectorStatus#DOWN}; classification itself never throws for that
+     * case. The connector must carry decrypted request data.
+     */
+    CheckResult check(Connector connector);
+
+    /**
+     * Outcome of a single health check.
+     *
+     * @param status     classified health of the remote API
+     * @param error      remote error message; {@code null} when {@code status} is {@code UP}
+     * @param latencyMs  wall-clock duration of the remote request
+     * @param checkedAt  when the check finished
+     * @param httpStatus raw HTTP status of the test response; {@code null} when the
+     *                   request itself failed ({@code status} is {@code DOWN})
+     */
+    record CheckResult(
+            ConnectorStatus status,
+            String error,
+            long latencyMs,
+            Date checkedAt,
+            HttpStatusCode httpStatus) {
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthService.java
@@ -37,6 +37,23 @@ public interface ConnectorHealthService {
     CheckResult check(Connector connector);
 
     /**
+     * The single write path used by the background monitor and the manual refresh:
+     * runs {@link #check}, always persists {@code lastCheckedAt}, and — only when the
+     * flap-damped state machine reports a status transition — persists the new status
+     * and notifies the registered {@link ConnectorStatusListener} strictly afterwards.
+     *
+     * <p>Silently returns when a check for the same connector is already in flight, so
+     * overlapping sweeps and manual refreshes never double-check a connector. The
+     * connector must carry decrypted request data.
+     */
+    void runCheck(Connector connector);
+
+    /**
+     * Drops the in-memory health state of a deleted connector.
+     */
+    void evict(int connectorId);
+
+    /**
      * Outcome of a single health check.
      *
      * @param status     classified health of the remote API

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthServiceImp.java
@@ -16,6 +16,7 @@
 
 package com.becon.opencelium.backend.database.mysql.service;
 
+import com.becon.opencelium.backend.constant.AppYamlPath;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
@@ -24,7 +25,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -32,7 +35,10 @@ import org.springframework.stereotype.Service;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 public class ConnectorHealthServiceImp implements ConnectorHealthService {
@@ -41,13 +47,22 @@ public class ConnectorHealthServiceImp implements ConnectorHealthService {
 
     private final ConnectorService connectorService;
     private final InvokerService invokerService;
+    private final ConnectorStatusListener statusListener;
+    private final int failureThreshold;
+
+    /** In-memory flap-damping state per connector id, lazily seeded from the persisted status. */
+    private final ConcurrentHashMap<Integer, HealthState> states = new ConcurrentHashMap<>();
 
     public ConnectorHealthServiceImp(
             @Qualifier("connectorServiceImp") ConnectorService connectorService,
-            @Qualifier("invokerServiceImp") InvokerService invokerService
+            @Qualifier("invokerServiceImp") InvokerService invokerService,
+            ObjectProvider<ConnectorStatusListener> statusListenerProvider,
+            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_FAILURE_THRESHOLD + ":3}") int failureThreshold
     ) {
         this.connectorService = connectorService;
         this.invokerService = invokerService;
+        this.statusListener = statusListenerProvider.getIfAvailable(() -> (connector, status, result) -> { });
+        this.failureThreshold = failureThreshold;
     }
 
     @Override
@@ -96,8 +111,88 @@ public class ConnectorHealthServiceImp implements ConnectorHealthService {
         return new CheckResult(status, error, latencyMs, new Date(), responseEntity.getStatusCode());
     }
 
+    @Override
+    public void runCheck(Connector connector) {
+        HealthState state = states.computeIfAbsent(
+                connector.getId(), id -> new HealthState(connector.getStatus()));
+        if (!state.tryAcquire()) {
+            log.debug("Health check for connector '{}' already in flight — skipped", connector.getTitle());
+            return;
+        }
+        try {
+            CheckResult result;
+            try {
+                result = check(connector);
+            } catch (Exception ex) {
+                // check() only shields the remote request itself; classification errors
+                // (unknown invoker, unparsable response, ...) also count as DOWN here.
+                log.debug("Health check failed for connector '{}'", connector.getTitle(), ex);
+                result = new CheckResult(ConnectorStatus.DOWN, ex.getMessage(), 0, new Date(), null);
+            }
+            connectorService.updateLastCheckedAt(connector.getId(), result.checkedAt());
+            CheckResult outcome = result;
+            state.apply(result.status(), failureThreshold).ifPresent(newStatus -> {
+                connectorService.updateStatus(connector.getId(), newStatus, outcome.error());
+                statusListener.onStatusTransition(connector, newStatus, outcome);
+            });
+        } finally {
+            state.release();
+        }
+    }
+
+    @Override
+    public void evict(int connectorId) {
+        states.remove(connectorId);
+    }
+
     private static long elapsedMs(long startNanos) {
         return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    /**
+     * Flap-damping state machine for one connector. A failure ({@code DOWN} or
+     * {@code AUTH_FAILED}) is published only after {@code threshold} consecutive
+     * failed checks; recovery to {@code UP} is published on the first success.
+     */
+    static final class HealthState {
+
+        private final AtomicBoolean inFlight = new AtomicBoolean(false);
+        private ConnectorStatus publishedStatus;
+        private int consecutiveFailures;
+
+        HealthState(ConnectorStatus initial) {
+            this.publishedStatus = initial == null ? ConnectorStatus.UNKNOWN : initial;
+        }
+
+        boolean tryAcquire() {
+            return inFlight.compareAndSet(false, true);
+        }
+
+        void release() {
+            inFlight.set(false);
+        }
+
+        /**
+         * Feeds one raw check outcome into the state machine. Returns the new status
+         * exactly when a damped transition happens, empty otherwise.
+         */
+        synchronized Optional<ConnectorStatus> apply(ConnectorStatus raw, int threshold) {
+            if (raw == ConnectorStatus.UP) {
+                consecutiveFailures = 0;
+                if (publishedStatus != ConnectorStatus.UP) {
+                    publishedStatus = ConnectorStatus.UP;
+                    return Optional.of(ConnectorStatus.UP);
+                }
+                return Optional.empty();
+            }
+            // DOWN and AUTH_FAILED are damped identically.
+            consecutiveFailures++;
+            if (consecutiveFailures >= threshold && publishedStatus != raw) {
+                publishedStatus = raw;
+                return Optional.of(raw);
+            }
+            return Optional.empty();
+        }
     }
 
     private static String convertMapToJson(Map<String, Object> map) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthServiceImp.java
@@ -49,6 +49,8 @@ public class ConnectorHealthServiceImp implements ConnectorHealthService {
     private final InvokerService invokerService;
     private final ConnectorStatusListener statusListener;
     private final int failureThreshold;
+    private final boolean requestLoggingEnabled;
+    private final int logMaxBodyLength;
 
     /** In-memory flap-damping state per connector id, lazily seeded from the persisted status. */
     private final ConcurrentHashMap<Integer, HealthState> states = new ConcurrentHashMap<>();
@@ -57,12 +59,16 @@ public class ConnectorHealthServiceImp implements ConnectorHealthService {
             @Qualifier("connectorServiceImp") ConnectorService connectorService,
             @Qualifier("invokerServiceImp") InvokerService invokerService,
             ObjectProvider<ConnectorStatusListener> statusListenerProvider,
-            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_FAILURE_THRESHOLD + ":3}") int failureThreshold
+            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_FAILURE_THRESHOLD + ":3}") int failureThreshold,
+            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_LOG_ENABLED + ":false}") boolean requestLoggingEnabled,
+            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_LOG_MAX_BODY_LENGTH + ":500}") int logMaxBodyLength
     ) {
         this.connectorService = connectorService;
         this.invokerService = invokerService;
         this.statusListener = statusListenerProvider.getIfAvailable(() -> (connector, status, result) -> { });
         this.failureThreshold = failureThreshold;
+        this.requestLoggingEnabled = requestLoggingEnabled;
+        this.logMaxBodyLength = logMaxBodyLength;
     }
 
     @Override
@@ -73,8 +79,10 @@ public class ConnectorHealthServiceImp implements ConnectorHealthService {
             responseEntity = connectorService.checkCommunication(connector);
         } catch (Exception ex) {
             log.debug("Health check request failed for connector '{}'", connector.getTitle(), ex);
-            return new CheckResult(
+            CheckResult failed = new CheckResult(
                     ConnectorStatus.DOWN, ex.getMessage(), elapsedMs(startNanos), new Date(), null);
+            logCheck(connector, failed, null);
+            return failed;
         }
         long latencyMs = elapsedMs(startNanos);
 
@@ -108,7 +116,51 @@ public class ConnectorHealthServiceImp implements ConnectorHealthService {
         } else {
             status = ConnectorStatus.UP;
         }
-        return new CheckResult(status, error, latencyMs, new Date(), responseEntity.getStatusCode());
+        CheckResult result = new CheckResult(status, error, latencyMs, new Date(), responseEntity.getStatusCode());
+        logCheck(connector, result, responseEntity.getBody());
+        return result;
+    }
+
+    /**
+     * Logs one health-check request/response pair at INFO when
+     * {@code opencelium.connector-health.request-logging.enabled} is on. The endpoint is
+     * logged as the invoker's template (placeholders unresolved) on purpose, so
+     * credentials injected into the URL or query string never reach the log. The
+     * response body is truncated to the configured maximum.
+     */
+    private void logCheck(Connector connector, CheckResult result, Object responseBody) {
+        if (!requestLoggingEnabled) {
+            return;
+        }
+        String method = "?";
+        String endpoint = "?";
+        try {
+            FunctionInvoker testFunction = invokerService.getTestFunction(connector.getInvoker());
+            method = testFunction.getRequest().getMethod();
+            endpoint = testFunction.getRequest().getEndpoint();
+        } catch (Exception ignored) {
+            // Unknown or incomplete invoker — the log line still carries the outcome.
+        }
+        String payload = responseBody != null ? String.valueOf(responseBody) : result.error();
+        log.info("Health check: connector='{}' (id={}), request={} {}, outcome={}, http={}, latency={}ms, response={}",
+                connector.getTitle(),
+                connector.getId(),
+                method,
+                endpoint,
+                result.status(),
+                result.httpStatus() == null ? "-" : result.httpStatus(),
+                result.latencyMs(),
+                truncate(payload));
+    }
+
+    private String truncate(String value) {
+        if (value == null) {
+            return "-";
+        }
+        if (value.length() <= logMaxBodyLength) {
+            return value;
+        }
+        return value.substring(0, logMaxBodyLength) + "... (truncated)";
     }
 
     @Override

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorHealthServiceImp.java
@@ -1,0 +1,155 @@
+/*
+ * // Copyright (C) <2020> <becon GmbH>
+ * //
+ * // This program is free software: you can redistribute it and/or modify
+ * // it under the terms of the GNU General Public License as published by
+ * // the Free Software Foundation, version 3 of the License.
+ * //
+ * // This program is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * // GNU General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU General Public License
+ * // along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.becon.opencelium.backend.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
+import com.becon.opencelium.backend.invoker.service.InvokerService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class ConnectorHealthServiceImp implements ConnectorHealthService {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectorHealthServiceImp.class);
+
+    private final ConnectorService connectorService;
+    private final InvokerService invokerService;
+
+    public ConnectorHealthServiceImp(
+            @Qualifier("connectorServiceImp") ConnectorService connectorService,
+            @Qualifier("invokerServiceImp") InvokerService invokerService
+    ) {
+        this.connectorService = connectorService;
+        this.invokerService = invokerService;
+    }
+
+    @Override
+    public CheckResult check(Connector connector) {
+        long startNanos = System.nanoTime();
+        ResponseEntity<?> responseEntity;
+        try {
+            responseEntity = connectorService.checkCommunication(connector);
+        } catch (Exception ex) {
+            log.debug("Health check request failed for connector '{}'", connector.getTitle(), ex);
+            return new CheckResult(
+                    ConnectorStatus.DOWN, ex.getMessage(), elapsedMs(startNanos), new Date(), null);
+        }
+        long latencyMs = elapsedMs(startNanos);
+
+        FunctionInvoker functionInvoker = invokerService.getTestFunction(connector.getInvoker());
+
+        Map<String, Object> failBody = null;
+        String formatType = "";
+        if (functionInvoker.getResponse().getFail() != null && functionInvoker.getResponse().getFail().getBody() != null) {
+            formatType = functionInvoker.getResponse().getFail().getBody().getFormat();
+            failBody = functionInvoker.getResponse().getFail().getBody().getFields();
+        }
+
+        String response = "";
+        String fail = convertMapToJson(failBody);
+        if (formatType.equals("json")) {
+            response = responseEntity.getBody().toString();
+        }
+
+        ConnectorStatus status;
+        String error = null;
+        if ((responseEntity.getStatusCode() == HttpStatus.OK) && hasError(fail, response)) {
+            // 200 whose body matches the invoker's declared fail body — the remote API
+            // signals bad credentials in-band.
+            status = ConnectorStatus.AUTH_FAILED;
+            error = response;
+        } else if (responseEntity.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+            status = ConnectorStatus.AUTH_FAILED;
+            error = responseEntity.getBody() != null
+                    ? responseEntity.getBody().toString()
+                    : "Error in remote system";
+        } else {
+            status = ConnectorStatus.UP;
+        }
+        return new CheckResult(status, error, latencyMs, new Date(), responseEntity.getStatusCode());
+    }
+
+    private static long elapsedMs(long startNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    private static String convertMapToJson(Map<String, Object> map) {
+        try {
+            return new ObjectMapper().writeValueAsString(map);
+        } catch (Exception e) {
+            log.warn("Could not serialize invoker fail body", e);
+            return null;
+        }
+    }
+
+    private static boolean hasError(String failBody, String response) {
+        if (failBody == null || failBody.isEmpty()) {
+            return false;
+        }
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode invFailNode = objectMapper.readTree(failBody);
+            JsonNode responseNode = objectMapper.readTree(response);
+
+            return containsProperties(responseNode, invFailNode);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean containsProperties(JsonNode jsonNode1, JsonNode jsonNode2) {
+        if (jsonNode2.isObject()) {
+            for (String key : iterable(jsonNode2.fieldNames())) {
+                if (!jsonNode1.has(key)) {
+                    return false;
+                }
+                if (!containsProperties(jsonNode1.get(key), jsonNode2.get(key))) {
+                    return false;
+                }
+            }
+        } else if (jsonNode2.isArray()) {
+            if (!jsonNode1.isArray() || jsonNode1.size() < jsonNode2.size()) {
+                return false;
+            }
+            for (int i = 0; i < jsonNode2.size(); i++) {
+                if (!containsProperties(jsonNode1.get(i), jsonNode2.get(i))) {
+                    return false;
+                }
+            }
+        } else {
+            return jsonNode1.isValueNode() && jsonNode2.isValueNode();
+        }
+        return true;
+    }
+
+    private static <T> Iterable<T> iterable(final Iterator<T> iterator) {
+        return () -> iterator;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,6 +64,11 @@ public interface ConnectorService {
      * The error is cleared when the status is {@link ConnectorStatus#UP}.
      */
     void updateStatus(int connectorId, ConnectorStatus status, String error);
+
+    /**
+     * Persists the time of the most recent health check without touching the status.
+     */
+    void updateLastCheckedAt(int connectorId, Date checkedAt);
 
     ResponseEntity<?> getAuthorization(Connector connector);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
@@ -18,6 +18,7 @@ package com.becon.opencelium.backend.database.mysql.service;
 
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.entity.RequestData;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.execution.logger.mapper.ParsedLogLineMapper;
 import com.becon.opencelium.backend.resource.IdentifiersDTO;
 import com.becon.opencelium.backend.resource.connector.ConnectorResource;
@@ -58,9 +59,10 @@ public interface ConnectorService {
     ResponseEntity<?> checkCommunication(Connector connector) throws JsonProcessingException;
 
     /**
-     * Persists the outcome of the most recent remote-API test on a saved connector.
+     * Persists the health status of the most recent remote-API check on a saved connector.
+     * The error is cleared when the status is {@link ConnectorStatus#UP}.
      */
-    void updateTestResult(int connectorId, boolean passed, String error);
+    void updateStatus(int connectorId, ConnectorStatus status, String error);
 
     ResponseEntity<?> getAuthorization(Connector connector);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorService.java
@@ -57,6 +57,19 @@ public interface ConnectorService {
 
     List<Connector> findAll();
 
+    /**
+     * All connectors without decrypting request data — for credential-free views
+     * (e.g. the health/status meta endpoints) only.
+     */
+    List<Connector> findAllRaw();
+
+    /**
+     * One connector without decrypting request data — for credential-free views only.
+     *
+     * @throws com.becon.opencelium.backend.exception.ConnectorNotFoundException when absent
+     */
+    Connector getByIdRaw(int id);
+
     ResponseEntity<?> checkCommunication(Connector connector) throws JsonProcessingException;
 
     /**

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -175,6 +175,17 @@ public class ConnectorServiceImp implements ConnectorService {
     }
 
     @Override
+    public List<Connector> findAllRaw() {
+        return connectorRepository.findAll();
+    }
+
+    @Override
+    public Connector getByIdRaw(int id) {
+        return connectorRepository.findById(id)
+                .orElseThrow(() -> new ConnectorNotFoundException(id));
+    }
+
+    @Override
     public List<Connector> findAllByTitleContains(String title) {
         List<Connector> list = connectorRepository.findAllByTitleContains(title);
         if (list != null && !list.isEmpty()) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -43,6 +43,7 @@ import com.becon.opencelium.backend.utility.StringUtility;
 import com.becon.opencelium.backend.utility.crypto.Encoder;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -63,6 +64,7 @@ public class ConnectorServiceImp implements ConnectorService {
     private final RequestDataService requestDataService;
     private final Environment env;
     private final StorageService storageService;
+    private final ConnectorHealthService connectorHealthService;
 
     public ConnectorServiceImp(
             ConnectorProps connectorProps, ConnectorRepository connectorRepository,
@@ -70,7 +72,9 @@ public class ConnectorServiceImp implements ConnectorService {
             @Qualifier("requestDataServiceImp") RequestDataServiceImp requestDataService,
             Encoder encoder,
             Environment env,
-            StorageService storageService
+            StorageService storageService,
+            // @Lazy breaks the constructor cycle: the health service itself depends on this service.
+            @Lazy ConnectorHealthService connectorHealthService
     ) {
         this.connectorProps = connectorProps;
         this.connectorRepository = connectorRepository;
@@ -79,6 +83,7 @@ public class ConnectorServiceImp implements ConnectorService {
         this.requestDataService = requestDataService;
         this.env = env;
         this.storageService = storageService;
+        this.connectorHealthService = connectorHealthService;
     }
 
     @Override
@@ -126,11 +131,14 @@ public class ConnectorServiceImp implements ConnectorService {
     @Override
     public void deleteById(int id) {
         connectorRepository.deleteById(id);
+        connectorHealthService.evict(id);
     }
 
     @Override
     public void deleteByInvoker(String invokerName) {
+        List<Connector> deleted = connectorRepository.findAllByInvoker(invokerName);
         connectorRepository.deleteByInvoker(invokerName);
+        deleted.forEach(connector -> connectorHealthService.evict(connector.getId()));
     }
 
     @Override
@@ -233,6 +241,14 @@ public class ConnectorServiceImp implements ConnectorService {
         connectorRepository.findById(connectorId).ifPresent(connector -> {
             connector.setStatus(status);
             connector.setLastTestError(status == ConnectorStatus.UP ? null : error);
+            connectorRepository.save(connector);
+        });
+    }
+
+    @Override
+    public void updateLastCheckedAt(int connectorId, Date checkedAt) {
+        connectorRepository.findById(connectorId).ifPresent(connector -> {
+            connector.setLastCheckedAt(checkedAt);
             connectorRepository.save(connector);
         });
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -23,6 +23,7 @@ import com.becon.opencelium.backend.constant.ExceptionMessages;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.entity.RequestData;
 import com.becon.opencelium.backend.database.mysql.repository.ConnectorRepository;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.exception.ConnectorAlreadyExistsException;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
@@ -226,12 +227,12 @@ public class ConnectorServiceImp implements ConnectorService {
     }
 
     @Override
-    public void updateTestResult(int connectorId, boolean passed, String error) {
-        // Load the raw (still-encrypted) entity and touch only the two test-result columns so the
+    public void updateStatus(int connectorId, ConnectorStatus status, String error) {
+        // Load the raw (still-encrypted) entity and touch only the two health columns so the
         // rest of the connector's persisted state (including encrypted request data) is untouched.
         connectorRepository.findById(connectorId).ifPresent(connector -> {
-            connector.setLastTestPassed(passed);
-            connector.setLastTestError(passed ? null : error);
+            connector.setStatus(status);
+            connector.setLastTestError(status == ConnectorStatus.UP ? null : error);
             connectorRepository.save(connector);
         });
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorStatusListener.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorStatusListener.java
@@ -1,0 +1,39 @@
+/*
+ * // Copyright (C) <2020> <becon GmbH>
+ * //
+ * // This program is free software: you can redistribute it and/or modify
+ * // it under the terms of the GNU General Public License as published by
+ * // the Free Software Foundation, version 3 of the License.
+ * //
+ * // This program is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * // GNU General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU General Public License
+ * // along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.becon.opencelium.backend.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService.CheckResult;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+
+/**
+ * Callback invoked by {@link ConnectorHealthService#runCheck} after a damped status
+ * transition has been persisted. Implemented by the WebSocket publisher; when no
+ * implementation is registered, transitions are simply not broadcast.
+ */
+@FunctionalInterface
+public interface ConnectorStatusListener {
+
+    /**
+     * Called strictly after the new status has been written to the database.
+     *
+     * @param connector the checked connector (state as loaded for the check)
+     * @param newStatus the freshly persisted status
+     * @param result    the raw check outcome that triggered the transition
+     */
+    void onStatusTransition(Connector connector, ConnectorStatus newStatus, CheckResult result);
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/enums/ConnectorStatus.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/enums/ConnectorStatus.java
@@ -1,0 +1,19 @@
+package com.becon.opencelium.backend.enums;
+
+/**
+ * Health status of a connector's remote API, as determined by the last communication check.
+ */
+public enum ConnectorStatus {
+
+    /** The remote API answered the test request successfully. */
+    UP,
+
+    /** The remote API is reachable but rejected the configured credentials. */
+    AUTH_FAILED,
+
+    /** The remote API could not be reached or the request failed. */
+    DOWN,
+
+    /** The connector has never been checked. */
+    UNKNOWN
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/socket/ConnectorStatusPublisher.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/socket/ConnectorStatusPublisher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.execution.socket;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService.CheckResult;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorStatusListener;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import com.becon.opencelium.backend.mapper.mysql.ConnectorResourceMapper;
+import com.becon.opencelium.backend.resource.connector.ConnectorMetaDTO;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Broadcasts damped connector status transitions to the
+ * {@link SocketConstant#CONNECTOR_STATUS_DESTINATION} WebSocket topic.
+ *
+ * <p>Wired into {@link com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService}
+ * as the {@link ConnectorStatusListener}, which invokes it exactly once per transition and
+ * strictly after the new status has been persisted.
+ */
+@Component
+public class ConnectorStatusPublisher implements ConnectorStatusListener {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+    private final ConnectorResourceMapper connectorResourceMapper;
+
+    public ConnectorStatusPublisher(
+            SimpMessagingTemplate simpMessagingTemplate,
+            ConnectorResourceMapper connectorResourceMapper
+    ) {
+        this.simpMessagingTemplate = simpMessagingTemplate;
+        this.connectorResourceMapper = connectorResourceMapper;
+    }
+
+    @Override
+    public void onStatusTransition(Connector connector, ConnectorStatus newStatus, CheckResult result) {
+        // The connector object predates the write, so overlay the freshly persisted state.
+        ConnectorMetaDTO meta = connectorResourceMapper.toMetaDTO(connector);
+        meta.setStatus(newStatus);
+        meta.setLastTestError(newStatus == ConnectorStatus.UP ? null : result.error());
+        meta.setLastCheckedAt(result.checkedAt() == null ? null : result.checkedAt().getTime());
+        simpMessagingTemplate.convertAndSend(SocketConstant.CONNECTOR_STATUS_DESTINATION, meta);
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/socket/SocketConstant.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/socket/SocketConstant.java
@@ -16,4 +16,7 @@ public interface SocketConstant {
 
     String USER_SESSION_DESTINATION_PREFIX = "/session";
     String USER_SESSION_DESTINATION = "/session";
+
+    String CONNECTOR_DESTINATION_PREFIX = "/connector"; // Message broker prefix for connector events
+    String CONNECTOR_STATUS_DESTINATION = "/connector/status"; // WebSocket topic for connector health status
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
@@ -11,6 +11,8 @@ import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.Date;
+
 @org.mapstruct.Mapper(
         componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
@@ -32,17 +34,26 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
             @Mapping(target = "invoker", qualifiedByName = {"helperMapper", "getInvokerDTO"}),
             @Mapping(target = "requestData", qualifiedByName = {"requestDataMapper", "toDTO"}),
             @Mapping(target = "sslCert", source = "trustCertificate"),
-            @Mapping(target = "lastTestPassed", source = "lastTestPassed"),
-            @Mapping(target = "lastTestError", source = "lastTestError")
+            @Mapping(target = "status", source = "status"),
+            @Mapping(target = "lastTestError", source = "lastTestError"),
+            @Mapping(target = "lastCheckedAt", source = "lastCheckedAt", qualifiedByName = "dateToEpochMillis")
     })
     ConnectorResource toDTO(Connector entity);
+
+    @Named("dateToEpochMillis")
+    static Long dateToEpochMillis(Date date) {
+        return date == null ? null : date.getTime();
+    }
 
     @Mappings({
             @Mapping(target = "id", source = "connectorId"),
             @Mapping(target = "invoker", source = "invoker.name"),
             @Mapping(target = "icon", expression = "java(StringUtility.findImageFromUrl(dto.getIcon()))"),
             @Mapping(target = "requestData", expression = "java(helperMapper.processRequestData(dto))"),
-            @Mapping(target = "trustCertificate", source = "sslCert")
+            @Mapping(target = "trustCertificate", source = "sslCert"),
+            // Health fields are written only by the backend's own check flow, never from client input.
+            @Mapping(target = "status", ignore = true),
+            @Mapping(target = "lastCheckedAt", ignore = true)
     })
     Connector toEntity(ConnectorResource dto);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/mysql/ConnectorResourceMapper.java
@@ -4,6 +4,7 @@ package com.becon.opencelium.backend.mapper.mysql;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.mapper.utils.HelperMapper;
+import com.becon.opencelium.backend.resource.connector.ConnectorMetaDTO;
 import com.becon.opencelium.backend.resource.connector.ConnectorResource;
 import com.becon.opencelium.backend.utility.StringUtility;
 import org.mapstruct.Mapping;
@@ -12,6 +13,7 @@ import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 import java.util.Date;
+import java.util.List;
 
 @org.mapstruct.Mapper(
         componentModel = "spring",
@@ -43,6 +45,31 @@ public interface ConnectorResourceMapper extends Mapper<Connector, ConnectorReso
     @Named("dateToEpochMillis")
     static Long dateToEpochMillis(Date date) {
         return date == null ? null : date.getTime();
+    }
+
+    /**
+     * Maps to the lightweight health/status view. Touches no request data, so it is
+     * safe on raw (still-encrypted) entities.
+     */
+    default ConnectorMetaDTO toMetaDTO(Connector entity) {
+        if (entity == null) {
+            return null;
+        }
+        ConnectorMetaDTO dto = new ConnectorMetaDTO();
+        dto.setConnectorId(entity.getId());
+        dto.setTitle(entity.getTitle());
+        dto.setIcon(StringUtility.resolveImagePath(entity.getIcon()));
+        dto.setSslCert(entity.isTrustCertificate());
+        dto.setTimeout(entity.getTimeout());
+        dto.setInvoker(new ConnectorMetaDTO.InvokerMetaDTO(entity.getInvoker()));
+        dto.setStatus(entity.getStatus());
+        dto.setLastTestError(entity.getLastTestError());
+        dto.setLastCheckedAt(dateToEpochMillis(entity.getLastCheckedAt()));
+        return dto;
+    }
+
+    default List<ConnectorMetaDTO> toMetaDTOAll(List<Connector> entities) {
+        return entities.stream().map(this::toMetaDTO).toList();
     }
 
     @Mappings({

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorMetaDTO.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorMetaDTO.java
@@ -1,0 +1,136 @@
+/*
+ * // Copyright (C) <2020> <becon GmbH>
+ * //
+ * // This program is free software: you can redistribute it and/or modify
+ * // it under the terms of the GNU General Public License as published by
+ * // the Free Software Foundation, version 3 of the License.
+ * //
+ * // This program is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * // GNU General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU General Public License
+ * // along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.becon.opencelium.backend.resource.connector;
+
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Lightweight connector view for health/status consumers (the {@code /connector/meta/all}
+ * snapshot, the status WebSocket topic, and the manual refresh endpoint). Carries no
+ * credentials, so it can be built without decrypting request data.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConnectorMetaDTO {
+
+    private int connectorId;
+    private String title;
+    private String icon;
+    private boolean sslCert;
+    private int timeout;
+    private InvokerMetaDTO invoker;
+    // Health status determined by the most recent communication check.
+    private ConnectorStatus status;
+    // Remote error message from the last failed check.
+    private String lastTestError;
+    // Epoch millis of the most recent health check; null = never checked.
+    private Long lastCheckedAt;
+
+    public int getConnectorId() {
+        return connectorId;
+    }
+
+    public void setConnectorId(int connectorId) {
+        this.connectorId = connectorId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public boolean isSslCert() {
+        return sslCert;
+    }
+
+    public void setSslCert(boolean sslCert) {
+        this.sslCert = sslCert;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    public InvokerMetaDTO getInvoker() {
+        return invoker;
+    }
+
+    public void setInvoker(InvokerMetaDTO invoker) {
+        this.invoker = invoker;
+    }
+
+    public ConnectorStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ConnectorStatus status) {
+        this.status = status;
+    }
+
+    public String getLastTestError() {
+        return lastTestError;
+    }
+
+    public void setLastTestError(String lastTestError) {
+        this.lastTestError = lastTestError;
+    }
+
+    public Long getLastCheckedAt() {
+        return lastCheckedAt;
+    }
+
+    public void setLastCheckedAt(Long lastCheckedAt) {
+        this.lastCheckedAt = lastCheckedAt;
+    }
+
+    /** Invoker reference reduced to its name — the meta view never ships operations. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class InvokerMetaDTO {
+
+        private String name;
+
+        public InvokerMetaDTO() {
+        }
+
+        public InvokerMetaDTO(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorResource.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/resource/connector/ConnectorResource.java
@@ -16,6 +16,7 @@
 
 package com.becon.opencelium.backend.resource.connector;
 
+import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Resource;
 
@@ -33,10 +34,12 @@ public class ConnectorResource {
     private boolean sslCert;
     private int timeout;
     private Map<String, String> requestData;
-    // Result of the most recent remote-API test: null = never tested, true = passed, false = failed.
-    private Boolean lastTestPassed;
+    // Health status determined by the most recent communication check.
+    private ConnectorStatus status;
     // Remote error message from the last failed test.
     private String lastTestError;
+    // Epoch millis of the most recent health check; null = never checked.
+    private Long lastCheckedAt;
 
     public int getConnectorId() {
         return connectorId;
@@ -102,12 +105,20 @@ public class ConnectorResource {
         this.requestData = requestData;
     }
 
-    public Boolean getLastTestPassed() {
-        return lastTestPassed;
+    public ConnectorStatus getStatus() {
+        return status;
     }
 
-    public void setLastTestPassed(Boolean lastTestPassed) {
-        this.lastTestPassed = lastTestPassed;
+    public void setStatus(ConnectorStatus status) {
+        this.status = status;
+    }
+
+    public Long getLastCheckedAt() {
+        return lastCheckedAt;
+    }
+
+    public void setLastCheckedAt(Long lastCheckedAt) {
+        this.lastCheckedAt = lastCheckedAt;
     }
 
     public String getLastTestError() {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/ConnectorHealthMonitor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/ConnectorHealthMonitor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.scheduler;
+
+import com.becon.opencelium.backend.constant.AppYamlPath;
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Periodic sweep that health-checks every connector's remote API in the background.
+ *
+ * <p>Each sweep loads all connectors and submits one check per connector to a dedicated
+ * bounded executor, so slow remotes never block the scheduler thread. The connector list
+ * is shuffled per sweep and the bounded pool staggers the actual request start times,
+ * which spreads the load on the remote systems (start jitter). Requests honor each
+ * connector's own {@code timeout}. Flap damping and persistence live in
+ * {@link ConnectorHealthService#runCheck}.
+ */
+@Component
+public class ConnectorHealthMonitor {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectorHealthMonitor.class);
+
+    private final ConnectorService connectorService;
+    private final ConnectorHealthService connectorHealthService;
+    private final ThreadPoolTaskExecutor executor;
+    private final boolean enabled;
+
+    public ConnectorHealthMonitor(
+            @Qualifier("connectorServiceImp") ConnectorService connectorService,
+            ConnectorHealthService connectorHealthService,
+            @Qualifier("connectorHealthTaskExecutor") ThreadPoolTaskExecutor executor,
+            @Value("${" + AppYamlPath.CONNECTOR_HEALTH_ENABLED + ":true}") boolean enabled
+    ) {
+        this.connectorService = connectorService;
+        this.connectorHealthService = connectorHealthService;
+        this.executor = executor;
+        this.enabled = enabled;
+    }
+
+    @Scheduled(
+            fixedDelayString = "${" + AppYamlPath.CONNECTOR_HEALTH_INTERVAL + ":300000}",
+            initialDelayString = "${" + AppYamlPath.CONNECTOR_HEALTH_INITIAL_DELAY + ":60000}"
+    )
+    public void sweep() {
+        if (!enabled) {
+            return;
+        }
+        List<Connector> connectors;
+        try {
+            // findAll decrypts every connector's request data; if any row cannot be
+            // decrypted the sweep is skipped entirely and statuses stay as they are.
+            connectors = new ArrayList<>(connectorService.findAll());
+        } catch (RuntimeException e) {
+            log.warn("Connector health sweep skipped: connectors could not be loaded", e);
+            return;
+        }
+        Collections.shuffle(connectors);
+        connectors.forEach(connector -> executor.execute(() -> connectorHealthService.runCheck(connector)));
+        log.debug("Connector health sweep submitted {} checks", connectors.size());
+    }
+}

--- a/src/backend/src/main/resources/application_default.yml
+++ b/src/backend/src/main/resources/application_default.yml
@@ -227,6 +227,25 @@ opencelium:
       initial-delay: 0
   ###########################################################################
   #                                                                         #
+  #   Background connector health monitor                                   #
+  #                                                                         #
+  #   enabled           — master switch for the periodic sweep              #
+  #   interval          — delay between two sweeps in milliseconds          #
+  #   initial-delay     — delay before the first sweep after startup (ms)   #
+  #   failure-threshold — consecutive failed checks before a connector's    #
+  #                       status transitions to DOWN/AUTH_FAILED            #
+  #                       (flap damping); recovery needs a single success   #
+  #   parallelism       — how many connectors are checked concurrently      #
+  #                                                                         #
+  ###########################################################################
+  connector-health:
+    enabled: true
+    interval: 300000
+    initial-delay: 60000
+    failure-threshold: 3
+    parallelism: 4
+  ###########################################################################
+  #                                                                         #
   #   Is customizable                                                       #
   #                                                                         #
   ###########################################################################

--- a/src/backend/src/main/resources/application_default.yml
+++ b/src/backend/src/main/resources/application_default.yml
@@ -236,6 +236,9 @@ opencelium:
   #                       status transitions to DOWN/AUTH_FAILED            #
   #                       (flap damping); recovery needs a single success   #
   #   parallelism       — how many connectors are checked concurrently      #
+  #   request-logging   — INFO-log each check's request (method + endpoint  #
+  #                       template, never resolved credentials) and its     #
+  #                       response (status, latency, truncated body)        #
   #                                                                         #
   ###########################################################################
   connector-health:
@@ -244,6 +247,9 @@ opencelium:
     initial-delay: 60000
     failure-threshold: 3
     parallelism: 4
+    request-logging:
+      enabled: false
+      max-body-length: 500
   ###########################################################################
   #                                                                         #
   #   Is customizable                                                       #

--- a/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
+++ b/src/backend/src/main/resources/db/changelog/mysql/changelog.sql
@@ -734,3 +734,10 @@ INSERT IGNORE INTO role_has_permission (role_id,component_id,permission_id) VALU
 
 --changeset 5.0:7 stripComments:true splitStatements:true endDelimiter:;
 ALTER TABLE connector CHANGE ssl_validation trust_certificate TINYINT(4) DEFAULT NULL;
+--changeset 5.0:8 stripComments:true splitStatements:true endDelimiter:;
+ALTER TABLE `connector` ADD COLUMN IF NOT EXISTS `status` VARCHAR(20) NOT NULL DEFAULT 'UNKNOWN';
+ALTER TABLE `connector` ADD COLUMN IF NOT EXISTS `last_checked_at` TIMESTAMP NULL DEFAULT NULL;
+UPDATE `connector` SET `status` = CASE WHEN `last_test_passed` = 1 THEN 'UP'
+                                       WHEN `last_test_passed` = 0 THEN 'DOWN'
+                                       ELSE 'UNKNOWN' END;
+ALTER TABLE `connector` DROP COLUMN IF EXISTS `last_test_passed`;

--- a/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
+++ b/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
@@ -244,3 +244,23 @@ versions:
         operation: add
         value: 0
         path: opencelium.sweeper.test-connection.initial-delay
+      - changeset: 8
+        operation: add
+        value: true
+        path: opencelium.connector-health.enabled
+      - changeset: 9
+        operation: add
+        value: 300000
+        path: opencelium.connector-health.interval
+      - changeset: 10
+        operation: add
+        value: 60000
+        path: opencelium.connector-health.initial-delay
+      - changeset: 11
+        operation: add
+        value: 3
+        path: opencelium.connector-health.failure-threshold
+      - changeset: 12
+        operation: add
+        value: 4
+        path: opencelium.connector-health.parallelism

--- a/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
+++ b/src/backend/src/main/resources/db/changelog/springboot/application_changelog.yml
@@ -264,3 +264,11 @@ versions:
         operation: add
         value: 4
         path: opencelium.connector-health.parallelism
+      - changeset: 13
+        operation: add
+        value: false
+        path: opencelium.connector-health.request-logging.enabled
+      - changeset: 14
+        operation: add
+        value: 500
+        path: opencelium.connector-health.request-logging.max-body-length

--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectorControllerTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectorControllerTest.java
@@ -14,8 +14,10 @@ import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
-import com.becon.opencelium.backend.mapper.base.Mapper;
+import com.becon.opencelium.backend.mapper.mysql.ConnectorResourceMapper;
+import com.becon.opencelium.backend.resource.connector.ConnectorMetaDTO;
 import com.becon.opencelium.backend.resource.connector.ConnectorResource;
 import com.becon.opencelium.backend.security.AuthenticationFilter;
 import com.becon.opencelium.backend.security.AuthorizationFilter;
@@ -32,19 +34,27 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.mockito.InOrder;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Slice tests for the icon endpoints of {@link ConnectorController}
- * ({@code POST/DELETE /connector/{id}/icon}).
+ * Slice tests for the icon endpoints ({@code POST/DELETE /connector/{id}/icon}) and the
+ * health/status endpoints ({@code GET /connector/meta/all},
+ * {@code POST /connector/{id}/status/refresh}) of {@link ConnectorController}.
  *
  * Web layer only — service beans are mocked. Security filters are excluded so
  * MockMvc reaches the controller directly. RuntimeExceptions thrown by the
@@ -64,7 +74,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         )
 )
 @ActiveProfiles("test")
-@DisplayName("ConnectorController — icon endpoints web slice")
+@DisplayName("ConnectorController — icon and health endpoints web slice")
 class ConnectorControllerTest {
 
     @Autowired
@@ -80,7 +90,7 @@ class ConnectorControllerTest {
     private ConnectionService connectionService;
 
     @MockBean
-    private Mapper<Connector, ConnectorResource> connectorResourceMapper;
+    private ConnectorResourceMapper connectorResourceMapper;
 
     @MockBean
     private MasterPasswordInterceptor masterPasswordInterceptor;
@@ -147,5 +157,99 @@ class ConnectorControllerTest {
 
         mockMvc.perform(delete("/connector/{id}/icon", 99))
                 .andExpect(status().isInternalServerError());
+    }
+
+    // ── GET /connector/meta/all ───────────────────────────────────────────────
+
+    @Test
+    void getAllMetaReturnsCredentialFreeViewWhenConnectorsExist() throws Exception {
+        Connector raw = new Connector();
+        raw.setId(7);
+        when(connectorService.findAllRaw()).thenReturn(java.util.List.of(raw));
+        when(connectorResourceMapper.toMetaDTOAll(java.util.List.of(raw)))
+                .thenReturn(java.util.List.of(aMetaDto()));
+
+        mockMvc.perform(get("/connector/meta/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].connectorId").value(7))
+                .andExpect(jsonPath("$[0].title").value("jira"))
+                .andExpect(jsonPath("$[0].sslCert").value(true))
+                .andExpect(jsonPath("$[0].timeout").value(5000))
+                .andExpect(jsonPath("$[0].status").value("DOWN"))
+                .andExpect(jsonPath("$[0].lastTestError").value("refused"))
+                // Epoch millis, same convention as ConnectorResource.
+                .andExpect(jsonPath("$[0].lastCheckedAt").value(1722249600000L))
+                // The nested invoker is reduced to its name — nothing else is shipped.
+                .andExpect(jsonPath("$[0].invoker.name").value("Jira"))
+                .andExpect(jsonPath("$[0].invoker.operations").doesNotExist())
+                .andExpect(jsonPath("$[0].invoker.requiredData").doesNotExist());
+
+        // The snapshot must never trigger the decrypting read.
+        verify(connectorService, never()).findAll();
+    }
+
+    // ── POST /connector/{id}/status/refresh ───────────────────────────────────
+
+    @Test
+    void refreshStatusRunsCheckAndReturnsPersistedStateWhenConnectorExists() throws Exception {
+        Connector decrypted = new Connector();
+        decrypted.setId(7);
+        Connector persisted = new Connector();
+        persisted.setId(7);
+        when(connectorService.getById(7)).thenReturn(decrypted);
+        when(connectorService.getByIdRaw(7)).thenReturn(persisted);
+        when(connectorResourceMapper.toMetaDTO(persisted)).thenReturn(aMetaDto());
+
+        mockMvc.perform(post("/connector/{id}/status/refresh", 7))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.connectorId").value(7))
+                .andExpect(jsonPath("$.status").value("DOWN"));
+
+        InOrder order = inOrder(connectorHealthService, connectorService);
+        order.verify(connectorHealthService).runCheck(decrypted);
+        order.verify(connectorService).getByIdRaw(7);
+    }
+
+    @Test
+    void refreshStatusReturns500WhenConnectorDoesNotExist() throws Exception {
+        // ConnectorNotFoundException follows the controller's existing not-found style,
+        // which the catch-all exception handler maps to HTTP 500.
+        when(connectorService.getById(99)).thenThrow(new ConnectorNotFoundException(99));
+
+        mockMvc.perform(post("/connector/{id}/status/refresh", 99))
+                .andExpect(status().isInternalServerError());
+
+        verify(connectorHealthService, never()).runCheck(any());
+    }
+
+    @Test
+    void refreshStatusReturnsCurrentStateWhenCheckIsAlreadyInFlight() throws Exception {
+        Connector decrypted = new Connector();
+        decrypted.setId(7);
+        Connector persisted = new Connector();
+        persisted.setId(7);
+        when(connectorService.getById(7)).thenReturn(decrypted);
+        when(connectorService.getByIdRaw(7)).thenReturn(persisted);
+        when(connectorResourceMapper.toMetaDTO(persisted)).thenReturn(aMetaDto());
+        // An in-flight check makes runCheck a silent no-op — the endpoint must still
+        // answer 200 with the currently stored state instead of erroring.
+        doNothing().when(connectorHealthService).runCheck(decrypted);
+
+        mockMvc.perform(post("/connector/{id}/status/refresh", 7))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DOWN"));
+    }
+
+    private static ConnectorMetaDTO aMetaDto() {
+        ConnectorMetaDTO meta = new ConnectorMetaDTO();
+        meta.setConnectorId(7);
+        meta.setTitle("jira");
+        meta.setSslCert(true);
+        meta.setTimeout(5000);
+        meta.setInvoker(new ConnectorMetaDTO.InvokerMetaDTO("Jira"));
+        meta.setStatus(ConnectorStatus.DOWN);
+        meta.setLastTestError("refused");
+        meta.setLastCheckedAt(1_722_249_600_000L);
+        return meta;
     }
 }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectorControllerTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/controller/ConnectorControllerTest.java
@@ -12,9 +12,9 @@ import com.becon.opencelium.backend.configuration.interceptors.MasterPasswordInt
 import com.becon.opencelium.backend.controller.ConnectorController;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
-import com.becon.opencelium.backend.invoker.service.InvokerService;
 import com.becon.opencelium.backend.mapper.base.Mapper;
 import com.becon.opencelium.backend.resource.connector.ConnectorResource;
 import com.becon.opencelium.backend.security.AuthenticationFilter;
@@ -73,8 +73,8 @@ class ConnectorControllerTest {
     @MockBean(name = "connectorServiceImp")
     private ConnectorService connectorService;
 
-    @MockBean(name = "invokerServiceImp")
-    private InvokerService invokerService;
+    @MockBean
+    private ConnectorHealthService connectorHealthService;
 
     @MockBean(name = "connectionServiceImp")
     private ConnectionService connectionService;

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthRequestLoggingTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthRequestLoggingTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthServiceImp;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorStatusListener;
+import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
+import com.becon.opencelium.backend.invoker.entity.RequestInv;
+import com.becon.opencelium.backend.invoker.entity.ResponseInv;
+import com.becon.opencelium.backend.invoker.service.InvokerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the configurable request/response logging of
+ * {@link ConnectorHealthServiceImp} ({@code opencelium.connector-health.request-logging}).
+ *
+ * A Logback {@link ListAppender} is attached to the service's logger to capture what
+ * would be written. Pinned contract: with logging enabled, every check emits exactly
+ * one INFO line carrying the test function's method and unresolved endpoint template,
+ * the outcome, the HTTP status, and the response body (or error) truncated to the
+ * configured maximum; with logging disabled, checks emit no INFO lines at all.
+ *
+ * Run with: ./gradlew test --tests "*.ConnectorHealthRequestLoggingTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectorHealthRequestLoggingTest {
+
+    @Mock
+    private ConnectorService connectorService;
+
+    @Mock
+    private InvokerService invokerService;
+
+    @Mock
+    private ObjectProvider<ConnectorStatusListener> statusListenerProvider;
+
+    private ListAppender<ILoggingEvent> appender;
+
+    private Connector connector;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(statusListenerProvider.getIfAvailable(any())).thenReturn((c, s, r) -> { });
+        appender = new ListAppender<>();
+        appender.start();
+        serviceLogger().addAppender(appender);
+        connector = new Connector();
+        connector.setId(7);
+        connector.setTitle("jira");
+        connector.setInvoker("Jira");
+    }
+
+    @AfterEach
+    void tearDown() {
+        serviceLogger().detachAppender(appender);
+    }
+
+    @Test
+    void checkLogsRequestAndResponseWhenLoggingEnabled() throws Exception {
+        ConnectorHealthServiceImp service = newService(true, 500);
+        doReturn(ResponseEntity.ok("{\"user\":\"admin\"}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunction());
+
+        service.check(connector);
+
+        List<String> infoLines = infoMessages();
+        assertThat(infoLines).hasSize(1);
+        assertThat(infoLines.get(0))
+                .contains("connector='jira' (id=7)")
+                .contains("request=GET {url}/rest/api/2/myself")
+                .contains("outcome=UP")
+                .contains("http=200")
+                .contains("response={\"user\":\"admin\"}");
+    }
+
+    @Test
+    void checkLogsErrorWhenRequestFailsAndLoggingEnabled() throws Exception {
+        ConnectorHealthServiceImp service = newService(true, 500);
+        when(connectorService.checkCommunication(connector))
+                .thenThrow(new RuntimeException("Connection refused"));
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunction());
+
+        service.check(connector);
+
+        List<String> infoLines = infoMessages();
+        assertThat(infoLines).hasSize(1);
+        assertThat(infoLines.get(0))
+                .contains("outcome=DOWN")
+                .contains("http=-")
+                .contains("response=Connection refused");
+    }
+
+    @Test
+    void checkTruncatesResponseBodyWhenLongerThanConfiguredMax() throws Exception {
+        ConnectorHealthServiceImp service = newService(true, 10);
+        doReturn(ResponseEntity.ok("{\"key\":\"0123456789ABCDEF\"}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunction());
+
+        service.check(connector);
+
+        assertThat(infoMessages().get(0))
+                .contains("response={\"key\":\"01... (truncated)")
+                .doesNotContain("ABCDEF");
+    }
+
+    @Test
+    void checkLogsNothingWhenLoggingDisabled() throws Exception {
+        ConnectorHealthServiceImp service = newService(false, 500);
+        doReturn(ResponseEntity.ok("{\"user\":\"admin\"}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunction());
+
+        service.check(connector);
+
+        assertThat(infoMessages()).isEmpty();
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private ConnectorHealthServiceImp newService(boolean loggingEnabled, int maxBodyLength) {
+        return new ConnectorHealthServiceImp(
+                connectorService, invokerService, statusListenerProvider, 3, loggingEnabled, maxBodyLength);
+    }
+
+    private static Logger serviceLogger() {
+        return (Logger) LoggerFactory.getLogger(ConnectorHealthServiceImp.class);
+    }
+
+    private List<String> infoMessages() {
+        return appender.list.stream()
+                .filter(event -> event.getLevel() == Level.INFO)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    /** Test function with a GET method, an unresolved endpoint template, and no fail body. */
+    private static FunctionInvoker aTestFunction() {
+        RequestInv request = new RequestInv();
+        request.setMethod("GET");
+        request.setEndpoint("{url}/rest/api/2/myself");
+
+        FunctionInvoker functionInvoker = new FunctionInvoker();
+        functionInvoker.setRequest(request);
+        functionInvoker.setResponse(new ResponseInv());
+        return functionInvoker;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthServiceImpTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.database.mysql.service;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService.CheckResult;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthServiceImp;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import com.becon.opencelium.backend.invoker.entity.Body;
+import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
+import com.becon.opencelium.backend.invoker.entity.ResponseInv;
+import com.becon.opencelium.backend.invoker.entity.ResultInv;
+import com.becon.opencelium.backend.invoker.service.InvokerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ConnectorHealthServiceImp}, one per classification branch.
+ *
+ * The remote request is stubbed through {@link ConnectorService#checkCommunication}
+ * and the test-function fail body through {@link InvokerService#getTestFunction},
+ * so no HTTP traffic is involved. Pinned contract: 200 with a clean body → UP
+ * (error null), 200 whose body matches the invoker's fail body → AUTH_FAILED
+ * carrying the response, 401 → AUTH_FAILED, request exception → DOWN with a null
+ * httpStatus. Every result carries a checkedAt timestamp and a non-negative latency.
+ *
+ * Run with: ./gradlew test --tests "*.ConnectorHealthServiceImpTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectorHealthServiceImpTest {
+
+    @Mock
+    private ConnectorService connectorService;
+
+    @Mock
+    private InvokerService invokerService;
+
+    private ConnectorHealthServiceImp service;
+
+    private Connector connector;
+
+    @BeforeEach
+    void setUp() {
+        service = new ConnectorHealthServiceImp(connectorService, invokerService);
+        connector = new Connector();
+        connector.setId(7);
+        connector.setTitle("jira");
+        connector.setInvoker("Jira");
+    }
+
+    // ── UP ────────────────────────────────────────────────────────────────────
+
+    @Test
+    void checkReturnsUpWhenResponseIsOkAndBodyIsClean() throws Exception {
+        doReturn(ResponseEntity.ok("{\"user\":\"admin\"}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithFailBody());
+
+        CheckResult result = service.check(connector);
+
+        assertThat(result.status()).isEqualTo(ConnectorStatus.UP);
+        assertThat(result.error()).isNull();
+        assertThat(result.httpStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(result.checkedAt()).isNotNull();
+        assertThat(result.latencyMs()).isNotNegative();
+    }
+
+    @Test
+    void checkReturnsUpWhenInvokerDeclaresNoFailBody() throws Exception {
+        doReturn(ResponseEntity.ok("{\"errorMessages\":[\"auth\"]}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithoutFailBody());
+
+        CheckResult result = service.check(connector);
+
+        // Without a declared fail body there is nothing to match against — 200 means UP.
+        assertThat(result.status()).isEqualTo(ConnectorStatus.UP);
+        assertThat(result.error()).isNull();
+    }
+
+    // ── AUTH_FAILED ───────────────────────────────────────────────────────────
+
+    @Test
+    void checkReturnsAuthFailedWhenOkResponseMatchesFailBody() throws Exception {
+        String responseBody = "{\"errorMessages\":[\"Login denied\"]}";
+        doReturn(ResponseEntity.ok(responseBody))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithFailBody());
+
+        CheckResult result = service.check(connector);
+
+        assertThat(result.status()).isEqualTo(ConnectorStatus.AUTH_FAILED);
+        assertThat(result.error()).isEqualTo(responseBody);
+        assertThat(result.httpStatus()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void checkReturnsAuthFailedWhenResponseIsUnauthorized() throws Exception {
+        doReturn(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("{\"msg\":\"bad token\"}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithFailBody());
+
+        CheckResult result = service.check(connector);
+
+        assertThat(result.status()).isEqualTo(ConnectorStatus.AUTH_FAILED);
+        assertThat(result.error()).isEqualTo("{\"msg\":\"bad token\"}");
+        assertThat(result.httpStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void checkReturnsDefaultErrorWhenUnauthorizedResponseHasNoBody() throws Exception {
+        doReturn(ResponseEntity.status(HttpStatus.UNAUTHORIZED).build())
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithoutFailBody());
+
+        CheckResult result = service.check(connector);
+
+        assertThat(result.status()).isEqualTo(ConnectorStatus.AUTH_FAILED);
+        assertThat(result.error()).isEqualTo("Error in remote system");
+    }
+
+    // ── DOWN ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void checkReturnsDownWhenRequestThrows() throws Exception {
+        when(connectorService.checkCommunication(connector))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        CheckResult result = service.check(connector);
+
+        assertThat(result.status()).isEqualTo(ConnectorStatus.DOWN);
+        assertThat(result.error()).isEqualTo("Connection refused");
+        assertThat(result.httpStatus()).isNull();
+        assertThat(result.checkedAt()).isNotNull();
+        assertThat(result.latencyMs()).isNotNegative();
+    }
+
+    @Test
+    void checkReturnsDownWhenRequestTimesOut() throws Exception {
+        when(connectorService.checkCommunication(connector))
+                .thenThrow(new RuntimeException(new SocketTimeoutException("connect timed out")));
+
+        CheckResult result = service.check(connector);
+
+        assertThat(result.status()).isEqualTo(ConnectorStatus.DOWN);
+        assertThat(result.httpStatus()).isNull();
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    /** Test function whose fail body declares {@code {"errorMessages": [...]}} in json format. */
+    private static FunctionInvoker aTestFunctionWithFailBody() {
+        Body body = new Body();
+        body.setFormat("json");
+        body.setFields(Map.of("errorMessages", List.of("auth")));
+
+        ResultInv fail = new ResultInv();
+        fail.setBody(body);
+
+        ResponseInv response = new ResponseInv();
+        response.setFail(fail);
+
+        FunctionInvoker functionInvoker = new FunctionInvoker();
+        functionInvoker.setResponse(response);
+        return functionInvoker;
+    }
+
+    private static FunctionInvoker aTestFunctionWithoutFailBody() {
+        FunctionInvoker functionInvoker = new FunctionInvoker();
+        functionInvoker.setResponse(new ResponseInv());
+        return functionInvoker;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthServiceImpTest.java
@@ -12,6 +12,7 @@ import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService.CheckResult;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthServiceImp;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorStatusListener;
 import com.becon.opencelium.backend.enums.ConnectorStatus;
 import com.becon.opencelium.backend.invoker.entity.Body;
 import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
@@ -23,15 +24,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -49,11 +61,19 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ConnectorHealthServiceImpTest {
 
+    private static final int FAILURE_THRESHOLD = 3;
+
     @Mock
     private ConnectorService connectorService;
 
     @Mock
     private InvokerService invokerService;
+
+    @Mock
+    private ObjectProvider<ConnectorStatusListener> statusListenerProvider;
+
+    @Mock
+    private ConnectorStatusListener statusListener;
 
     private ConnectorHealthServiceImp service;
 
@@ -61,7 +81,9 @@ class ConnectorHealthServiceImpTest {
 
     @BeforeEach
     void setUp() {
-        service = new ConnectorHealthServiceImp(connectorService, invokerService);
+        when(statusListenerProvider.getIfAvailable(any())).thenReturn(statusListener);
+        service = new ConnectorHealthServiceImp(
+                connectorService, invokerService, statusListenerProvider, FAILURE_THRESHOLD);
         connector = new Connector();
         connector.setId(7);
         connector.setTitle("jira");
@@ -166,7 +188,133 @@ class ConnectorHealthServiceImpTest {
         assertThat(result.httpStatus()).isNull();
     }
 
+    // ── runCheck — the damped write path ──────────────────────────────────────
+
+    @Test
+    void runCheckWritesTimestampButNotStatusWhenStatusIsUnchanged() throws Exception {
+        connector.setStatus(ConnectorStatus.UP);
+        stubCheckReturningUp();
+
+        service.runCheck(connector);
+
+        verify(connectorService).updateLastCheckedAt(eq(7), any());
+        verify(connectorService, never()).updateStatus(anyInt(), any(), any());
+        verifyNoInteractions(statusListener);
+    }
+
+    @Test
+    void runCheckPublishesUpWithClearedErrorWhenConnectorRecovers() throws Exception {
+        connector.setStatus(ConnectorStatus.DOWN);
+        stubCheckReturningUp();
+
+        service.runCheck(connector);
+
+        // Recovery is published on the first successful check, with the error cleared,
+        // and the listener fires strictly after the database write.
+        var order = inOrder(connectorService, statusListener);
+        order.verify(connectorService).updateStatus(7, ConnectorStatus.UP, null);
+        order.verify(statusListener).onStatusTransition(eq(connector), eq(ConnectorStatus.UP), any());
+    }
+
+    @Test
+    void runCheckPublishesDownOnlyWhenFailuresReachThreshold() throws Exception {
+        connector.setStatus(ConnectorStatus.UP);
+        when(connectorService.checkCommunication(connector))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        service.runCheck(connector);
+        service.runCheck(connector);
+        verify(connectorService, never()).updateStatus(anyInt(), any(), any());
+
+        service.runCheck(connector);
+
+        verify(connectorService).updateStatus(7, ConnectorStatus.DOWN, "Connection refused");
+        verify(statusListener, times(1)).onStatusTransition(eq(connector), eq(ConnectorStatus.DOWN), any());
+        // The timestamp is written on every check, transition or not.
+        verify(connectorService, times(3)).updateLastCheckedAt(eq(7), any());
+    }
+
+    @Test
+    void runCheckDampsAuthFailedLikeDown() throws Exception {
+        connector.setStatus(ConnectorStatus.UP);
+        doReturn(ResponseEntity.status(HttpStatus.UNAUTHORIZED).build())
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithoutFailBody());
+
+        service.runCheck(connector);
+        service.runCheck(connector);
+        verify(connectorService, never()).updateStatus(anyInt(), any(), any());
+
+        service.runCheck(connector);
+
+        verify(connectorService).updateStatus(7, ConnectorStatus.AUTH_FAILED, "Error in remote system");
+    }
+
+    @Test
+    void runCheckTreatsClassificationErrorAsDown() throws Exception {
+        ConnectorHealthServiceImp impatientService = new ConnectorHealthServiceImp(
+                connectorService, invokerService, statusListenerProvider, 1);
+        connector.setStatus(ConnectorStatus.UP);
+        doReturn(ResponseEntity.ok("{}")).when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenThrow(new RuntimeException("Invoker not found"));
+
+        impatientService.runCheck(connector);
+
+        verify(connectorService).updateLastCheckedAt(eq(7), any());
+        verify(connectorService).updateStatus(7, ConnectorStatus.DOWN, "Invoker not found");
+    }
+
+    @Test
+    void runCheckSkipsWhenCheckForSameConnectorIsInFlight() throws Exception {
+        connector.setStatus(ConnectorStatus.UP);
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        when(connectorService.checkCommunication(connector)).thenAnswer(invocation -> {
+            entered.countDown();
+            release.await(5, TimeUnit.SECONDS);
+            return ResponseEntity.ok("{}");
+        });
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithoutFailBody());
+        Thread firstCheck = new Thread(() -> service.runCheck(connector));
+        firstCheck.start();
+        assertThat(entered.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // While the first check still holds the in-flight flag, a second call must
+        // return immediately without touching the remote API or the database.
+        service.runCheck(connector);
+
+        release.countDown();
+        firstCheck.join(TimeUnit.SECONDS.toMillis(5));
+        verify(connectorService, times(1)).checkCommunication(connector);
+        verify(connectorService, times(1)).updateLastCheckedAt(eq(7), any());
+    }
+
+    @Test
+    void runCheckRestartsFailureCounterWhenStateWasEvicted() throws Exception {
+        connector.setStatus(ConnectorStatus.UP);
+        when(connectorService.checkCommunication(connector))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        service.runCheck(connector);
+        service.runCheck(connector);
+        service.evict(7);
+        // Without the eviction the third failure would have crossed the threshold.
+        service.runCheck(connector);
+        service.runCheck(connector);
+        verify(connectorService, never()).updateStatus(anyInt(), any(), any());
+
+        service.runCheck(connector);
+
+        verify(connectorService, times(1)).updateStatus(7, ConnectorStatus.DOWN, "Connection refused");
+    }
+
     // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private void stubCheckReturningUp() throws Exception {
+        doReturn(ResponseEntity.ok("{\"user\":\"admin\"}"))
+                .when(connectorService).checkCommunication(connector);
+        when(invokerService.getTestFunction("Jira")).thenReturn(aTestFunctionWithoutFailBody());
+    }
 
     /** Test function whose fail body declares {@code {"errorMessages": [...]}} in json format. */
     private static FunctionInvoker aTestFunctionWithFailBody() {

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorHealthServiceImpTest.java
@@ -83,7 +83,7 @@ class ConnectorHealthServiceImpTest {
     void setUp() {
         when(statusListenerProvider.getIfAvailable(any())).thenReturn(statusListener);
         service = new ConnectorHealthServiceImp(
-                connectorService, invokerService, statusListenerProvider, FAILURE_THRESHOLD);
+                connectorService, invokerService, statusListenerProvider, FAILURE_THRESHOLD, false, 500);
         connector = new Connector();
         connector.setId(7);
         connector.setTitle("jira");
@@ -253,7 +253,7 @@ class ConnectorHealthServiceImpTest {
     @Test
     void runCheckTreatsClassificationErrorAsDown() throws Exception {
         ConnectorHealthServiceImp impatientService = new ConnectorHealthServiceImp(
-                connectorService, invokerService, statusListenerProvider, 1);
+                connectorService, invokerService, statusListenerProvider, 1, false, 500);
         connector.setStatus(ConnectorStatus.UP);
         doReturn(ResponseEntity.ok("{}")).when(connectorService).checkCommunication(connector);
         when(invokerService.getTestFunction("Jira")).thenThrow(new RuntimeException("Invoker not found"));

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorServiceImpIconTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/database/mysql/service/ConnectorServiceImpIconTest.java
@@ -3,6 +3,7 @@ package com.becon.opencelium.backend.unit.database.mysql.service;
 import com.becon.opencelium.backend.constant.props.ConnectorProps;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.repository.ConnectorRepository;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorServiceImp;
 import com.becon.opencelium.backend.database.mysql.service.RequestDataServiceImp;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
@@ -52,13 +53,14 @@ class ConnectorServiceImpIconTest {
     @Mock private Encoder encoder;
     @Mock private Environment env;
     @Mock private StorageService storageService;
+    @Mock private ConnectorHealthService connectorHealthService;
 
     private ConnectorServiceImp service;
 
     private ConnectorServiceImp newService() {
         return new ConnectorServiceImp(
                 connectorProps, connectorRepository, invokerService,
-                requestDataService, encoder, env, storageService);
+                requestDataService, encoder, env, storageService, connectorHealthService);
     }
 
     private Connector aConnector(int id, String icon) {

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/socket/ConnectorStatusPublisherTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/execution/socket/ConnectorStatusPublisherTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.execution.socket;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService.CheckResult;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import com.becon.opencelium.backend.execution.socket.ConnectorStatusPublisher;
+import com.becon.opencelium.backend.execution.socket.SocketConstant;
+import com.becon.opencelium.backend.mapper.mysql.ConnectorResourceMapper;
+import com.becon.opencelium.backend.resource.connector.ConnectorMetaDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ConnectorStatusPublisher}.
+ *
+ * Pinned contract: exactly one message per {@code onStatusTransition} call, sent to
+ * {@link SocketConstant#CONNECTOR_STATUS_DESTINATION}, carrying the freshly persisted
+ * state — the transitioned status, the check's error (cleared on UP), and the check's
+ * timestamp — overlaid on the mapped meta view. The publisher itself never fires
+ * without a transition because it is only reachable through the
+ * {@code ConnectorStatusListener} callback (covered by ConnectorHealthServiceImpTest).
+ *
+ * Run with: ./gradlew test --tests "*.ConnectorStatusPublisherTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectorStatusPublisherTest {
+
+    @Mock
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    @Mock
+    private ConnectorResourceMapper connectorResourceMapper;
+
+    private ConnectorStatusPublisher publisher;
+
+    private Connector connector;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new ConnectorStatusPublisher(simpMessagingTemplate, connectorResourceMapper);
+        connector = new Connector();
+        connector.setId(7);
+        connector.setTitle("jira");
+        connector.setInvoker("Jira");
+        ConnectorMetaDTO mapped = new ConnectorMetaDTO();
+        mapped.setConnectorId(7);
+        mapped.setTitle("jira");
+        // Stale values from the entity as loaded before the check — must be overlaid.
+        mapped.setStatus(ConnectorStatus.UP);
+        mapped.setLastTestError(null);
+        when(connectorResourceMapper.toMetaDTO(connector)).thenReturn(mapped);
+    }
+
+    @Test
+    void onStatusTransitionPublishesExactlyOneMessageToStatusTopicWhenCalled() {
+        publisher.onStatusTransition(connector, ConnectorStatus.DOWN, aResult(ConnectorStatus.DOWN, "refused"));
+
+        verify(simpMessagingTemplate, times(1))
+                .convertAndSend(eq(SocketConstant.CONNECTOR_STATUS_DESTINATION), any(ConnectorMetaDTO.class));
+    }
+
+    @Test
+    void onStatusTransitionOverlaysPersistedStateWhenStatusIsDown() {
+        publisher.onStatusTransition(connector, ConnectorStatus.DOWN, aResult(ConnectorStatus.DOWN, "refused"));
+
+        ConnectorMetaDTO sent = capturePublishedMeta();
+        assertThat(sent.getConnectorId()).isEqualTo(7);
+        assertThat(sent.getStatus()).isEqualTo(ConnectorStatus.DOWN);
+        assertThat(sent.getLastTestError()).isEqualTo("refused");
+        assertThat(sent.getLastCheckedAt()).isEqualTo(1_722_249_600_000L);
+    }
+
+    @Test
+    void onStatusTransitionClearsErrorWhenStatusIsUp() {
+        publisher.onStatusTransition(connector, ConnectorStatus.UP, aResult(ConnectorStatus.UP, "stale error"));
+
+        ConnectorMetaDTO sent = capturePublishedMeta();
+        assertThat(sent.getStatus()).isEqualTo(ConnectorStatus.UP);
+        assertThat(sent.getLastTestError()).isNull();
+    }
+
+    private ConnectorMetaDTO capturePublishedMeta() {
+        ArgumentCaptor<ConnectorMetaDTO> captor = ArgumentCaptor.forClass(ConnectorMetaDTO.class);
+        verify(simpMessagingTemplate)
+                .convertAndSend(eq(SocketConstant.CONNECTOR_STATUS_DESTINATION), captor.capture());
+        return captor.getValue();
+    }
+
+    private static CheckResult aResult(ConnectorStatus status, String error) {
+        return new CheckResult(status, error, 12, new Date(1_722_249_600_000L),
+                status == ConnectorStatus.UP ? HttpStatus.OK : null);
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/mapper/mysql/ConnectorResourceMapperTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/mapper/mysql/ConnectorResourceMapperTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.mapper.mysql;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.enums.ConnectorStatus;
+import com.becon.opencelium.backend.mapper.mysql.ConnectorResourceMapper;
+import com.becon.opencelium.backend.mapper.mysql.ConnectorResourceMapperImpl;
+import com.becon.opencelium.backend.mapper.mysql.RequestDataMapper;
+import com.becon.opencelium.backend.mapper.utils.HelperMapper;
+import com.becon.opencelium.backend.resource.connector.ConnectorResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ConnectorResourceMapper}, focused on the connector
+ * health fields introduced with OC-1515.
+ *
+ * Runs the MapStruct-generated {@code ConnectorResourceMapperImpl} directly,
+ * wired to Mockito mocks for {@link HelperMapper} and {@link RequestDataMapper}
+ * via {@link ReflectionTestUtils} — the invoker/request-data mappings are those
+ * collaborators' concern, not this test's.
+ *
+ * Pinned contract: entity → DTO carries {@code status} through as the enum,
+ * converts {@code lastCheckedAt} to epoch millis (null-safe), and passes
+ * {@code lastTestError} through; DTO → entity deliberately ignores the health
+ * fields so client input can never overwrite backend-owned state.
+ *
+ * Run with: ./gradlew test --tests "*.ConnectorResourceMapperTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectorResourceMapperTest {
+
+    @Mock
+    private HelperMapper helperMapper;
+
+    @Mock
+    private RequestDataMapper requestDataMapper;
+
+    private ConnectorResourceMapperImpl mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ConnectorResourceMapperImpl();
+        ReflectionTestUtils.setField(mapper, "helperMapper", helperMapper);
+        ReflectionTestUtils.setField(mapper, "requestDataMapper", requestDataMapper);
+    }
+
+    // ── toDTO — health fields ─────────────────────────────────────────────────
+
+    @Test
+    void toDtoMapsStatusWhenEntityHasStatus() {
+        Connector entity = aConnector();
+        entity.setStatus(ConnectorStatus.AUTH_FAILED);
+
+        ConnectorResource dto = mapper.toDTO(entity);
+
+        assertThat(dto.getStatus()).isEqualTo(ConnectorStatus.AUTH_FAILED);
+    }
+
+    @Test
+    void toDtoMapsStatusToNullWhenEntityStatusIsNull() {
+        Connector entity = aConnector();
+
+        ConnectorResource dto = mapper.toDTO(entity);
+
+        // @JsonInclude(NON_NULL) on the DTO omits a null status from the JSON.
+        assertThat(dto.getStatus()).isNull();
+    }
+
+    @Test
+    void toDtoConvertsLastCheckedAtToEpochMillisWhenEntityHasTimestamp() {
+        Connector entity = aConnector();
+        entity.setLastCheckedAt(new Date(1_722_249_600_000L));
+
+        ConnectorResource dto = mapper.toDTO(entity);
+
+        assertThat(dto.getLastCheckedAt()).isEqualTo(1_722_249_600_000L);
+    }
+
+    @Test
+    void toDtoMapsLastCheckedAtToNullWhenEntityWasNeverChecked() {
+        Connector entity = aConnector();
+
+        ConnectorResource dto = mapper.toDTO(entity);
+
+        assertThat(dto.getLastCheckedAt()).isNull();
+    }
+
+    @Test
+    void toDtoMapsLastTestErrorWhenEntityHasError() {
+        Connector entity = aConnector();
+        entity.setStatus(ConnectorStatus.DOWN);
+        entity.setLastTestError("connect timed out");
+
+        ConnectorResource dto = mapper.toDTO(entity);
+
+        assertThat(dto.getLastTestError()).isEqualTo("connect timed out");
+    }
+
+    // ── toEntity — health fields are backend-owned ────────────────────────────
+
+    @Test
+    void toEntityIgnoresStatusWhenDtoCarriesStatus() {
+        ConnectorResource dto = aResource();
+        dto.setStatus(ConnectorStatus.UP);
+
+        Connector entity = mapper.toEntity(dto);
+
+        assertThat(entity.getStatus()).isNull();
+    }
+
+    @Test
+    void toEntityIgnoresLastCheckedAtWhenDtoCarriesTimestamp() {
+        ConnectorResource dto = aResource();
+        dto.setLastCheckedAt(1_722_249_600_000L);
+
+        Connector entity = mapper.toEntity(dto);
+
+        assertThat(entity.getLastCheckedAt()).isNull();
+    }
+
+    // ── dateToEpochMillis — the @Named conversion itself ──────────────────────
+
+    @Test
+    void dateToEpochMillisReturnsMillisWhenDateIsPresent() {
+        assertThat(ConnectorResourceMapper.dateToEpochMillis(new Date(42L))).isEqualTo(42L);
+    }
+
+    @Test
+    void dateToEpochMillisReturnsNullWhenDateIsNull() {
+        assertThat(ConnectorResourceMapper.dateToEpochMillis(null)).isNull();
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    private static Connector aConnector() {
+        Connector connector = new Connector();
+        connector.setId(7);
+        connector.setTitle("jira");
+        connector.setInvoker("Jira");
+        return connector;
+    }
+
+    private static ConnectorResource aResource() {
+        ConnectorResource dto = new ConnectorResource();
+        dto.setConnectorId(7);
+        dto.setTitle("jira");
+        return dto;
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/mapper/mysql/ConnectorResourceMapperTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/mapper/mysql/ConnectorResourceMapperTest.java
@@ -134,6 +134,49 @@ class ConnectorResourceMapperTest {
         assertThat(entity.getLastCheckedAt()).isNull();
     }
 
+    // ── toMetaDTO — credential-free health view ───────────────────────────────
+
+    @Test
+    void toMetaDtoMapsIdentityAndHealthFieldsWhenEntityIsComplete() {
+        Connector entity = aConnector();
+        entity.setTrustCertificate(true);
+        entity.setTimeout(5000);
+        entity.setStatus(ConnectorStatus.DOWN);
+        entity.setLastTestError("refused");
+        entity.setLastCheckedAt(new Date(1_722_249_600_000L));
+
+        var meta = mapper.toMetaDTO(entity);
+
+        assertThat(meta.getConnectorId()).isEqualTo(7);
+        assertThat(meta.getTitle()).isEqualTo("jira");
+        assertThat(meta.isSslCert()).isTrue();
+        assertThat(meta.getTimeout()).isEqualTo(5000);
+        assertThat(meta.getStatus()).isEqualTo(ConnectorStatus.DOWN);
+        assertThat(meta.getLastTestError()).isEqualTo("refused");
+        assertThat(meta.getLastCheckedAt()).isEqualTo(1_722_249_600_000L);
+    }
+
+    @Test
+    void toMetaDtoNestsInvokerAsNameOnlyObjectWhenEntityHasInvoker() {
+        var meta = mapper.toMetaDTO(aConnector());
+
+        assertThat(meta.getInvoker()).isNotNull();
+        assertThat(meta.getInvoker().getName()).isEqualTo("Jira");
+    }
+
+    @Test
+    void toMetaDtoMapsLastCheckedAtToNullWhenEntityWasNeverChecked() {
+        var meta = mapper.toMetaDTO(aConnector());
+
+        assertThat(meta.getLastCheckedAt()).isNull();
+        assertThat(meta.getStatus()).isNull();
+    }
+
+    @Test
+    void toMetaDtoReturnsNullWhenEntityIsNull() {
+        assertThat(mapper.toMetaDTO(null)).isNull();
+    }
+
     // ── dateToEpochMillis — the @Named conversion itself ──────────────────────
 
     @Test

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/scheduler/ConnectorHealthMonitorTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/scheduler/ConnectorHealthMonitorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.unit.scheduler;
+
+import com.becon.opencelium.backend.database.mysql.entity.Connector;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorHealthService;
+import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
+import com.becon.opencelium.backend.scheduler.ConnectorHealthMonitor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ConnectorHealthMonitor}.
+ *
+ * The executor mock runs submitted tasks inline, so no threads, sleeps, or
+ * Awaitility polling are needed. Pinned contract: a disabled monitor never
+ * touches any collaborator; an enabled sweep submits exactly one
+ * {@code runCheck} per connector; a sweep whose connector load fails (e.g.
+ * credential decryption error) is skipped without submitting anything.
+ *
+ * Run with: ./gradlew test --tests "*.ConnectorHealthMonitorTest"
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectorHealthMonitorTest {
+
+    @Mock
+    private ConnectorService connectorService;
+
+    @Mock
+    private ConnectorHealthService connectorHealthService;
+
+    @Mock
+    private ThreadPoolTaskExecutor executor;
+
+    @Test
+    void sweepDoesNothingWhenDisabled() {
+        ConnectorHealthMonitor monitor = new ConnectorHealthMonitor(
+                connectorService, connectorHealthService, executor, false);
+
+        monitor.sweep();
+
+        verifyNoInteractions(connectorService, connectorHealthService, executor);
+    }
+
+    @Test
+    void sweepSubmitsOneCheckPerConnectorWhenEnabled() {
+        Connector first = aConnector(1);
+        Connector second = aConnector(2);
+        when(connectorService.findAll()).thenReturn(List.of(first, second));
+        doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(executor).execute(any(Runnable.class));
+        ConnectorHealthMonitor monitor = new ConnectorHealthMonitor(
+                connectorService, connectorHealthService, executor, true);
+
+        monitor.sweep();
+
+        verify(connectorHealthService).runCheck(first);
+        verify(connectorHealthService).runCheck(second);
+    }
+
+    @Test
+    void sweepSubmitsNothingWhenConnectorsCannotBeLoaded() {
+        when(connectorService.findAll()).thenThrow(new RuntimeException("decryption failed"));
+        ConnectorHealthMonitor monitor = new ConnectorHealthMonitor(
+                connectorService, connectorHealthService, executor, true);
+
+        monitor.sweep();
+
+        verifyNoInteractions(connectorHealthService, executor);
+    }
+
+    private static Connector aConnector(int id) {
+        Connector connector = new Connector();
+        connector.setId(id);
+        connector.setTitle("connector-" + id);
+        connector.setInvoker("Invoker");
+        return connector;
+    }
+}

--- a/src/backend/src/test/resources/application-test.yml
+++ b/src/backend/src/test/resources/application-test.yml
@@ -63,6 +63,12 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
 
+# ── OpenCelium ────────────────────────────────────────────────────────────────
+#  Background jobs are disabled so tests never fire real remote requests.
+opencelium:
+  connector-health:
+    enabled: false
+
 # ── Logging ───────────────────────────────────────────────────────────────────
 logging:
   level:


### PR DESCRIPTION
# [Added] OC-1515: connector health status with background monitor and websocket events

## What
Replaced the connector's boolean `lastTestPassed` with a persisted `ConnectorStatus` enum
(`UP`/`AUTH_FAILED`/`DOWN`/`UNKNOWN`) plus `lastCheckedAt`, and added a background health
monitor that keeps it current:

- Extracted the `/connector/check` classification logic into `ConnectorHealthService`;
  the endpoint's response bodies are byte-compatible.
- Added a scheduled sweep (`ConnectorHealthMonitor`) that checks every connector's remote
  API through a bounded executor, with flap damping — a failure is published only after
  N consecutive failed checks, recovery after a single success.
- Added a credential-free `ConnectorMetaDTO` served by `GET /connector/meta/all`
  (no decryption) and `POST /connector/{id}/status/refresh` (immediate check), and a
  `/connector/status` STOMP topic that emits one message per damped transition, strictly
  after the DB write.
- Added optional INFO logging of each check's request (method + unresolved endpoint
  template) and response (status, latency, truncated body), off by default.

## Why
Connector credentials silently expire and remote APIs go down; today users only find out
when a connection execution fails. A persisted, damped health status with push updates
lets the frontend show connector state live and lets users trigger a re-check on demand.

**Breaking change:** `ConnectorResource` no longer has `lastTestPassed` — clients must
read `status` (enum) and the new `lastCheckedAt` (epoch millis). Frontend handoff notice
required.

New config under `opencelium.connector-health` (`enabled`, `interval`, `initial-delay`,
`failure-threshold`, `parallelism`, `request-logging.*`) — all keys have code defaults;
registered in `application_default.yml` and `application_changelog.yml`. DB migration:
Liquibase changeset `5.0:8` (adds `status`, `last_checked_at`; drops `last_test_passed`
after value migration).
Closes OC-1515.

## How to test
```bash
# Full unit + slice suite — no Docker needed
./gradlew test

# Focused runs
./gradlew test --tests "*.ConnectorHealthServiceImpTest" --tests "*.ConnectorHealthMonitorTest" \
  --tests "*.ConnectorStatusPublisherTest" --tests "*.ConnectorResourceMapperTest" \
  --tests "*.ConnectorControllerTest" --tests "*.ConnectorHealthRequestLoggingTest"

# Integration suite — Docker required
./gradlew integrationTest
```

Manual: `bootRun` against a migrated DB, subscribe to `/connector/status`, stop a
connector's remote API → `DOWN` after 3 sweeps; bring it back → `UP` after one.
`POST /connector/{id}/status/refresh` short-circuits the wait. Set
`request-logging.enabled: true` to see each check's request/response in the console.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `ConnectorResourceMapperTest`, `ConnectorHealthServiceImpTest`,
      `ConnectorHealthMonitorTest`, `ConnectorStatusPublisherTest`,
      `ConnectorHealthRequestLoggingTest`, `ConnectorControllerTest` (extended),
      `ConnectorServiceImpIconTest` (constructor update)
- [ ] `./gradlew integrationTest` passes — **not run, Docker unavailable**
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed — 6 commits, one per logical stage
