### PR TITLE
Add file size validation on license upload

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/SubscriptionController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/SubscriptionController.java
@@ -18,6 +18,7 @@ import com.becon.opencelium.backend.api.ApiType;
 import com.becon.opencelium.backend.api.module.SubscriptionModule;
 import com.becon.opencelium.backend.subscription.utility.LicenseKeyUtility;
 import com.becon.opencelium.backend.utility.crypto.Base64Utility;
+import com.becon.opencelium.backend.validation.file.FileValidator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,7 @@ import org.springframework.data.domain.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -42,6 +44,7 @@ import java.time.ZoneId;
 @RestController
 @RequestMapping(value = "/subs")
 @Tag(name = "Subscription")
+@Validated
 public class SubscriptionController {
 
     private final ApiClient<ServicePortal> servicePortal;
@@ -143,7 +146,9 @@ public class SubscriptionController {
     }
 
     @PostMapping(value = "/activate/license", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> activateLicense(@RequestParam("file") MultipartFile licenseKey) {
+    public ResponseEntity<?> activateLicense(
+            @FileValidator(maxSize = 10L * 1024 * 1024) @RequestParam("file") MultipartFile licenseKey
+    ) {
         String content;
         try {
             content = new String(licenseKey.getBytes(), StandardCharsets.UTF_8);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/exception/handler/ResponseExceptionHandler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/exception/handler/ResponseExceptionHandler.java
@@ -5,6 +5,8 @@ import com.becon.opencelium.backend.exception.ApplicationConfigValidationExcepti
 import com.becon.opencelium.backend.exception.ApplicationConfigWriteException;
 import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -56,6 +58,25 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
         String uri = ((ServletWebRequest) req).getRequest().getRequestURI();
         return ResponseEntity.internalServerError()
                 .body(new ErrorResource(ex, HttpStatus.INTERNAL_SERVER_ERROR, uri));
+    }
+
+    /**
+     * Handles constraint violations raised on method parameters of {@code @Validated} controllers
+     * (e.g. an uploaded file exceeding the size allowed by {@code @FileValidator}).
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Object> constraintViolationHandler(ConstraintViolationException ex, WebRequest req) {
+        String uri = ((ServletWebRequest) req).getRequest().getRequestURI();
+        ErrorResource errorResource = new ErrorResource();
+        errorResource.setStatus(HttpStatus.BAD_REQUEST);
+        errorResource.setError(HttpStatus.BAD_REQUEST.name());
+        errorResource.setMessage(ex.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining("; ")));
+        errorResource.setTimestamp(new Date());
+        errorResource.setPath(uri);
+        return ResponseEntity.badRequest().body(errorResource);
     }
 
     /**

--- a/src/backend/src/main/java/com/becon/opencelium/backend/validation/file/FileValidator.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/validation/file/FileValidator.java
@@ -1,0 +1,27 @@
+package com.becon.opencelium.backend.validation.file;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = MultipartFileValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FileValidator {
+    String message() default "File size must not exceed {maxSize} bytes";
+
+    /**
+     * Maximum allowed file size in bytes. Defaults to 10 MB.
+     */
+    long maxSize() default 10L * 1024 * 1024;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/validation/file/MultipartFileValidator.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/validation/file/MultipartFileValidator.java
@@ -1,0 +1,20 @@
+package com.becon.opencelium.backend.validation.file;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+public class MultipartFileValidator implements ConstraintValidator<FileValidator, MultipartFile> {
+
+    private long maxSize;
+
+    @Override
+    public void initialize(FileValidator constraintAnnotation) {
+        this.maxSize = constraintAnnotation.maxSize();
+    }
+
+    @Override
+    public boolean isValid(MultipartFile file, ConstraintValidatorContext context) {
+        return file == null || file.getSize() <= maxSize;
+    }
+}


### PR DESCRIPTION
## What
Add a reusable `@FileValidator` bean-validation constraint with a `maxSize` attribute, and apply it to the uploaded file on `POST /subs/activate/license` with a 10 MB limit.

New files:
- `validation/file/FileValidator.java` — the constraint annotation (`maxSize`, defaults to 10 MB)
- `validation/file/MultipartFileValidator.java` — the `ConstraintValidator<FileValidator, MultipartFile>`

Supporting changes:
- `SubscriptionController` — annotated the `file` request param, plus a class-level `@Validated`
- `ResponseExceptionHandler` — new `ConstraintViolationException` handler mapping violations to 400

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed