### PR TITLE
OC-1571: make connector decrypt all-or-nothing and stop the self-heal 

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -93,13 +93,16 @@ public class ConnectorServiceImp implements ConnectorService {
     @Override
     public Optional<Connector> findById(int id) {
         Optional<Connector> optional = connectorRepository.findById(id);
-        try {
-            optional.ifPresent(this::decrypt);
+        if (optional.isEmpty()) {
             return optional;
-        } catch (RuntimeException e) {
-            Connector saved = save(optional.get());
-            return Optional.of(saved);
         }
+        Connector connector = optional.get();
+        try {
+            decrypt(connector);
+        } catch (RuntimeException e) {
+            repairRequestData(connector);
+        }
+        return optional;
     }
 
     @Override
@@ -441,6 +444,38 @@ public class ConnectorServiceImp implements ConnectorService {
 
     private void decrypt(Connector connector) {
         List<RequestData> requestData = connector.getRequestData();
-        requestData.forEach(e -> e.setValue(encoder.decrypt(e.getValue())));
+        if (requestData == null) {
+            return;
+        }
+        List<String> decrypted = new ArrayList<>(requestData.size());
+        requestData.forEach(e -> decrypted.add(encoder.decrypt(e.getValue())));
+        for (int i = 0; i < requestData.size(); i++) {
+            requestData.get(i).setValue(decrypted.get(i));
+        }
+    }
+
+    private void repairRequestData(Connector connector) {
+        List<RequestData> requestData = connector.getRequestData();
+        if (requestData == null) {
+            return;
+        }
+        List<String> plaintext = new ArrayList<>(requestData.size());
+        List<RequestData> repaired = new ArrayList<>();
+        for (RequestData entry : requestData) {
+            String stored = entry.getValue();
+            try {
+                plaintext.add(encoder.decrypt(stored));
+            } catch (RuntimeException e) {
+                plaintext.add(stored);
+                entry.setValue(encoder.encrypt(stored));
+                repaired.add(entry);
+            }
+        }
+        if (!repaired.isEmpty()) {
+            requestDataService.saveAll(repaired);
+        }
+        for (int i = 0; i < requestData.size(); i++) {
+            requestData.get(i).setValue(plaintext.get(i));
+        }
     }
 }


### PR DESCRIPTION
## What
`ConnectorServiceImp.decrypt` is now all-or-nothing — values are staged and written back only once the whole connector could be read — and tolerates a `null` request data list, matching `encrypt`. The `findById` recovery path moves from `save()` to a new `repairRequestData`, which encrypts only the values that are not already encrypted.

## Why
Closes OC-1571.

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed
