### PR TITLE
OC-1572: name the connector and field when a stored credential cannot be decrypted

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionConstant.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionConstant.java
@@ -49,6 +49,7 @@ public interface ExceptionConstant {
 
     String CONNECTOR_NOT_FOUND = "CONNECTOR_NOT_FOUND";
     String CONNECTOR_ALREADY_EXISTS = "CONNECTOR_ALREADY_EXISTS";
+    String DECRYPTION_FAILED = "DECRYPTION_FAILED";
 
     // ----------------------------------------- Connection ----------------------------------------------- //
     String CONNECTION_NOT_FOUND = "CONNECTION_NOT_FOUND";

--- a/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/constant/ExceptionMessages.java
@@ -5,6 +5,7 @@ package com.becon.opencelium.backend.constant;
  */
 public interface ExceptionMessages {
     String REQUIRED_DATA_NOT_FOUND = "'%s' required data not found";
+    String REQUEST_DATA_DECRYPTION_FAILED = "Failed to decrypt request data '%s' of connector (id=%s)";
     String MASTER_PASSWORD_IS_MISSING_IN_HEADER = "master_password is missing or empty";
     String MASTER_PASSWORD_WRONG = "Invalid master password";
     String LOG_NOT_FOUND = "Log not found for execution: %d";

--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectorServiceImp.java
@@ -28,6 +28,7 @@ import com.becon.opencelium.backend.exception.ConnectorAlreadyExistsException;
 import com.becon.opencelium.backend.exception.ConnectorNotFoundException;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.exception.StorageException;
+import com.becon.opencelium.backend.exception.WrongDecryptException;
 import com.becon.opencelium.backend.execution.rdata.RequiredDataService;
 import com.becon.opencelium.backend.execution.rdata.RequiredDataServiceImp;
 import com.becon.opencelium.backend.invoker.InvokerRequestBuilder;
@@ -448,7 +449,17 @@ public class ConnectorServiceImp implements ConnectorService {
             return;
         }
         List<String> decrypted = new ArrayList<>(requestData.size());
-        requestData.forEach(e -> decrypted.add(encoder.decrypt(e.getValue())));
+        for (RequestData entry : requestData) {
+            try {
+                decrypted.add(encoder.decrypt(entry.getValue()));
+            } catch (RuntimeException e) {
+                // Which row blocked the read is the whole question during an incident: without it
+                // the offending value has to be found by scanning the table by hand.
+                throw new WrongDecryptException(
+                        ExceptionMessages.REQUEST_DATA_DECRYPTION_FAILED
+                                .formatted(entry.getField(), connector.getId()), e);
+            }
+        }
         for (int i = 0; i < requestData.size(); i++) {
             requestData.get(i).setValue(decrypted.get(i));
         }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/exception/WrongDecryptException.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/exception/WrongDecryptException.java
@@ -5,4 +5,12 @@ public class WrongDecryptException extends RuntimeException{
     public WrongDecryptException(Throwable cause) {
         super(cause);
     }
+
+    public WrongDecryptException(String message) {
+        super(message);
+    }
+
+    public WrongDecryptException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/backend/src/main/java/com/becon/opencelium/backend/exception/handler/GlobalExceptionHandler.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/exception/handler/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.becon.opencelium.backend.exception.handler;
 
+import com.becon.opencelium.backend.constant.ExceptionConstant;
 import com.becon.opencelium.backend.exception.GeneralServiceException;
 import com.becon.opencelium.backend.exception.StorageFileNotFoundException;
 import com.becon.opencelium.backend.exception.JumpValidationException;
+import com.becon.opencelium.backend.exception.WrongDecryptException;
 import com.becon.opencelium.backend.ocel.exception.InvalidExpressionException;
 import com.becon.opencelium.backend.resource.error.ErrorResource;
 import com.becon.opencelium.backend.resource.error.JumpValidationErrorResource;
@@ -51,6 +53,16 @@ public class GlobalExceptionHandler {
         errorResource.setStatus(ex.getStatus());
         return ResponseEntity.status(ex.getStatus())
                 .body(errorResource);
+    }
+
+    @ExceptionHandler(WrongDecryptException.class)
+    public ResponseEntity<ErrorResource> handleWrongDecryptException(WrongDecryptException ex) {
+        ErrorResource errorResource = new ErrorResource();
+        errorResource.setMessage(ex.getMessage());
+        errorResource.setError(ExceptionConstant.DECRYPTION_FAILED);
+        errorResource.setTimestamp(Date.from(Instant.now()));
+        errorResource.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.internalServerError().body(errorResource);
     }
 
     @ExceptionHandler(StorageFileNotFoundException.class)

--- a/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/ConnectorHealthMonitor.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/scheduler/ConnectorHealthMonitor.java
@@ -70,7 +70,7 @@ public class ConnectorHealthMonitor {
             // decrypted the sweep is skipped entirely and statuses stay as they are.
             connectors = new ArrayList<>(connectorService.findAll());
         } catch (RuntimeException e) {
-            log.warn("Connector health sweep skipped: connectors could not be loaded", e);
+            log.warn("Connector health sweep skipped: connectors could not be loaded - {}", e.getMessage(), e);
             return;
         }
         Collections.shuffle(connectors);

--- a/src/backend/src/main/java/com/becon/opencelium/backend/utility/crypto/Encoder.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/utility/crypto/Encoder.java
@@ -1,6 +1,7 @@
 package com.becon.opencelium.backend.utility.crypto;
 
 import com.becon.opencelium.backend.constant.AppYamlPath;
+import com.becon.opencelium.backend.exception.WrongDecryptException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -62,12 +63,15 @@ public class Encoder {
             decryptCipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivspec);
             byte[] decryptedText = decryptCipher.doFinal(encryptedData, 16, encryptedData.length - 16);  // Decrypt data after IV
             return new String(decryptedText, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new WrongDecryptException(
+                    "Decryption failed: the value is not valid Base64 ciphertext.", e);
         } catch (BadPaddingException e) {
-            throw new RuntimeException("Decryption failed due to bad padding. Check if the key is correct.");
+            throw new WrongDecryptException("Decryption failed due to bad padding. Check if the key is correct.");
         } catch (IllegalBlockSizeException e) {
-            throw new RuntimeException("Decryption failed due to illegal block size. Data may be corrupted.", e);
+            throw new WrongDecryptException("Decryption failed due to illegal block size. Data may be corrupted.", e);
         } catch (InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException e) {
-            throw new RuntimeException("Error during decryption", e);
+            throw new WrongDecryptException("Error during decryption", e);
         }
     }
 


### PR DESCRIPTION
## What
An unreadable `request_data` value now says which connector and which field it belongs to. `Encoder.decrypt` raises `WrongDecryptException` for a Base64 rejection instead of letting `IllegalArgumentException` escape, `ConnectorServiceImp.decrypt` adds the connector id and field name, `GlobalExceptionHandler` maps the failure to an `ErrorResource` carrying a `DECRYPTION_FAILED` code, and the health sweep's skip warning repeats that message.

## Why
Closes OC-1572

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed