### PR TITLE
[OC-1398] Tests for ExtraOpsServiceImp - Slice

### DIFF
--- a/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/ExtraOpsRepositoryTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/slice/database/mysql/repository/ExtraOpsRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.becon.opencelium.backend.slice.database.mysql.repository;
+
+import com.becon.opencelium.backend.database.mysql.entity.ActivationRequest;
+import com.becon.opencelium.backend.database.mysql.entity.ExtraOps;
+import com.becon.opencelium.backend.database.mysql.entity.Subscription;
+import com.becon.opencelium.backend.database.mysql.repository.ExtraOpsRepository;
+import com.becon.opencelium.backend.enums.ActivReqStatus;
+import com.becon.opencelium.backend.subscription.enums.ExtraOpsStatus;
+import com.becon.opencelium.backend.testutil.annotation.SliceTest;
+import com.becon.opencelium.backend.testutil.fixture.ActivationRequestFixture;
+import com.becon.opencelium.backend.testutil.fixture.ExtraOpsFixture;
+import com.becon.opencelium.backend.testutil.fixture.SubscriptionFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SliceTest
+@DisplayName("ExtraOpsRepository — JPA slice")
+class ExtraOpsRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private ExtraOpsRepository repository;
+
+    private static final long GENERATED_AT = 1_700_000_000_000L;
+
+    // ── existsByStatus ───────────────────────────────────────────────────────
+
+    @Test
+    void existsByStatusReturnsTrueWhenMatchingExtraOpsExists() {
+        // GIVEN
+        persistAndFlush(ExtraOpsStatus.ACTIVE, GENERATED_AT);
+
+        // WHEN-THEN
+        assertThat(repository.existsByStatus(ExtraOpsStatus.ACTIVE)).isTrue();
+    }
+
+    @Test
+    void existsByStatusReturnsFalseWhenOnlyDifferentStatusExists() {
+        // GIVEN
+        persistAndFlush(ExtraOpsStatus.PENDING, GENERATED_AT);
+
+        // WHEN-THEN
+        assertThat(repository.existsByStatus(ExtraOpsStatus.ACTIVE)).isFalse();
+    }
+
+    // ── existsByGeneratedAt ──────────────────────────────────────────────────
+
+    @Test
+    void existsByGeneratedAtReturnsTrueWhenMatchingExtraOpsExists() {
+        // GIVEN
+        persistAndFlush(ExtraOpsStatus.PENDING, GENERATED_AT);
+
+        // WHEN-THEN
+        assertThat(repository.existsByGeneratedAt(GENERATED_AT)).isTrue();
+    }
+
+    @Test
+    void existsByGeneratedAtReturnsFalseWhenTimestampDoesNotMatch() {
+        // GIVEN
+        persistAndFlush(ExtraOpsStatus.PENDING, GENERATED_AT);
+
+        // WHEN-THEN
+        assertThat(repository.existsByGeneratedAt(GENERATED_AT + 1)).isFalse();
+    }
+
+    // ── findAndLockById ──────────────────────────────────────────────────────
+
+    @Test
+    void findAndLockByIdReturnsExtraOpsWhenIdExists() {
+        // GIVEN
+        ExtraOps extraOps = persistAndFlush(ExtraOpsStatus.ACTIVE, GENERATED_AT);
+        Long id = extraOps.getId();
+        em.clear();
+
+        // WHEN
+        Optional<ExtraOps> result = repository.findAndLockById(id);
+
+        // THEN
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(id);
+    }
+
+    @Test
+    void findAndLockByIdReturnsEmptyWhenIdDoesNotExist() {
+        // GIVEN
+        Long id = Long.MAX_VALUE;
+
+        // WHEN-THEN
+        assertThat(repository.findAndLockById(id)).isEmpty();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private ExtraOps persistAndFlush(ExtraOpsStatus status, long generatedAt) {
+        ActivationRequest activationRequest = em.persist(
+                ActivationRequestFixture.anActivationRequest(ActivReqStatus.PROCESSED, true)
+        );
+
+        Subscription subscription = em.persist(
+                SubscriptionFixture.aSubscription(
+                        UUID.randomUUID().toString(),
+                        "license-" + UUID.randomUUID(),
+                        true,
+                        activationRequest
+                )
+        );
+
+        return em.persistAndFlush(
+                ExtraOpsFixture.anExtraOps(subscription, status, generatedAt)
+        );
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/ExtraOpsFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/ExtraOpsFixture.java
@@ -1,0 +1,34 @@
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.database.mysql.entity.ExtraOps;
+import com.becon.opencelium.backend.database.mysql.entity.Subscription;
+import com.becon.opencelium.backend.subscription.enums.ExtraOpsStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * Object mother for {@link ExtraOps} test data.
+ */
+public final class ExtraOpsFixture {
+    private ExtraOpsFixture() {
+    }
+
+    /**
+     * Creates a transient extra-operations record attached to the supplied subscription.
+     */
+    public static ExtraOps anExtraOps(Subscription subscription, ExtraOpsStatus status, long generatedAt) {
+        ExtraOps extraOps = new ExtraOps();
+
+        extraOps.setSubscription(subscription);
+        extraOps.setStartDate(LocalDateTime.of(2026, 8, 1, 0, 0));
+        extraOps.setEndDate(LocalDateTime.of(2026, 8, 31, 23, 59, 59));
+        extraOps.setStatus(status);
+        extraOps.setCurrentOpsUsage(0L);
+        extraOps.setCurrentOpsUsageHmac("current-ops-usage-hmac");
+        extraOps.setTotalOpsUsage(1_000L);
+        extraOps.setTotalOpsUsageHmac("total-ops-usage-hmac");
+        extraOps.setGeneratedAt(generatedAt);
+
+        return extraOps;
+    }
+}


### PR DESCRIPTION
## What
Add `ExtraOpsRepositoryTest` — 6 slice tests. No inline data creation, uses helper methods.

## Why
Resolves part of: [[OC-1398] Tests for ExtraOpsServiceImp](https://becon.atlassian.net/browse/OC-1398)

## How to test
```bash
./gradlew test --tests "*.ExtraOpsRepositoryTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] No secrets, debug logs, or commented-out code