### PR TITLE
Optimized references management

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -32,6 +32,9 @@ import com.becon.opencelium.backend.enums.Action;
 import com.becon.opencelium.backend.exception.ConnectionNotFoundException;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.mapper.base.Mapper;
+import com.becon.opencelium.backend.reference.ReferenceScanner;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
+import com.becon.opencelium.backend.reference.model.WebhookReference;
 import com.becon.opencelium.backend.resource.IdentifiersDTO;
 import com.becon.opencelium.backend.resource.PatchConnectionDetails;
 import com.becon.opencelium.backend.resource.connection.*;
@@ -59,8 +62,6 @@ import org.springframework.util.CollectionUtils;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -469,7 +470,7 @@ public class ConnectionServiceImp implements ConnectionService {
 
     @Override
     public List<WebhookParamDTO> extractVarsFromJson(String json) throws IOException {
-        ArrayList<String> webhookVarList = new ArrayList<>();
+        List<WebhookReference> webhookVarList = new ArrayList<>();
         extractVars(json, webhookVarList);
         return webhookVarList.stream()
                 .map(webhookService::toParamResource)
@@ -807,7 +808,7 @@ public class ConnectionServiceImp implements ConnectionService {
                 : UpdaterVersion.VERSION_4_8.getVersion();
     }
 
-    private void extractVars(Object json, List<String> varList) {
+    private void extractVars(Object json, List<WebhookReference> varList) {
         if (json instanceof JSONObject jsonObject) {
             for (String key : jsonObject.keySet()) {
                 extractVars(jsonObject.get(key), varList);
@@ -817,11 +818,9 @@ public class ConnectionServiceImp implements ConnectionService {
                 extractVars(o, varList);
             }
         } else if (json instanceof String str) {
-            Pattern pattern = Pattern.compile(RegExpression.webhook);
-            Matcher matcher = pattern.matcher(str);
-            while (matcher.find()) {
-                varList.add(matcher.group(1));
-            }
+            ReferenceScanner.extract(str, ReferenceType.WEBHOOK).stream()
+                    .map(WebhookReference::parse)
+                    .forEach(varList::add);
         }
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookService.java
@@ -18,6 +18,7 @@ package com.becon.opencelium.backend.database.mysql.service;
 
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
 import com.becon.opencelium.backend.database.mysql.entity.Webhook;
+import com.becon.opencelium.backend.reference.model.WebhookReference;
 import com.becon.opencelium.backend.resource.webhook.WebhookParamDTO;
 import com.becon.opencelium.backend.resource.webhook.WebhookResource;
 import com.becon.opencelium.backend.resource.webhook.WebhookTokenResource;
@@ -49,7 +50,7 @@ public interface WebhookService {
 
     boolean existsBySchedulerId(int id);
 
-    WebhookParamDTO toParamResource(String param);
+    WebhookParamDTO toParamResource(WebhookReference param);
 
     Map<String, Object> mergeParams(Map<String, Object> primaryParams, Map<String, Object> additionalParams);
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/WebhookServiceImp.java
@@ -21,7 +21,9 @@ import com.becon.opencelium.backend.constant.ExceptionMessages;
 import com.becon.opencelium.backend.database.mysql.entity.Scheduler;
 import com.becon.opencelium.backend.database.mysql.entity.Webhook;
 import com.becon.opencelium.backend.database.mysql.repository.WebhookRepository;
+import com.becon.opencelium.backend.enums.execution.DataType;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
+import com.becon.opencelium.backend.reference.model.WebhookReference;
 import com.becon.opencelium.backend.resource.webhook.WebhookParamDTO;
 import com.becon.opencelium.backend.resource.webhook.WebhookResource;
 import com.becon.opencelium.backend.resource.webhook.WebhookTokenResource;
@@ -167,18 +169,11 @@ public class WebhookServiceImp implements WebhookService {
     }
 
     @Override
-    public WebhookParamDTO toParamResource(String param) { // param = val:type; type = [string, int, double, boolean, array]
+    public WebhookParamDTO toParamResource(WebhookReference reference) { // param = val:type; type = [string, int, double, boolean, array]
         WebhookParamDTO webhookParamDTO = new WebhookParamDTO();
-        String[] var = param.split(":");
-        if (var.length == 0) {
-            throw new RuntimeException("One of webhook parameters is empty");
-        }
-        webhookParamDTO.setName(var[0]);
-        if (var.length == 1) {
-            webhookParamDTO.setType("string");
-        } else {
-            webhookParamDTO.setType(var[1]);
-        }
+        webhookParamDTO.setName(reference.getPath());
+        DataType dataType = reference.getDataType();
+        webhookParamDTO.setType(dataType == DataType.UNDEFINED ? DataType.STRING.getType() : dataType.getType());
         return webhookParamDTO;
     }
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/Loop.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/execution/oc721/Loop.java
@@ -1,7 +1,7 @@
 package com.becon.opencelium.backend.execution.oc721;
 
-import com.becon.opencelium.backend.constant.RegExpression;
 import com.becon.opencelium.backend.enums.RelationalOperator;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
 import com.becon.opencelium.backend.resource.execution.OperatorEx;
 import com.becon.opencelium.backend.reference.utility.ReferenceUtility;
 
@@ -30,7 +30,7 @@ public class Loop {
     public static Loop fromExpression(String expression) {
         Loop loop = new Loop();
 
-        String wrappedDirectRef = ReferenceUtility.extractReference(expression, RegExpression.wrappedDirectRef);
+        String wrappedDirectRef = ReferenceUtility.extractReference(expression, ReferenceType.WRAPPED_DIRECT);
 
         if (expression.startsWith(FOR_IN.getName())) {
             configureForInLoop(loop, expression, wrappedDirectRef);
@@ -114,7 +114,7 @@ public class Loop {
     }
 
     private static String buildIterableWebhookRef(String expression) {
-        String webhookRef = ReferenceUtility.extractReference(expression, RegExpression.webhook);
+        String webhookRef = ReferenceUtility.extractReference(expression, ReferenceType.WEBHOOK);
 
         int colonIndex = webhookRef.contains(":")
                 ? webhookRef.indexOf(":")

--- a/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/OperationExMapper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/mapper/execution/OperationExMapper.java
@@ -1,6 +1,5 @@
 package com.becon.opencelium.backend.mapper.execution;
 
-import com.becon.opencelium.backend.constant.RegExpression;
 import com.becon.opencelium.backend.database.mongodb.entity.*;
 import com.becon.opencelium.backend.database.mysql.service.ConnectorService;
 import com.becon.opencelium.backend.enums.execution.DataType;
@@ -8,6 +7,12 @@ import com.becon.opencelium.backend.enums.execution.ParamLocation;
 import com.becon.opencelium.backend.enums.execution.ParamStyle;
 import com.becon.opencelium.backend.invoker.entity.FunctionInvoker;
 import com.becon.opencelium.backend.invoker.service.InvokerService;
+import com.becon.opencelium.backend.reference.ReferenceDetector;
+import com.becon.opencelium.backend.reference.ReferenceMatchers;
+import com.becon.opencelium.backend.reference.ReferenceParser;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
+import com.becon.opencelium.backend.reference.model.Reference;
 import com.becon.opencelium.backend.resource.execution.*;
 import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -632,10 +637,7 @@ public class OperationExMapper {
     }
 
     private DataType findTypeOfReference(String value) {
-        if (value.matches(RegExpression.requiredData)
-                || value.matches(RegExpression.enhancement)
-                || value.matches(RegExpression.directRef)
-                || value.matches(RegExpression.webhook)) {
+        if (ReferenceDetector.containsReference(value, ReferenceGroup.DIRECT_WITHOUT_PAGE)) {
             return DataType.UNDEFINED;
         } else {
             return DataType.STRING;
@@ -744,16 +746,15 @@ public class OperationExMapper {
     }
 
     private String extractNameOfRef(String param) {
-        if (param.matches(RegExpression.wrappedDirectRef)) {
-            return param.substring(2, param.length() - 2);
-        } else if (("#" + param).matches(RegExpression.enhancement)) {
-            return param.substring(2, param.length() - 2);
-        } else if (param.matches(RegExpression.requestData)) {
-            return param.substring(1, param.length() - 1);
-        } else if (param.matches(RegExpression.webhook)) {
-            return param.substring(2, param.length() - 1);
+        if (ReferenceMatchers.isEnhancement("#" + param)) {
+            return ReferenceParser.parse(param, ReferenceType.ENHANCEMENT).getName();
         }
-        return param;
+
+        try {
+            return ReferenceParser.parse(param).getName();
+        } catch (Exception e) {
+            return param;
+        }
     }
 
     private static class Tree {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/OCExpressionHelper.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/OCExpressionHelper.java
@@ -11,8 +11,9 @@ import com.becon.opencelium.backend.ocel.operator.operators.OperatorFactory;
 import com.becon.opencelium.backend.ocel.token.Token;
 import com.becon.opencelium.backend.ocel.token.TokenType;
 import com.becon.opencelium.backend.ocel.token.Tokenizer;
-import com.becon.opencelium.backend.ocel.utils.ReferenceUtils;
 import com.becon.opencelium.backend.ocel.utils.ValueUtils;
+import com.becon.opencelium.backend.reference.ReferenceMatchers;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
 import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
 import io.micrometer.common.util.StringUtils;
 
@@ -68,7 +69,7 @@ public class OCExpressionHelper {
             if (tokens.get(0).getType() == TokenType.OPERATOR && tokens.get(1).getType() == TokenType.OPERAND) {
                 OperatorEnum operatorEnum = OperatorEnum.fromName(tokens.get(0).getLexeme());
                 if (!(operatorEnum == OperatorEnum.FOR || operatorEnum == OperatorEnum.FOR_IN)) {
-                    if (ReferenceUtils.isReference(tokens.get(1).getLexeme()) || ValueUtils.isArray(tokens.get(1).getLexeme())) {
+                    if (ReferenceMatchers.isReference(tokens.get(1).getLexeme(), ReferenceGroup.WRAPPED) || ValueUtils.isArray(tokens.get(1).getLexeme())) {
                         throw new InvalidExpressionException(
                                 ErrorCode.INVALID_LOOP_TYPE,
                                 "Loop type is incorrect. Did you mean 'for %s'?".formatted(tokens.get(1).getLexeme())
@@ -83,8 +84,8 @@ public class OCExpressionHelper {
             // SPLIT_STRING
             OperatorEnum operatorEnum = OperatorEnum.fromName(tokens.get(1).getLexeme());
             if (operatorEnum != OperatorEnum.SPLIT_STRING) {
-                if ((ReferenceUtils.isReference(tokens.get(0).getLexeme()) || ValueUtils.isString(tokens.get(0).getLexeme()))
-                        && (ReferenceUtils.isReference(tokens.get(2).getLexeme()) || ValueUtils.isString(tokens.get(2).getLexeme()))) {
+                if ((ReferenceMatchers.isReference(tokens.get(0).getLexeme(), ReferenceGroup.WRAPPED) || ValueUtils.isString(tokens.get(0).getLexeme()))
+                        && (ReferenceMatchers.isReference(tokens.get(2).getLexeme(), ReferenceGroup.WRAPPED) || ValueUtils.isString(tokens.get(2).getLexeme()))) {
                     throw new InvalidExpressionException(
                             ErrorCode.INVALID_LOOP_TYPE,
                             "Loop type is incorrect. Did you mean '%s SplitString %s'?".formatted(tokens.get(0).getLexeme(), tokens.get(2).getLexeme())
@@ -92,13 +93,13 @@ public class OCExpressionHelper {
                 }
                 throw InvalidExpressionException.invalidLoopExpression(exp);
             } else {
-                if (!(ReferenceUtils.isReference(tokens.get(0).getLexeme()) || ValueUtils.isString(tokens.get(0).getLexeme()))) {
+                if (!(ReferenceMatchers.isReference(tokens.get(0).getLexeme(), ReferenceGroup.WRAPPED) || ValueUtils.isString(tokens.get(0).getLexeme()))) {
                     throw new InvalidExpressionException(
                             ErrorCode.INVALID_TOKEN_FOUND,
                             "'%s' is not valid left operand for SplitString".formatted(tokens.get(0).getLexeme())
                     );
                 }
-                if (!(ReferenceUtils.isReference(tokens.get(2).getLexeme()) || ValueUtils.isString(tokens.get(2).getLexeme()))) {
+                if (!(ReferenceMatchers.isReference(tokens.get(2).getLexeme(), ReferenceGroup.WRAPPED) || ValueUtils.isString(tokens.get(2).getLexeme()))) {
                     throw new InvalidExpressionException(
                             ErrorCode.INVALID_TOKEN_FOUND,
                             "'%s' is not valid right operand for SplitString".formatted(tokens.get(2).getLexeme())

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operand/OperandUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/operand/OperandUtils.java
@@ -1,7 +1,8 @@
 package com.becon.opencelium.backend.ocel.operand;
 
-import com.becon.opencelium.backend.ocel.utils.ReferenceUtils;
 import com.becon.opencelium.backend.ocel.utils.ValueUtils;
+import com.becon.opencelium.backend.reference.ReferenceMatchers;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
 
 import java.util.List;
 
@@ -10,7 +11,7 @@ public class OperandUtils {
         return "null".equals(token)
                 || "true".equals(token)
                 || "false".equals(token)
-                || ReferenceUtils.isReference(token)
+                || ReferenceMatchers.isReference(token, ReferenceGroup.WRAPPED)
                 || ValueUtils.isString(token)
                 || ValueUtils.isNumberStr(token)
                 || ValueUtils.isArray(token)

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/PostfixExpressionProcessor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/PostfixExpressionProcessor.java
@@ -10,7 +10,7 @@ import com.becon.opencelium.backend.ocel.exception.InvalidExpressionException;
 import com.becon.opencelium.backend.ocel.token.Token;
 import com.becon.opencelium.backend.ocel.token.TokenType;
 import com.becon.opencelium.backend.ocel.token.Tokenizer;
-import com.becon.opencelium.backend.ocel.utils.ReferenceUtils;
+import com.becon.opencelium.backend.reference.ReferenceMatchers;
 import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
 import org.apache.commons.lang3.StringUtils;
 
@@ -63,7 +63,7 @@ public class PostfixExpressionProcessor implements ExpressionProcessor {
                 if (lexeme == null) {
                     continue;
                 }
-                if (ReferenceUtils.isDirectReference(lexeme)) {
+                if (ReferenceMatchers.isWrappedDirect(lexeme)) {
                     references.add(lexeme);
                 } else {
                     // direct references embedded inside a larger literal

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/PostfixShallowEvaluator.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/PostfixShallowEvaluator.java
@@ -1,7 +1,6 @@
 package com.becon.opencelium.backend.ocel.postfix;
 
 import com.becon.opencelium.backend.ocel.ShallowEvaluator;
-import com.becon.opencelium.backend.ocel.utils.ReferenceUtils;
 import com.becon.opencelium.backend.ocel.exception.ApplyFunctionException;
 import com.becon.opencelium.backend.ocel.function.FunctionFactory;
 import com.becon.opencelium.backend.ocel.operand.Operand;
@@ -15,6 +14,8 @@ import com.becon.opencelium.backend.ocel.operator.Operator;
 import com.becon.opencelium.backend.ocel.utils.RawValueParser;
 import com.becon.opencelium.backend.ocel.token.Token;
 import com.becon.opencelium.backend.ocel.token.TokenType;
+import com.becon.opencelium.backend.reference.ReferenceMatchers;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
 import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
 
 import java.util.*;
@@ -125,7 +126,7 @@ public class PostfixShallowEvaluator implements ShallowEvaluator {
                     }
                 } else if (Objects.equals(token.getType(), TokenType.OPERAND)) {
                     String rawValue = token.getLexeme();
-                    if (ReferenceUtils.isReference(rawValue)) {
+                    if (ReferenceMatchers.isReference(rawValue, ReferenceGroup.WRAPPED)) {
                         operandStack.push(dummy);
                     } else {
                         List<int[]> ints = PathAndReferenceUtility.extractReferenceIndexes(rawValue);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/ValueNode.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/postfix/ValueNode.java
@@ -6,8 +6,9 @@ import com.becon.opencelium.backend.execution.masking.MaskingService;
 import com.becon.opencelium.backend.ocel.exception.InvalidExpressionException;
 import com.becon.opencelium.backend.ocel.exception.ValueParseException;
 import com.becon.opencelium.backend.ocel.utils.RawValueParser;
-import com.becon.opencelium.backend.ocel.utils.ReferenceUtils;
 import com.becon.opencelium.backend.ocel.utils.ValueUtils;
+import com.becon.opencelium.backend.reference.ReferenceMatchers;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
 import com.becon.opencelium.backend.utility.PathAndReferenceUtility;
 
 import java.util.List;
@@ -43,7 +44,7 @@ class ValueNode implements ASTNode {
     }
 
     private Object getValueOfRaw(String rawValue, Function<String, Object> referenceExtractor, OcLogger<ExecutionLog> logger, MaskingService masking) throws ValueParseException, InvalidExpressionException {
-        if (ReferenceUtils.isReference(rawValue)) {
+        if (ReferenceMatchers.isReference(rawValue, ReferenceGroup.WRAPPED)) {
             if (referenceExtractor == null)
                 throw InvalidExpressionException.referenceExtractorNotFound(rawValue);
 

--- a/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ReferenceUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/ocel/utils/ReferenceUtils.java
@@ -21,15 +21,4 @@ public class ReferenceUtils {
     public static Map<String, String> getPreSufMap() {
         return prefixSuffixMap;
     }
-
-    public static boolean isReference(String token) {
-        return token.matches(RegExpression.wrappedDirectRef)
-                || token.matches(RegExpression.enhancement)
-                || token.matches(RegExpression.requestData)
-                || token.matches(RegExpression.webhook);
-    }
-
-    public static boolean isDirectReference(String token) {
-        return token.matches(RegExpression.wrappedDirectRef);
-    }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/Patterns.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/Patterns.java
@@ -1,0 +1,51 @@
+package com.becon.opencelium.backend.reference;
+
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
+
+import java.util.regex.Pattern;
+
+import static com.becon.opencelium.backend.constant.RegExpression.*;
+import static com.becon.opencelium.backend.constant.RegExpression.pageRef;
+import static com.becon.opencelium.backend.constant.RegExpression.requestData;
+import static com.becon.opencelium.backend.constant.RegExpression.webhook;
+
+public interface Patterns {
+    Pattern ALL_CONTAINS_PATTERN =
+            Pattern.compile(
+                    directRef + "|" +
+                            wrappedDirectRef + "|" +
+                            enhancement + "|" +
+                            webhook + "|" +
+                            pageRef + "|" +
+                            requestData
+            );
+
+    Pattern WITHOUT_DIRECT_REF =
+            Pattern.compile(
+                    enhancement + "|" +
+                            webhook + "|" +
+                            pageRef + "|" +
+                            requestData
+            );
+
+    Pattern DIRECT_REF = Pattern.compile(directRef);
+    Pattern WRAPPED_DIRECT_REF = Pattern.compile(wrappedDirectRef);
+    Pattern ENHANCEMENT_REF = Pattern.compile(enhancement);
+    Pattern WEBHOOK_REF = Pattern.compile(webhook);
+    Pattern PAGE_REF = Pattern.compile(pageRef);
+    Pattern REQUEST_DATA_REF = Pattern.compile(requestData);
+
+    /**
+     * Returns the pattern that matches the given reference type.
+     */
+    static Pattern of(ReferenceType type) {
+        return switch (type) {
+            case DIRECT -> DIRECT_REF;
+            case WRAPPED_DIRECT -> WRAPPED_DIRECT_REF;
+            case ENHANCEMENT -> ENHANCEMENT_REF;
+            case WEBHOOK -> WEBHOOK_REF;
+            case PAGE -> PAGE_REF;
+            case REQUEST_DATA -> REQUEST_DATA_REF;
+        };
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceDetector.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceDetector.java
@@ -1,25 +1,9 @@
 package com.becon.opencelium.backend.reference;
 
-import java.util.regex.Pattern;
-
-import static com.becon.opencelium.backend.constant.RegExpression.directRef;
-import static com.becon.opencelium.backend.constant.RegExpression.enhancement;
-import static com.becon.opencelium.backend.constant.RegExpression.pageRef;
-import static com.becon.opencelium.backend.constant.RegExpression.requestData;
-import static com.becon.opencelium.backend.constant.RegExpression.webhook;
-import static com.becon.opencelium.backend.constant.RegExpression.wrappedDirectRef;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
 
 public class ReferenceDetector {
-    private static final Pattern CONTAINS_PATTERN =
-            Pattern.compile(
-                    directRef + "|" +
-                            wrappedDirectRef + "|" +
-                            enhancement + "|" +
-                            webhook + "|" +
-                            pageRef + "|" +
-                            requestData
-            );
-
     private ReferenceDetector() {
     }
 
@@ -32,9 +16,38 @@ public class ReferenceDetector {
             return false;
         }
 
-        return CONTAINS_PATTERN.matcher(expression).find();
+        return Patterns.ALL_CONTAINS_PATTERN.matcher(expression).find();
     }
 
+    public static boolean containsReference(String expression, ReferenceType referenceType) {
+        if (expression == null) {
+            return false;
+        }
+
+        if (!mayContainReference(expression)) {
+            return false;
+        }
+
+        return Patterns.of(referenceType).matcher(expression).find();
+    }
+
+    public static boolean containsReference(String expression, ReferenceGroup group) {
+        if (expression == null) {
+            return false;
+        }
+
+        if (!mayContainReference(expression)) {
+            return false;
+        }
+
+        for (ReferenceType reference : group.getReferences()) {
+            if (containsReference(expression, reference)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Fast pre-check for possible references.

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceMatchers.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceMatchers.java
@@ -1,13 +1,9 @@
 package com.becon.opencelium.backend.reference;
 
-import java.util.regex.Pattern;
+import com.becon.opencelium.backend.reference.enums.ReferenceGroup;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
 
-import static com.becon.opencelium.backend.constant.RegExpression.directRef;
-import static com.becon.opencelium.backend.constant.RegExpression.enhancement;
-import static com.becon.opencelium.backend.constant.RegExpression.pageRef;
-import static com.becon.opencelium.backend.constant.RegExpression.requestData;
-import static com.becon.opencelium.backend.constant.RegExpression.webhook;
-import static com.becon.opencelium.backend.constant.RegExpression.wrappedDirectRef;
+import static com.becon.opencelium.backend.reference.Patterns.*;
 
 /**
  * Low-level reference classifiers.
@@ -17,12 +13,6 @@ import static com.becon.opencelium.backend.constant.RegExpression.wrappedDirectR
  * low-level and performance-oriented.
  */
 public final class ReferenceMatchers {
-    private static final Pattern DIRECT_REF = Pattern.compile(directRef);
-    private static final Pattern WRAPPED_DIRECT_REF = Pattern.compile(wrappedDirectRef);
-    private static final Pattern ENHANCEMENT_REF = Pattern.compile(enhancement);
-    private static final Pattern WEBHOOK_REF = Pattern.compile(webhook);
-    private static final Pattern PAGE_REF = Pattern.compile(pageRef);
-    private static final Pattern REQUEST_DATA_REF = Pattern.compile(requestData);
 
     private ReferenceMatchers() {
     }
@@ -107,5 +97,25 @@ public final class ReferenceMatchers {
         }
 
         return REQUEST_DATA_REF.matcher(ref).matches();
+    }
+
+    public static boolean isReference(String ref, ReferenceGroup group) {
+        for (ReferenceType type : group.getReferences()) {
+            if (isThatReference(ref, type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isThatReference(String ref, ReferenceType type) {
+        return switch (type) {
+            case ENHANCEMENT -> isEnhancement(ref);
+            case PAGE -> isPage(ref);
+            case REQUEST_DATA -> isRequestData(ref);
+            case DIRECT -> isDirect(ref);
+            case WEBHOOK -> isWebhook(ref);
+            case WRAPPED_DIRECT -> isWrappedDirect(ref);
+        };
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceParser.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceParser.java
@@ -1,12 +1,9 @@
 package com.becon.opencelium.backend.reference;
 
-import com.becon.opencelium.backend.reference.model.DirectReference;
-import com.becon.opencelium.backend.reference.model.EnhancementReference;
-import com.becon.opencelium.backend.reference.model.PageReference;
-import com.becon.opencelium.backend.reference.model.Reference;
-import com.becon.opencelium.backend.reference.model.RequestDataReference;
-import com.becon.opencelium.backend.reference.model.WebhookReference;
-import com.becon.opencelium.backend.reference.model.WrappedDirectReference;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
+import com.becon.opencelium.backend.reference.model.*;
+
+import java.util.Optional;
 
 public class ReferenceParser {
 
@@ -39,5 +36,31 @@ public class ReferenceParser {
         }
 
         throw new IllegalArgumentException("Unknown reference: " + ref);
+    }
+
+    public static Optional<Reference> tryParse(String expression, ReferenceType referenceType) {
+        try {
+            return switch (referenceType) {
+                case WEBHOOK -> Optional.of(WebhookReference.parse(expression));
+                case WRAPPED_DIRECT -> Optional.of(WrappedDirectReference.parse(expression));
+                case DIRECT -> Optional.of(DirectReference.parse(expression));
+                case ENHANCEMENT -> Optional.of(EnhancementReference.parse(expression));
+                case PAGE -> Optional.of(PageReference.parse(expression));
+                case REQUEST_DATA -> Optional.of(RequestDataReference.parse(expression));
+            };
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Reference parse(String expression, ReferenceType referenceType) {
+        return switch (referenceType) {
+            case WEBHOOK -> WebhookReference.parse(expression);
+            case WRAPPED_DIRECT -> WrappedDirectReference.parse(expression);
+            case DIRECT -> DirectReference.parse(expression);
+            case ENHANCEMENT -> EnhancementReference.parse(expression);
+            case PAGE -> PageReference.parse(expression);
+            case REQUEST_DATA -> RequestDataReference.parse(expression);
+        };
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceScanner.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/ReferenceScanner.java
@@ -1,26 +1,14 @@
 package com.becon.opencelium.backend.reference;
 
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static com.becon.opencelium.backend.constant.RegExpression.enhancement;
-import static com.becon.opencelium.backend.constant.RegExpression.pageRef;
-import static com.becon.opencelium.backend.constant.RegExpression.requestData;
-import static com.becon.opencelium.backend.constant.RegExpression.webhook;
-import static com.becon.opencelium.backend.constant.RegExpression.wrappedDirectRef;
+import static com.becon.opencelium.backend.reference.Patterns.*;
 
 public final class ReferenceScanner {
-    private static final Pattern EXTRACTION_PATTERN =
-            Pattern.compile(
-                    enhancement + "|" +
-                            webhook + "|" +
-                            pageRef + "|" +
-                            requestData
-            );
-
-    private static final Pattern WRAPPED_DIRECT_REF = Pattern.compile(wrappedDirectRef);
 
     private ReferenceScanner() {
     }
@@ -33,7 +21,7 @@ public final class ReferenceScanner {
         List<String> result = new ArrayList<>();
         char[] copy = expression.toCharArray();
 
-        Matcher matcher = EXTRACTION_PATTERN.matcher(expression);
+        Matcher matcher = WITHOUT_DIRECT_REF.matcher(expression);
         while (matcher.find()) {
             result.add(matcher.group());
 
@@ -44,6 +32,21 @@ public final class ReferenceScanner {
 
         matcher = WRAPPED_DIRECT_REF.matcher(new String(copy));
 
+        while (matcher.find()) {
+            result.add(matcher.group());
+        }
+
+        return result;
+    }
+
+    public static List<String> extract(String expression, ReferenceType type) {
+        if (expression == null || expression.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> result = new ArrayList<>();
+
+        Matcher matcher = Patterns.of(type).matcher(expression);
         while (matcher.find()) {
             result.add(matcher.group());
         }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/enums/ReferenceGroup.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/enums/ReferenceGroup.java
@@ -1,0 +1,18 @@
+package com.becon.opencelium.backend.reference.enums;
+
+import java.util.Set;
+
+public enum ReferenceGroup {
+    WRAPPED(Set.of(ReferenceType.WRAPPED_DIRECT, ReferenceType.ENHANCEMENT, ReferenceType.WEBHOOK, ReferenceType.REQUEST_DATA)),
+    DIRECT_WITHOUT_PAGE(Set.of(ReferenceType.DIRECT, ReferenceType.ENHANCEMENT, ReferenceType.WEBHOOK, ReferenceType.REQUEST_DATA));
+
+    private final Set<ReferenceType> references;
+
+    ReferenceGroup(Set<ReferenceType> references) {
+        this.references = references;
+    }
+
+    public Set<ReferenceType> getReferences() {
+        return references;
+    }
+}

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/DirectReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/DirectReference.java
@@ -95,6 +95,11 @@ public final class DirectReference implements Reference {
         return raw;
     }
 
+    @Override
+    public String getName() {
+        return raw;
+    }
+
     public String getColor() {
         return color;
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/EnhancementReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/EnhancementReference.java
@@ -42,6 +42,11 @@ public final class EnhancementReference implements Reference {
         return raw;
     }
 
+    @Override
+    public String getName() {
+        return raw.substring(3, raw.length() - 2);
+    }
+
     public String getBindId() {
         return bindId;
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/PageReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/PageReference.java
@@ -43,6 +43,11 @@ public final class PageReference implements Reference {
         return raw;
     }
 
+    @Override
+    public String getName() {
+        return raw.substring(2, raw.length() - 1);
+    }
+
     public PageParam getPageParam() {
         return pageParam;
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/Reference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/Reference.java
@@ -5,4 +5,5 @@ import com.becon.opencelium.backend.reference.enums.ReferenceType;
 public sealed interface Reference permits DirectReference, WrappedDirectReference, EnhancementReference, WebhookReference, PageReference, RequestDataReference {
     ReferenceType getType();
     String getRaw();
+    String getName();
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/RequestDataReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/RequestDataReference.java
@@ -45,6 +45,11 @@ public final class RequestDataReference implements Reference {
         return raw;
     }
 
+    @Override
+    public String getName() {
+        return raw.substring(1, raw.length() - 1);
+    }
+
     public Integer getCtorId() {
         return ctorId;
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/WebhookReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/WebhookReference.java
@@ -45,6 +45,11 @@ public final class WebhookReference implements Reference {
         return raw;
     }
 
+    @Override
+    public String getName() {
+        return raw.substring(2, raw.length() - 1);
+    }
+
     public String getPath() {
         return path;
     }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/WrappedDirectReference.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/model/WrappedDirectReference.java
@@ -42,6 +42,11 @@ public final class WrappedDirectReference implements Reference {
         return raw;
     }
 
+    @Override
+    public String getName() {
+        return raw.substring(2, raw.length() - 2);
+    }
+
     /**
      * Returns the unwrapped direct reference.
      */

--- a/src/backend/src/main/java/com/becon/opencelium/backend/reference/utility/ReferenceUtility.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/reference/utility/ReferenceUtility.java
@@ -1,8 +1,10 @@
 package com.becon.opencelium.backend.reference.utility;
 
+import com.becon.opencelium.backend.reference.Patterns;
 import com.becon.opencelium.backend.reference.ReferenceDetector;
 import com.becon.opencelium.backend.reference.ReferenceParser;
 import com.becon.opencelium.backend.reference.ReferenceScanner;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
 import com.becon.opencelium.backend.reference.model.Reference;
 
 import java.util.ArrayList;
@@ -30,8 +32,8 @@ public class ReferenceUtility {
         return "NO ref(" + expression + ")";
     }
 
-    public static String extractReference(String value, String type) {
-        Pattern pattern = Pattern.compile(type);
+    public static String extractReference(String value, ReferenceType type) {
+        Pattern pattern = Patterns.of(type);
         Matcher matcher = pattern.matcher(value);
 
         if (matcher.find()) {

--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/BindingUtility.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/BindingUtility.java
@@ -1,11 +1,14 @@
 package com.becon.opencelium.backend.utility;
 
-import com.becon.opencelium.backend.constant.RegExpression;
 import com.becon.opencelium.backend.database.mongodb.entity.BodyMng;
 import com.becon.opencelium.backend.database.mongodb.entity.FieldBindingMng;
 import com.becon.opencelium.backend.database.mongodb.entity.LinkedFieldMng;
 import com.becon.opencelium.backend.database.mongodb.entity.MethodMng;
 import com.becon.opencelium.backend.exception.FieldTypeMismatchException;
+import com.becon.opencelium.backend.reference.ReferenceDetector;
+import com.becon.opencelium.backend.reference.ReferenceParser;
+import com.becon.opencelium.backend.reference.enums.ReferenceType;
+import com.becon.opencelium.backend.reference.model.Reference;
 
 import java.util.*;
 
@@ -64,11 +67,9 @@ public class BindingUtility {
 
     private static Object findRefAndReplace(Object obj, List<FieldBindingMng> fieldBinding) {
         if (obj instanceof String str) {
-            if (str.matches(RegExpression.enhancement)) {
-                String id = str.replace("#{%", "")
-                        .replace("%}", "");
-
-                obj = getRefOfFB(id, fieldBinding);
+            Optional<Reference> reference = ReferenceParser.tryParse(str, ReferenceType.ENHANCEMENT);
+            if (reference.isPresent()) {
+                obj = getRefOfFB(reference.get().getName(), fieldBinding);
             }
         } else if (obj instanceof List<?> list) {
             List<Object> objects = new ArrayList<>();
@@ -130,7 +131,7 @@ public class BindingUtility {
             List<String[]> variables = PathAndReferenceUtility.getQueryVariables(query);
             out:
             for (String[] p : variables) {
-                if (p[1].matches(".*" + RegExpression.wrappedDirectRef + ".*")) {
+                if (ReferenceDetector.containsReference(p[1], ReferenceType.WRAPPED_DIRECT)) {
                     // p[1] can be:
                     // pure ref - '{%#ffffff.(response).body.$.a.b%}'
                     // one enhancement having several references - '{%#ffffff.(response).body.$.a.b;#ffffff.(response).a.c%}'
@@ -159,7 +160,7 @@ public class BindingUtility {
         List<String> subPaths = PathAndReferenceUtility.splitByDelimiter(path, '/');
         out:
         for (int i = 0; i < subPaths.size(); i++) {
-            if (subPaths.get(i).matches(".*" + RegExpression.wrappedDirectRef + ".*")) {
+            if (ReferenceDetector.containsReference(subPaths.get(i), ReferenceType.WRAPPED_DIRECT)) {
                 for (String ref : refs) {
                     if (!subPaths.get(i).contains(ref)) {
                         continue out;


### PR DESCRIPTION
## What
Move all reference-syntax knowledge into `reference` package. Call sites now use them instead of `String.matches(RegExpression.*)`, inline `Pattern.compile(...)`
and hand-written `substring()` unwrapping: `OCExpressionHelper`, `OperandUtils`, `ValueNode`,
`PostfixShallowEvaluator`, `OperationExMapper`, `BindingUtility`, `Loop`, `ReferenceUtility`,
`ConnectionServiceImp`.

## Why

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
