### PR TITLE
OC-1558 Enforce an invoker naming policy

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/RegExpression.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/RegExpression.java
@@ -4,6 +4,13 @@ public interface RegExpression {
     // Invoker
     String requiredData = "\\{(.*?)\\}";
 
+    /**
+     * Invoker name policy: letters, digits, spaces, '-', '_', '(' and ')'.
+     * A dot is allowed only inside the name: it can neither open nor close the
+     * name and two dots may not follow each other.
+     */
+    String INVOKER_NAME_REGEX = "[\\p{L}\\p{N} _()\\-]+(?:\\.[\\p{L}\\p{N} _()\\-]+)*";
+
     // Reference
     String directRef = "#[a-zA-Z0-9]{6}\\.(\\(response\\)|\\(request\\))\\..+";
     String wrappedDirectRef = "\\{%#[a-zA-Z0-9]{6}\\.(\\(response\\)|\\(request\\))\\..+\\%}";

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/FileController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/FileController.java
@@ -16,7 +16,6 @@
 
 package com.becon.opencelium.backend.controller;
 
-import com.becon.opencelium.backend.constant.PathConstant;
 import com.becon.opencelium.backend.constant.props.OpenceliumProps;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.entity.User;
@@ -35,8 +34,8 @@ import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.becon.opencelium.backend.storage.UserStorageService;
 import com.becon.opencelium.backend.template.entity.Template;
 import com.becon.opencelium.backend.template.service.TemplateServiceImp;
+import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.utility.FileNameUtils;
-import com.becon.opencelium.backend.utility.Xml;
 import com.becon.opencelium.backend.versionmanager.EntityUpdater;
 import com.becon.opencelium.backend.versionmanager.EntityVersionManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,18 +61,14 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.w3c.dom.Document;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
@@ -317,20 +312,15 @@ public class FileController {
     @PostMapping(path = "/invoker", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> uploadInvoker(@RequestParam("file") MultipartFile file) {
         String filename = file.getOriginalFilename();
-        String extension = FileNameUtils.getExtension(file.getOriginalFilename());
+        if (file.isEmpty()) {
+            throw new StorageException("Failed to store empty file " + filename);
+        }
+        Objects.requireNonNull(filename);
+
+        String targetFileName = invokerServiceImp.toStoredFileName(filename);
+        String name = null;
         try {
-            if (file.isEmpty()) {
-                throw new StorageException("Failed to store empty file " + filename);
-            }
-            Objects.requireNonNull(filename);
-            if (filename.contains("..")) {
-                throw new StorageException(
-                        "Cannot store file with relative path outside current directory "
-                                + filename);
-            }
-            Objects.requireNonNull(extension);
-            Xml xml = saveXmlFile(file.getInputStream(), filename);
-            String name = xml.getValueByXPath("//invoker/name");
+            name = invokerServiceImp.storeInvokerFile(file.getInputStream(), targetFileName);
             FileDTO fileDTO = new FileDTO(name);
 
             // update invoker sync table to store latest files information
@@ -338,8 +328,12 @@ public class FileController {
 
             return ResponseEntity.ok(fileDTO);
         }
+        catch (GeneralServiceException e) {
+            // the invoker was rejected before anything was written - report the reason as it is
+            throw e;
+        }
         catch (Exception e) {
-            invokerServiceImp.delete(FileNameUtils.removeExtension(filename));
+            invokerServiceImp.deleteQuietly(name);
             throw new StorageException("Failed to store file " + filename, e);
         }
     }
@@ -383,12 +377,12 @@ public class FileController {
 
             while ((zipEntry = zis.getNextEntry()) != null) {
                 try {
-                    if (zipEntry.isDirectory() || !zipEntry.getName().endsWith(".xml")) {
+                    if (zipEntry.isDirectory() || !zipEntry.getName().toLowerCase(Locale.ROOT).endsWith(".xml")) {
                         continue;
                     }
 
-                    Xml xml = saveXmlFile(zis, zipEntry.getName());
-                    String name = xml.getValueByXPath("//invoker/name");
+                    String name = invokerServiceImp.storeInvokerFile(
+                            zis, invokerServiceImp.toStoredFileName(zipEntry.getName()));
 
                     fileDTOList.add(new FileDTO(name));
 
@@ -400,45 +394,14 @@ public class FileController {
             }
 
             return ResponseEntity.ok(fileDTOList);
+        } catch (GeneralServiceException e) {
+            fileDTOList.forEach(f -> invokerServiceImp.deleteQuietly(f.getId()));
+            throw e;
         } catch (Exception e) {
-            fileDTOList.forEach(f -> invokerServiceImp.delete(f.getId()));
+            fileDTOList.forEach(f -> invokerServiceImp.deleteQuietly(f.getId()));
             throw new StorageException("Failed to store file " + filename, e);
         }
     }
-
-    private Xml saveXmlFile(InputStream inputStream, String filename) {
-        try {
-            DocumentBuilder dBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-            InputStream copyIS = getInputStreamCopy(inputStream);
-            Document doc = dBuilder.parse(copyIS);
-            doc.setDocumentURI(PathConstant.INVOKER + filename);
-            Xml xml = new Xml(doc, filename);
-            xml.save(); // TODO: add to invokerServiceImpl
-            invokerServiceImp.save(doc);
-            copyIS.close();
-            return xml;
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
-    }
-
-    private InputStream getInputStreamCopy(InputStream originInputStream) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        byte[] buffer = new byte[1024];
-        int bytesRead;
-        try {
-            while ((bytesRead = originInputStream.read(buffer)) > -1 ) {
-                baos.write(buffer, 0, bytesRead);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        return new ByteArrayInputStream(baos.toByteArray());
-    }
-
 
     /**
      * @deprecated Connector icon management has moved to the connector resource itself.

--- a/src/backend/src/main/java/com/becon/opencelium/backend/controller/InvokerController.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/controller/InvokerController.java
@@ -16,7 +16,6 @@
 
 package com.becon.opencelium.backend.controller;
 
-import com.becon.opencelium.backend.constant.PathConstant;
 import com.becon.opencelium.backend.database.mysql.entity.Connection;
 import com.becon.opencelium.backend.database.mysql.entity.Connector;
 import com.becon.opencelium.backend.database.mysql.service.ConnectionService;
@@ -55,15 +54,6 @@ import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathFactory;
-import java.io.File;
 import java.io.StringReader;
 import java.util.List;
 import java.util.Objects;
@@ -203,26 +193,13 @@ public class InvokerController {
     public ResponseEntity<?> save(@RequestBody InvokerXMLResource invokerXMLResource) throws Exception {
         Document doc = convertStringToXMLDocument(invokerXMLResource.getXml());
         Objects.requireNonNull(doc);
-        XPathFactory xPathFactory = XPathFactory.newInstance();
-        XPath xpath = xPathFactory.newXPath();
-        XPathExpression expression = xpath.compile("/invoker/name");
-        String filename = expression.evaluate(doc);
-        if (invokerService.existsByName(filename)) {
-            throw new RuntimeException("INVOKER_ALREADY_EXISTS");
-        }
 
-        try {
-            TransformerFactory tFactory = TransformerFactory.newInstance();
-            Transformer transformer = tFactory.newTransformer();
-            DOMSource source = new DOMSource(doc);
-            StreamResult result = new StreamResult(new File(PathConstant.INVOKER + "/" + filename + ".xml"));
-            transformer.transform(source, result);
+        // The name becomes a file name ('<name>.xml') and the key connectors refer to, so the
+        // service validates and normalizes it before anything is written to disk.
+        String filename = invokerService.createInvokerFile(doc);
 
-            // update sync information for new invoker file
-            invokerSyncService.updateSync(filename);
-        } catch (TransformerException ex) {
-            throw new RuntimeException(ex);
-        }
+        // update sync information for new invoker file
+        invokerSyncService.updateSync(filename);
 
         try {
             invokerService.refresh();

--- a/src/backend/src/main/java/com/becon/opencelium/backend/invoker/InvokerContainer.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/invoker/InvokerContainer.java
@@ -17,9 +17,11 @@
 package com.becon.opencelium.backend.invoker;
 
 import com.becon.opencelium.backend.invoker.entity.Invoker;
+import com.becon.opencelium.backend.utility.InvokerNameUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Component
 public class InvokerContainer {
@@ -35,19 +37,31 @@ public class InvokerContainer {
     }
 
     public Invoker getByName(String name) {
-        if (!invokers.containsKey(name)) {
-            for (Invoker invoker : invokers.values()) {
-                if (invoker.getName().equals(name)) {
-                    return invoker;
-                }
-            }
-            throw new RuntimeException("Invoker " + name + " from DB not found in invoker folder");
-        }
-        return invokers.get(name);
+        return findByName(name)
+                .orElseThrow(() -> new RuntimeException("Invoker " + name + " from DB not found in invoker folder"));
     }
 
     public boolean existsByName(String name) {
-        return invokers.get(name) != null;
+        return findByName(name).isPresent();
+    }
+
+    /**
+     * Looks the invoker up by its exact name first and falls back to a case-insensitive match,
+     * because the name may come from a database or a file system that does not preserve case.
+     */
+    public Optional<Invoker> findByName(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        Invoker exact = invokers.get(name);
+        if (exact != null) {
+            return Optional.of(exact);
+        }
+        return invokers.entrySet().stream()
+                .filter(e -> InvokerNameUtils.sameName(e.getKey(), name)
+                        || (e.getValue() != null && InvokerNameUtils.sameName(e.getValue().getName(), name)))
+                .map(Map.Entry::getValue)
+                .findFirst();
     }
 
     public void updateAll(Map<String, Invoker> invokers) {
@@ -59,6 +73,15 @@ public class InvokerContainer {
     }
 
     public void remove(String name) {
-        invokers.remove(name);
+        if (name == null) {
+            return;
+        }
+        if (invokers.remove(name) != null) {
+            return;
+        }
+        invokers.keySet().stream()
+                .filter(key -> InvokerNameUtils.sameName(key, name))
+                .findFirst()
+                .ifPresent(invokers::remove);
     }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/invoker/service/InvokerService.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/invoker/service/InvokerService.java
@@ -24,6 +24,7 @@ import org.w3c.dom.Document;
 
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
+import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,15 @@ public interface InvokerService {
     Document getDocument(String name) throws Exception;
     List<Document> getAllInvokerDocuments();
     void save(Document document);
+
+    String createInvokerFile(Document document);
+
+    String storeInvokerFile(InputStream inputStream, String fileName);
+
+    String toStoredFileName(String fileName);
+
+    /** Best-effort removal used to roll back a failed upload. Never throws. */
+    void deleteQuietly(String name);
     Map<String, String> findAllByPathAsString(String path);
     UpdateInvokerResource toUpdateInvokerResource(Map.Entry<String, String> entry) throws XPathExpressionException;
     Map<String, Invoker> findAllAsMap();

--- a/src/backend/src/main/java/com/becon/opencelium/backend/invoker/service/InvokerServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/invoker/service/InvokerServiceImp.java
@@ -26,24 +26,32 @@ import com.becon.opencelium.backend.invoker.entity.Invoker;
 import com.becon.opencelium.backend.invoker.parser.InvokerParserImp;
 import com.becon.opencelium.backend.resource.application.UpdateInvokerResource;
 import com.becon.opencelium.backend.enums.execution.DataType;
-import com.becon.opencelium.backend.storage.StorageService;
 import com.becon.opencelium.backend.reference.utility.ReferenceUtility;
+import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.utility.FileNameUtils;
+import com.becon.opencelium.backend.utility.InvokerNameUtils;
+import com.becon.opencelium.backend.utility.Xml;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -63,20 +71,14 @@ public class InvokerServiceImp implements InvokerService {
 
     private static final Logger log = LoggerFactory.getLogger(InvokerServiceImp.class);
 
-    @Autowired
-    @Lazy
-    private InvokerContainer invokerContainer;
-
-    @Autowired
-    private StorageService storageService;
-
-    @Lazy
-    @Autowired
-    private InvokerSyncService invokerSyncService;
-
+    private final InvokerContainer invokerContainer;
+    private final InvokerSyncService invokerSyncService;
     private final Path filePath;
 
-    public InvokerServiceImp() {
+    @Autowired
+    public InvokerServiceImp(@Lazy InvokerContainer invokerContainer, @Lazy @Qualifier("invokerSyncServiceImp") InvokerSyncService invokerSyncService) {
+        this.invokerContainer = invokerContainer;
+        this.invokerSyncService = invokerSyncService;
         this.filePath = Paths.get(PathConstant.INVOKER);
     }
 
@@ -117,14 +119,21 @@ public class InvokerServiceImp implements InvokerService {
         return invokerContainer.existsByName(name);
     }
 
+    /**
+     * An invoker is always stored as '<name>.xml', so the file name is matched as given -
+     * only case-insensitively, because on a case-insensitive file system (APFS, NTFS) writing
+     * 'Jira.xml' next to an existing 'jira.xml' silently overwrites it.
+     */
     @Override
     public boolean existsByFileName(String fileName) {
-        String ext = FileNameUtils.getExtension(fileName);
-        if (ext == null || ext.isEmpty()) {
-            fileName += ".xml";
+        if (fileName == null || fileName.isBlank()) {
+            return false;
         }
-        Path path = Path.of(PathConstant.INVOKER + fileName);
-        return exists(path);
+        File[] files = filePath.toFile().listFiles();
+        if (files == null) {
+            return false;
+        }
+        return Arrays.stream(files).anyMatch(file -> file.getName().equalsIgnoreCase(fileName));
     }
 
     @Override
@@ -212,6 +221,13 @@ public class InvokerServiceImp implements InvokerService {
 //            invoker = invoker.replace("%20", " ");
             Invoker invoker =  parser.parse();
             String invokerName = invoker.getName();
+            container.keySet().stream()
+                    .filter(existing -> InvokerNameUtils.sameName(existing, invokerName))
+                    .findFirst()
+                    .ifPresent(existing -> log.warn(
+                            "Invokers '{}' and '{}' differ only in case or in whitespace. "
+                                    + "They are treated as one invoker, so only one of them stays reachable.",
+                            existing, invokerName));
             container.put(invokerName, invoker);
         });
         return container;
@@ -481,6 +497,149 @@ public class InvokerServiceImp implements InvokerService {
     }
 
     @Override
+    public String createInvokerFile(Document document) {
+        String name = applyNamePolicy(document);
+        String fileName = name + ".xml";
+
+        // The container is keyed by the name each file declares, so a file could still be
+        // sitting under this name without the container knowing it.
+        if (existsByName(name) || existsByFileName(fileName)) {
+            throw new GeneralServiceException(HttpStatus.CONFLICT, "INVOKER_ALREADY_EXISTS",
+                    "Invoker '" + name + "' already exists. Invoker names are compared without regard to case.");
+        }
+
+        write(document, fileName);
+        return name;
+    }
+
+    @Override
+    public String storeInvokerFile(InputStream inputStream, String fileName) {
+        Document document = parse(inputStream, fileName);
+
+        // The name is validated and normalized before the file is written, so that a rejected
+        // invoker never leaves a file behind.
+        String name = applyNamePolicy(document);
+        assertNotStoredInAnotherFile(name, fileName);
+
+        write(document, fileName);
+        return name;
+    }
+
+    @Override
+    public String toStoredFileName(String fileName) {
+        Objects.requireNonNull(fileName);
+        String baseName = fileName.replace('\\', '/');
+        baseName = baseName.substring(baseName.lastIndexOf('/') + 1).trim();
+
+        if (baseName.isEmpty() || baseName.equals(".") || baseName.equals("..")) {
+            throw new GeneralServiceException(HttpStatus.BAD_REQUEST, "INVALID_FILE_NAME",
+                    "Cannot store invoker file '" + fileName + "': the file name is empty or points outside "
+                            + "the invoker folder.");
+        }
+        if (!"xml".equalsIgnoreCase(FileNameUtils.getExtension(baseName))) {
+            throw new GeneralServiceException(HttpStatus.BAD_REQUEST, "INVALID_FILE_NAME",
+                    "Invoker file '" + fileName + "' must have the '.xml' extension.");
+        }
+        return baseName;
+    }
+
+    @Override
+    public void deleteQuietly(String name) {
+        if (name == null) {
+            return;
+        }
+        try {
+            delete(name);
+        } catch (Exception e) {
+            log.warn("Failed to roll back invoker '{}'", name, e);
+        }
+    }
+
+    /**
+     * Validates the name declared in '/invoker/name' against the naming policy and writes the
+     * normalized form back, so that the stored file, the name node and the container key all
+     * carry the very same value.
+     *
+     * @return the normalized invoker name
+     */
+    private String applyNamePolicy(Document document) {
+        Node nameNode = findNameNode(document);
+
+        // a document without the node carries no name, which validate() rejects - so once it
+        // returns, the node is there to write the normalized name back into
+        String name = InvokerNameUtils.validate(nameNode == null ? null : nameNode.getTextContent());
+        nameNode.setTextContent(name);
+        return name;
+    }
+
+    private static Node findNameNode(Document document) {
+        try {
+            return (Node) XPathFactory.newInstance().newXPath()
+                    .compile("/invoker/name").evaluate(document, XPathConstants.NODE);
+        } catch (XPathExpressionException e) {
+            throw new StorageException("Failed to read the invoker name", e);
+        }
+    }
+
+    /**
+     * Two files declaring the same invoker name would shadow each other in the invoker
+     * container, so a file may only be overwritten by the invoker it already carries.
+     */
+    private void assertNotStoredInAnotherFile(String name, String fileName) {
+        if (!existsByName(name)) {
+            return;
+        }
+
+        String existingFileName;
+        try {
+            existingFileName = findFileByInvokerName(name).getName();
+        } catch (RuntimeException e) {
+            // the container knows the invoker but no file declares it any more - nothing to shadow
+            log.warn("No file found for invoker '{}' while storing '{}'", name, fileName, e);
+            return;
+        }
+
+        if (!existingFileName.equalsIgnoreCase(fileName)) {
+            throw new GeneralServiceException(HttpStatus.CONFLICT, "INVOKER_ALREADY_EXISTS",
+                    "Invoker '" + name + "' is already stored in '" + existingFileName
+                            + "'. Invoker names are compared without regard to case.");
+        }
+    }
+
+    private Document parse(InputStream inputStream, String fileName) {
+        try {
+            // The stream may be a ZipInputStream sitting on an entry: read the entry's bytes
+            // first so that the parser cannot close the archive they belong to.
+            byte[] content = inputStream.readAllBytes();
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            return builder.parse(new ByteArrayInputStream(content));
+        } catch (Exception e) {
+            throw new StorageException("Failed to read invoker file " + fileName, e);
+        }
+    }
+
+    /**
+     * Serializes the document into the invoker folder and registers the invoker in the container.
+     *
+     * <p>Serializing goes through {@link Xml#writeTo(Path)} - the same call the upload path uses,
+     * so both write invoker files the same way. It wraps the plain identity transformer and owns
+     * the output stream, because a handle the transformer leaves open keeps the file locked on
+     * Windows until GC. The single-argument {@link Xml} constructor is deliberate: the two-argument
+     * one reads the {@code type} attribute off the {@code <invoker>} element and fails on a
+     * document that omits it.
+     */
+    private void write(Document document, String fileName) {
+        Path target = filePath.resolve(fileName);
+        try {
+            document.setDocumentURI(target.toString());
+            new Xml(document).writeTo(target);
+            save(document);
+        } catch (Exception e) {
+            throw new StorageException("Failed to store invoker file " + fileName, e);
+        }
+    }
+
+    @Override
     public File findFileByInvokerName(String invokerName) {
         return findInvokerFile(invokerName)
                 .orElseThrow(() -> new RuntimeException("Invoker '" + invokerName + "' not found."));
@@ -511,7 +670,7 @@ public class InvokerServiceImp implements InvokerService {
             String xPathExpr = "/invoker/name";
             String nodeValue = getNodeValue(file, xPathExpr);
             Objects.requireNonNull(nodeValue);
-            return nodeValue.equals(nodeName);
+            return InvokerNameUtils.sameName(nodeValue, nodeName);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/InvokerNameUtils.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/InvokerNameUtils.java
@@ -1,0 +1,81 @@
+package com.becon.opencelium.backend.utility;
+
+import com.becon.opencelium.backend.constant.RegExpression;
+import com.becon.opencelium.backend.exception.GeneralServiceException;
+import org.springframework.http.HttpStatus;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public final class InvokerNameUtils {
+
+    public static final int MAX_LENGTH = 200;
+
+    public static final String INVALID_NAME_ERROR = "INVALID_INVOKER_NAME";
+
+    private static final Pattern NAME_PATTERN = Pattern.compile(RegExpression.INVOKER_NAME_REGEX);
+    private static final Pattern WHITESPACES = Pattern.compile("[\\s\\u00A0]+");
+
+    private InvokerNameUtils() {
+    }
+
+    /**
+     * Trims the name and collapses repeated whitespace into a single space.
+     */
+    public static String normalize(String name) {
+        if (name == null) {
+            return null;
+        }
+        return WHITESPACES.matcher(name).replaceAll(" ").trim();
+    }
+
+    /**
+     * @return {@code true} if the name complies with the policy once normalized
+     */
+    public static boolean isValid(String name) {
+        String normalized = normalize(name);
+        return normalized != null
+                && !normalized.isEmpty()
+                && normalized.length() <= MAX_LENGTH
+                && NAME_PATTERN.matcher(normalized).matches();
+    }
+
+    /**
+     * Validates the name against the policy and returns it normalized.
+     */
+    public static String validate(String name) {
+        String normalized = normalize(name);
+        if (normalized == null || normalized.isEmpty()) {
+            throw invalidName("Invoker name must not be empty.");
+        }
+        if (normalized.length() > MAX_LENGTH) {
+            throw invalidName("Invoker name must not exceed " + MAX_LENGTH
+                    + " characters, but '" + normalized + "' has " + normalized.length() + ".");
+        }
+        if (!NAME_PATTERN.matcher(normalized).matches()) {
+            throw invalidName("Invoker name '" + normalized + "' is not allowed. Use letters, digits, spaces, "
+                    + "'-', '_', '(' and ')'. A dot is allowed only inside the name and not twice in a row.");
+        }
+        return normalized;
+    }
+
+    /**
+     * @return the form used to compare two invoker names, i.e. normalized and lower-cased
+     */
+    public static String canonical(String name) {
+        String normalized = normalize(name);
+        return normalized == null ? null : normalized.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * @return {@code true} if both names denote the same invoker, ignoring case and extra whitespace
+     */
+    public static boolean sameName(String left, String right) {
+        String canonicalLeft = canonical(left);
+        return canonicalLeft != null && canonicalLeft.equals(canonical(right));
+    }
+
+    private static GeneralServiceException invalidName(String message) {
+        return new GeneralServiceException(HttpStatus.BAD_REQUEST, INVALID_NAME_ERROR, message);
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/InvokerFixture.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/testutil/fixture/InvokerFixture.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 becon GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ */
+
+package com.becon.opencelium.backend.testutil.fixture;
+
+import com.becon.opencelium.backend.invoker.entity.Invoker;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public final class InvokerFixture {
+
+    public static final String DELL_WARRANTY = "Dell Warranty";
+
+    private InvokerFixture() {}
+
+    // ── Entity factories ──────────────────────────────────────────────────────
+
+
+    public static Invoker anInvokerNamed(String name) {
+        Invoker invoker = new Invoker();
+        invoker.setName(name);
+        return invoker;
+    }
+
+    public static Invoker aDellWarrantyInvoker() {
+        return anInvokerNamed(DELL_WARRANTY);
+    }
+
+    // ── File content factories ────────────────────────────────────────────────
+
+
+    public static String anInvokerFileDeclaring(String name) {
+        return "<invoker type=\"json\"><name>" + name + "</name></invoker>";
+    }
+
+    public static Document anInvokerDocumentDeclaring(String name) {
+        try {
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            return builder.parse(anInvokerFileStreamDeclaring(name));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build an invoker document for '" + name + "'", e);
+        }
+    }
+
+    public static InputStream anInvokerFileStreamDeclaring(String name) {
+        return new ByteArrayInputStream(anInvokerFileDeclaring(name).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/invoker/InvokerContainerTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/invoker/InvokerContainerTest.java
@@ -1,0 +1,92 @@
+package com.becon.opencelium.backend.unit.invoker;
+
+import com.becon.opencelium.backend.invoker.InvokerContainer;
+import com.becon.opencelium.backend.invoker.entity.Invoker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.DELL_WARRANTY;
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.aDellWarrantyInvoker;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("InvokerContainer — unit")
+class InvokerContainerTest {
+
+    private InvokerContainer container;
+
+    @BeforeEach
+    void setUp() {
+        Map<String, Invoker> invokers = new HashMap<>();
+        invokers.put(DELL_WARRANTY, aDellWarrantyInvoker());
+        container = new InvokerContainer(invokers);
+    }
+
+    // ── getByName ─────────────────────────────────────────────────────────────
+
+    @Test
+    void getByNameReturnsTheInvokerForTheExactName() {
+        assertThat(container.getByName(DELL_WARRANTY).getName()).isEqualTo(DELL_WARRANTY);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"dell warranty", "DELL WARRANTY", "Dell   Warranty", "  Dell Warranty  "})
+    void getByNameReturnsTheInvokerWhenTheStoredNameDiffersOnlyInCaseOrWhitespace(String name) {
+        // a connector in the database may refer to the invoker with a name a case-insensitive
+        // file system handed back in a different spelling
+        assertThat(container.getByName(name).getName()).isEqualTo(DELL_WARRANTY);
+    }
+
+    @Test
+    void getByNameFailsForAnUnknownInvoker() {
+        assertThatThrownBy(() -> container.getByName("Jira"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Jira");
+    }
+
+    // ── existsByName ──────────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Dell Warranty", "dell warranty", "DELL warranty", " Dell  Warranty "})
+    void existsByNameReportsTheInvokerRegardlessOfCaseAndWhitespace(String name) {
+        assertThat(container.existsByName(name)).isTrue();
+    }
+
+    @Test
+    void existsByNameReturnsFalseForAnUnknownInvoker() {
+        assertThat(container.existsByName("Dell Warranties")).isFalse();
+        assertThat(container.existsByName(null)).isFalse();
+    }
+
+    @Test
+    void existsByNameFindsAnInvokerWhoseContainerKeyDoesNotMatchItsDeclaredName() {
+        Map<String, Invoker> invokers = new HashMap<>();
+        invokers.put("dellwarranty.xml", aDellWarrantyInvoker());
+
+        assertThat(new InvokerContainer(invokers).existsByName("dell warranty")).isTrue();
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    @Test
+    void removeDropsTheInvokerWhenTheNameDiffersOnlyInCase() {
+        container.remove("DELL WARRANTY");
+
+        assertThat(container.getInvokers()).isEmpty();
+        assertThat(container.existsByName("Dell Warranty")).isFalse();
+    }
+
+    @Test
+    void removeKeepsUnrelatedInvokers() {
+        container.remove("Jira");
+        container.remove(null);
+
+        assertThat(container.getInvokers()).containsOnlyKeys("Dell Warranty");
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/invoker/InvokerServiceImpTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/invoker/InvokerServiceImpTest.java
@@ -1,0 +1,250 @@
+package com.becon.opencelium.backend.unit.invoker;
+
+import com.becon.opencelium.backend.database.mysql.service.InvokerSyncService;
+import com.becon.opencelium.backend.exception.GeneralServiceException;
+import com.becon.opencelium.backend.invoker.InvokerContainer;
+import com.becon.opencelium.backend.invoker.service.InvokerServiceImp;
+import com.becon.opencelium.backend.utility.InvokerNameUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.DELL_WARRANTY;
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.aDellWarrantyInvoker;
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.anInvokerDocumentDeclaring;
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.anInvokerFileDeclaring;
+import static com.becon.opencelium.backend.testutil.fixture.InvokerFixture.anInvokerFileStreamDeclaring;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InvokerServiceImp — unit")
+class InvokerServiceImpTest {
+
+    @TempDir
+    Path invokerFolder;
+
+    @Mock
+    private InvokerSyncService invokerSyncService;
+
+    private InvokerContainer container;
+    private InvokerServiceImp invokerService;
+
+    @BeforeEach
+    void setUp() {
+        container = new InvokerContainer(new HashMap<>());
+        invokerService = new InvokerServiceImp(container, invokerSyncService, invokerFolder);
+    }
+
+    // ── existsByFileName ──────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = {"dellwarranty.xml", "DellWarranty.xml", "DELLWARRANTY.XML"})
+    void existsByFileNameReportsTheFileRegardlessOfCase(String fileName) throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+
+        assertThat(invokerService.existsByFileName(fileName)).isTrue();
+    }
+
+    @Test
+    void existsByFileNameReportsAFileWhoseNameCarriesADot() throws IOException {
+        writeInvokerFile("api.v2.xml", "api.v2");
+
+        assertThat(invokerService.existsByFileName("api.v2.xml")).isTrue();
+        assertThat(invokerService.existsByFileName("API.V2.XML")).isTrue();
+    }
+
+    @Test
+    void existsByFileNameReturnsFalseWithoutTheXmlExtension() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+
+        // an invoker can only be stored as '<name>.xml', so there is nothing to match without it
+        assertThat(invokerService.existsByFileName("dellwarranty")).isFalse();
+    }
+
+    @Test
+    void existsByFileNameReturnsFalseWhenNoSuchFileIsStored() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+
+        assertThat(invokerService.existsByFileName("jira.xml")).isFalse();
+        assertThat(invokerService.existsByFileName("")).isFalse();
+        assertThat(invokerService.existsByFileName(null)).isFalse();
+    }
+
+    // ── deleteInvokerFile ─────────────────────────────────────────────────────
+
+    @Test
+    void deleteInvokerFileRemovesTheFileWhoseDeclaredNameDiffersOnlyInCase() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+        container.add(DELL_WARRANTY, aDellWarrantyInvoker());
+
+        invokerService.deleteInvokerFile("dell warranty");
+
+        assertThat(invokerFolder.resolve("dellwarranty.xml")).doesNotExist();
+        assertThat(container.getInvokers()).isEmpty();
+    }
+
+    // ── containerize ──────────────────────────────────────────────────────────
+
+    @Test
+    void existsByNameFindsAnInvokerLoadedFromDiskIgnoringCase() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+
+        invokerService.refresh();
+
+        assertThat(invokerService.existsByName("DELL WARRANTY")).isTrue();
+        assertThat(invokerService.findByName("dell warranty").getName()).isEqualTo(DELL_WARRANTY);
+    }
+
+    // ── createInvokerFile ─────────────────────────────────────────────────────
+
+    @Test
+    void createInvokerFileStoresTheNormalizedNameInBothTheFileNameAndTheDocument() throws IOException {
+        String name = invokerService.createInvokerFile(anInvokerDocumentDeclaring("  Dell   Warranty "));
+
+        assertThat(name).isEqualTo(DELL_WARRANTY);
+        // the file name, the '<name>' node and the container key must not drift apart
+        assertThat(invokerFolder.resolve("Dell Warranty.xml")).exists();
+        assertThat(Files.readString(invokerFolder.resolve("Dell Warranty.xml"))).contains("<name>" + DELL_WARRANTY + "</name>");
+        assertThat(container.existsByName(DELL_WARRANTY)).isTrue();
+    }
+
+    @Test
+    void createInvokerFileWritesNothingWhenTheNameBreaksThePolicy() {
+        assertThatThrownBy(() -> invokerService.createInvokerFile(anInvokerDocumentDeclaring("../../etc/passwd")))
+                .isInstanceOf(GeneralServiceException.class)
+                .extracting(e -> ((GeneralServiceException) e).getError())
+                .isEqualTo(InvokerNameUtils.INVALID_NAME_ERROR);
+
+        assertThat(invokerFolder).isEmptyDirectory();
+        assertThat(container.getInvokers()).isEmpty();
+    }
+
+    @Test
+    void createInvokerFileRejectsANameAlreadyTakenByAnotherCase() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+        invokerService.refresh();
+
+        assertThatThrownBy(() -> invokerService.createInvokerFile(anInvokerDocumentDeclaring("DELL WARRANTY")))
+                .isInstanceOf(GeneralServiceException.class)
+                .extracting(e -> ((GeneralServiceException) e).getError(),
+                        e -> ((GeneralServiceException) e).getStatus())
+                .containsExactly("INVOKER_ALREADY_EXISTS", HttpStatus.CONFLICT);
+
+        assertThat(invokerFolder.resolve("DELL WARRANTY.xml")).doesNotExist();
+    }
+
+    // ── storeInvokerFile ──────────────────────────────────────────────────────
+
+    @Test
+    void storeInvokerFileWritesTheUploadedFileAndRegistersTheInvoker() {
+        String name = invokerService.storeInvokerFile(anInvokerFileStreamDeclaring(" Dell  Warranty "), "anything.xml");
+
+        assertThat(name).isEqualTo(DELL_WARRANTY);
+        assertThat(invokerFolder.resolve("anything.xml")).exists();
+        assertThat(container.existsByName(DELL_WARRANTY)).isTrue();
+    }
+
+    @Test
+    void storeInvokerFileReplacesTheFileThatAlreadyCarriesTheInvoker() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+        invokerService.refresh();
+
+        String name = invokerService.storeInvokerFile(anInvokerFileStreamDeclaring(DELL_WARRANTY), "DELLWARRANTY.XML");
+
+        assertThat(name).isEqualTo(DELL_WARRANTY);
+        assertThat(invokerFolder.toFile().list()).containsExactly("dellwarranty.xml");
+    }
+
+    @Test
+    void storeInvokerFileRefusesASecondFileDeclaringTheSameInvoker() throws IOException {
+        writeInvokerFile("dellwarranty.xml", DELL_WARRANTY);
+        invokerService.refresh();
+
+        assertThatThrownBy(() -> invokerService.storeInvokerFile(
+                anInvokerFileStreamDeclaring("dell warranty"), "copy.xml"))
+                .isInstanceOf(GeneralServiceException.class)
+                .hasMessageContaining("dellwarranty.xml")
+                .extracting(e -> ((GeneralServiceException) e).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        assertThat(invokerFolder.resolve("copy.xml")).doesNotExist();
+    }
+
+    @Test
+    void storeInvokerFileRejectsAnInvokerThatDeclaresNoNameAtAll() {
+        InputStream withoutNameNode =
+                new ByteArrayInputStream("<invoker type=\"json\"/>".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> invokerService.storeInvokerFile(withoutNameNode, "jira.xml"))
+                .isInstanceOf(GeneralServiceException.class)
+                .extracting(e -> ((GeneralServiceException) e).getError())
+                .isEqualTo(InvokerNameUtils.INVALID_NAME_ERROR);
+
+        assertThat(invokerFolder).isEmptyDirectory();
+    }
+
+    @Test
+    void storeInvokerFileWritesNothingWhenTheNameBreaksThePolicy() {
+        assertThatThrownBy(() -> invokerService.storeInvokerFile(
+                anInvokerFileStreamDeclaring("Jira/Confluence"), "jira.xml"))
+                .isInstanceOf(GeneralServiceException.class)
+                .extracting(e -> ((GeneralServiceException) e).getError())
+                .isEqualTo(InvokerNameUtils.INVALID_NAME_ERROR);
+
+        assertThat(invokerFolder).isEmptyDirectory();
+    }
+
+    // ── toStoredFileName ──────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+            "jira.xml|jira.xml",
+            "invokers/jira.xml|jira.xml",
+            "../../etc/jira.xml|jira.xml",
+            "invokers\\jira.xml|jira.xml",
+            "  jira.xml  |jira.xml",
+            "JIRA.XML|JIRA.XML"
+    })
+    void toStoredFileNameKeepsOnlyThePlainFileName(String given, String expected) {
+        assertThat(invokerService.toStoredFileName(given)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"jira.txt", "jira", "..", ".", "invokers/", "   "})
+    void toStoredFileNameRejectsAnythingThatIsNotAPlainXmlFile(String fileName) {
+        assertThatThrownBy(() -> invokerService.toStoredFileName(fileName))
+                .isInstanceOf(GeneralServiceException.class)
+                .extracting(e -> ((GeneralServiceException) e).getError())
+                .isEqualTo("INVALID_FILE_NAME");
+    }
+
+    // ── deleteQuietly ─────────────────────────────────────────────────────────
+
+    @Test
+    void deleteQuietlySwallowsTheFailureWhenNoSuchInvokerIsStored() {
+        assertThatCode(() -> invokerService.deleteQuietly("Jira")).doesNotThrowAnyException();
+        assertThatCode(() -> invokerService.deleteQuietly(null)).doesNotThrowAnyException();
+    }
+
+    private void writeInvokerFile(String fileName, String invokerName) throws IOException {
+        Files.writeString(invokerFolder.resolve(fileName), anInvokerFileDeclaring(invokerName));
+    }
+}

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/InvokerNameUtilsTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/utility/InvokerNameUtilsTest.java
@@ -1,0 +1,186 @@
+package com.becon.opencelium.backend.unit.utility;
+
+import com.becon.opencelium.backend.exception.GeneralServiceException;
+import com.becon.opencelium.backend.utility.InvokerNameUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("InvokerNameUtils — unit")
+class InvokerNameUtilsTest {
+
+    // ── isValid ───────────────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Jira",
+            "KIX",
+            "i-doit",
+            "Dell Warranty",
+            "fake_api",
+            "SnowInventory",
+            "Invoker (v2)",
+            "OTRS 6 (test)",
+            "api.v2",
+            "a.b.c",
+            "Ürlaubsverwaltung",
+            "2go",
+            "-leading-dash",
+            "trailing_underscore_",
+            "a"
+    })
+    void isValidReturnsTrueForNameFollowingThePolicy(String name) {
+        assertThat(InvokerNameUtils.isValid(name)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            "   ",
+            ".",
+            ".jira",
+            "jira.",
+            "ji..ra",
+            "..",
+            "../../etc/passwd",
+            "Jira/Confluence",
+            "Jira\\Confluence",
+            "Jira:1",
+            "Jira*",
+            "Jira?",
+            "Jira|Confluence",
+            "Jira\"",
+            "Jira<x>",
+            "Jira%20Cloud",
+            "Jira+Cloud",
+            "Jira#1",
+            "Jira,Cloud",
+            "Jira;drop"
+    })
+    void isValidReturnsFalseForNameBreakingThePolicy(String name) {
+        assertThat(InvokerNameUtils.isValid(name)).isFalse();
+    }
+
+    @Test
+    void isValidAcceptsTheMaximumLengthAndRejectsOneCharacterMore() {
+        assertThat(InvokerNameUtils.isValid("a".repeat(InvokerNameUtils.MAX_LENGTH))).isTrue();
+        assertThat(InvokerNameUtils.isValid("a".repeat(InvokerNameUtils.MAX_LENGTH + 1))).isFalse();
+    }
+
+    @Test
+    void isValidLeavesRoomForTheXmlExtensionWithinTheFileNameLimit() {
+        // the backend stores the invoker as '<name>.xml', and file systems cap a name at 255 bytes
+        assertThat(InvokerNameUtils.MAX_LENGTH + ".xml".length()).isLessThan(250);
+    }
+
+    // ── normalize ─────────────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+            "  Jira  |Jira",
+            "Dell   Warranty|Dell Warranty",
+            "Jira|Jira"
+    })
+    void normalizeTrimsAndCollapsesWhitespace(String given, String expected) {
+        assertThat(InvokerNameUtils.normalize(given)).isEqualTo(expected);
+    }
+
+    @Test
+    void normalizeReplacesTabsAndLineBreaksWithASingleSpace() {
+        assertThat(InvokerNameUtils.normalize("\n Dell \t\r\n Warranty \t")).isEqualTo("Dell Warranty");
+    }
+
+    @Test
+    void normalizeCollapsesTheNoBreakSpaceThatComesFromPastedNames() {
+        assertThat(InvokerNameUtils.normalize("Dell\u00A0Warranty")).isEqualTo("Dell Warranty");
+        assertThat(InvokerNameUtils.isValid("Dell\u00A0Warranty")).isTrue();
+    }
+
+    @Test
+    void normalizeReturnsNullForNull() {
+        assertThat(InvokerNameUtils.normalize(null)).isNull();
+    }
+
+    // ── validate ──────────────────────────────────────────────────────────────
+
+    @Test
+    void validateReturnsTheNormalizedNameWhenNameFollowsThePolicy() {
+        assertThat(InvokerNameUtils.validate("  Dell   Warranty ")).isEqualTo("Dell Warranty");
+    }
+
+    @Test
+    void validateRejectsAnEmptyNameWithABadRequest() {
+        assertThatThrownBy(() -> InvokerNameUtils.validate("   "))
+                .isInstanceOf(GeneralServiceException.class)
+                .hasMessageContaining("must not be empty")
+                .extracting(e -> ((GeneralServiceException) e).getError(),
+                        e -> ((GeneralServiceException) e).getStatus())
+                .containsExactly(InvokerNameUtils.INVALID_NAME_ERROR, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void validateRejectsANameLongerThanTheMaximumLength() {
+        String tooLong = "a".repeat(InvokerNameUtils.MAX_LENGTH + 1);
+
+        assertThatThrownBy(() -> InvokerNameUtils.validate(tooLong))
+                .isInstanceOf(GeneralServiceException.class)
+                .hasMessageContaining(String.valueOf(InvokerNameUtils.MAX_LENGTH))
+                .extracting(e -> ((GeneralServiceException) e).getError())
+                .isEqualTo(InvokerNameUtils.INVALID_NAME_ERROR);
+    }
+
+    @Test
+    void validateRejectsANameThatWouldEscapeTheInvokerFolder() {
+        assertThatThrownBy(() -> InvokerNameUtils.validate("../../etc/passwd"))
+                .isInstanceOf(GeneralServiceException.class)
+                .extracting(e -> ((GeneralServiceException) e).getError())
+                .isEqualTo(InvokerNameUtils.INVALID_NAME_ERROR);
+    }
+
+    @Test
+    void validateAcceptsANameThatOnlyBecomesValidAfterTrimming() {
+        assertThatCode(() -> InvokerNameUtils.validate(" KIX ")).doesNotThrowAnyException();
+    }
+
+    // ── canonical / sameName ──────────────────────────────────────────────────
+
+    @Test
+    void canonicalIgnoresCaseAndExtraWhitespace() {
+        assertThat(InvokerNameUtils.canonical("  Dell   WARRANTY ")).isEqualTo("dell warranty");
+    }
+
+    @Test
+    void canonicalReturnsNullForNull() {
+        assertThat(InvokerNameUtils.canonical(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+            "Jira|jira",
+            "Jira|JIRA",
+            "Dell Warranty|dell   warranty",
+            "' KIX '|kix"
+    })
+    void sameNameMatchesNamesThatDifferOnlyInCaseOrWhitespace(String left, String right) {
+        assertThat(InvokerNameUtils.sameName(left, right)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+            "Jira|Jira Cloud",
+            "Jira|",
+            "|Jira",
+            "|"
+    })
+    void sameNameDoesNotMatchDifferentOrMissingNames(String left, String right) {
+        assertThat(InvokerNameUtils.sameName(left, right)).isFalse();
+    }
+}


### PR DESCRIPTION
## What
Enforce a naming policy for invokers and compare invoker names case-insensitively.

Invoker file handling moved out of the controllers into `InvokerService` (`createInvokerFile`, `storeInvokerFile`, `toStoredFileName`, `deleteQuietly`), dropping `FileController.saveXmlFile` and the `// TODO: add to invokerServiceImpl` it carried.

## Why
Closes OC-1558.

## How to test
```bash
# Unit tests — no Docker needed 
./gradlew test --tests "*.InvokerNameUtilsTest" --tests "*.InvokerContainerTest" --tests "*.InvokerServiceImpTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes
- [x] Tests added or updated — `InvokerNameUtilsTest`, `InvokerContainerTest`, `InvokerServiceImpTest`
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed