### PR TITLE
Changed log on updating connection/template to current version

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/database/mysql/service/ConnectionServiceImp.java
@@ -575,7 +575,7 @@ public class ConnectionServiceImp implements ConnectionService {
                         connectionMngService.save(connectionMng);
                     }
 
-                    log.info("Connection[id={}, name={}, version={}] successfully updated to {} version", connection.getId(), connection.getTitle(), connection.getOcVersion(), targetVersion);
+                    log.info("Connection[id={}, name={}, version={}] successfully updated to current version", connection.getId(), connection.getTitle(), connection.getOcVersion());
                 } catch (Exception e) {
                     log.error("Failed to update Connection[id={}, name={}, version={}]", connection.getId(), connection.getTitle(), connection.getOcVersion(), e);
                     continue;

--- a/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateServiceImp.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/template/service/TemplateServiceImp.java
@@ -234,7 +234,7 @@ public class TemplateServiceImp implements TemplateService {
                                 template.setVersion(targetVersion);
                                 FileBackupManager.doBackup(backup, oldVersion, targetVersion);
                                 save(template, fileName);
-                                log.info("Template[id={}, name={}] is successfully updated to {} version", template.getTemplateId(), template.getName(), targetVersion);
+                                log.info("Template[id={}, name={}] is successfully updated to current version", template.getTemplateId(), template.getName());
                             });
                 } catch (Exception e) {
                     log.error("Failed to update Template[id={}, name={}]", template.getTemplateId(), template.getName(), e);


### PR DESCRIPTION
## What
On 5.0, we update connection and templates to 4.8 version only, so there are logs that users can misunderstand it. So i remove target version on logs

## Why
Improves log comprehance

## Checklist
[x] Self-reviewed the diff
[x] WIP commits squashed