### PR TITLE
OC-1596: Write a separating space when merging into an empty-valued YAML key

### DIFF
--- a/src/backend/src/main/java/com/becon/opencelium/backend/appYml/service/ApplicationConfigServiceImpl.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/appYml/service/ApplicationConfigServiceImpl.java
@@ -24,6 +24,9 @@ import com.becon.opencelium.backend.exception.ApplicationConfigWriteException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.lowlevel.Compose;
+import org.snakeyaml.engine.v2.nodes.Node;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
@@ -98,7 +101,31 @@ public class ApplicationConfigServiceImpl implements ApplicationConfigService {
         if (!effective.disablePaths.isEmpty()) {
             merged = writer.commentOut(merged, effective.disablePaths);
         }
+
+        verifyParseable(merged);
+
         fileWriter.write(target, merged);
+    }
+
+    /**
+     * Re-parses the merged text exactly as the Spring config loader would, and
+     * refuses the patch if it no longer forms valid YAML.
+     */
+    private void verifyParseable(String merged) {
+        LoadSettings settings = LoadSettings.builder().build();
+        try {
+            // composeAllFromString is lazy: it parses only as the Iterable is
+            // advanced. The loop below is what performs the parse — without it
+            // this method silently accepts anything.
+            for (Node ignored : new Compose(settings).composeAllFromString(merged)) {
+                // no-op: parsing is the assertion
+            }
+        } catch (Exception e) {
+            throw new ApplicationConfigWriteException(
+                    "Refusing to save: applying this change would produce an invalid "
+                            + "application.yml, so it was not written and the file on disk is "
+                            + "unchanged. " + YamlShadow.describeParseFailure(merged, e), e);
+        }
     }
 
     // ── Patch payload parsing ────────────────────────────────────────────────

--- a/src/backend/src/main/java/com/becon/opencelium/backend/appYml/service/YamlConfigWriter.java
+++ b/src/backend/src/main/java/com/becon/opencelium/backend/appYml/service/YamlConfigWriter.java
@@ -244,13 +244,31 @@ public class YamlConfigWriter {
         Node value = tuple.getValueNode();
         int keyStartLine = markLine(keyScalar);
         int keyIndent = markColumn(keyScalar);
+
+        boolean newIsContainer = newValue.isObject() || newValue.isArray();
+        boolean oldIsScalar = value instanceof ScalarNode;
+        boolean oldIsEmpty = value instanceof ScalarNode s && s.getValue().isEmpty();
+
+        if (oldIsEmpty) {
+            // A key with no value (`username:`, `url: `) has no text on disk to
+            // overwrite, and snakeyaml gives its empty scalar degenerate marks:
+            // a zero-width point immediately after the `:` — or, when a trailing
+            // comment follows the colon, a point on the *next* line entirely.
+            // Splicing at either would produce `username:Test123` or swallow the following line
+            if (!newIsContainer) {
+                edits.add(new FillEmptyValue(
+                        markEndLine(keyScalar), markEndColumn(keyScalar), emitScalar(newValue)));
+                return;
+            }
+            edits.add(new ReplaceLineRange(
+                    keyStartLine, keyStartLine, renderEntry(keyScalar.getValue(), newValue, keyIndent)));
+            return;
+        }
+
         int valueStartLine = markLine(value);
         int valueEndLine = markEndLine(value);
         int valueStartCol = markColumn(value);
         int valueEndCol = markEndColumn(value);
-
-        boolean newIsContainer = newValue.isObject() || newValue.isArray();
-        boolean oldIsScalar = value instanceof ScalarNode;
 
         if (oldIsScalar && !newIsContainer && valueStartLine == valueEndLine && valueStartLine == keyStartLine) {
             String emitted = emitScalar(newValue);
@@ -347,7 +365,8 @@ public class YamlConfigWriter {
         return new ApplicationConfigWriteException("YAML node has no source position");
     }
 
-    private sealed interface Edit permits ReplaceInLine, ReplaceLineRange, InsertAfter, CommentLineRange {
+    private sealed interface Edit
+            permits ReplaceInLine, FillEmptyValue, ReplaceLineRange, InsertAfter, CommentLineRange {
         int sortKey();
 
         void apply(List<String> lines);
@@ -398,6 +417,43 @@ public class YamlConfigWriter {
             int safeStart = Math.min(startCol, safeEnd);
             String replaced = original.substring(0, safeStart) + newText + original.substring(safeEnd);
             lines.set(line, replaced);
+        }
+    }
+
+    /**
+     * Writes a value into a key that currently has none. Unlike
+     * {@link ReplaceInLine} this does not trust the value node's marks — an
+     * empty scalar has none worth trusting — but re-finds the {@code :} from
+     * the end of the key and rebuilds the line around it, guaranteeing exactly
+     * one space between colon and value. Any whitespace already sitting after
+     * the colon is collapsed into that single space, and a trailing comment is
+     * preserved with a space of its own.
+     */
+    private record FillEmptyValue(int line, int keyEndCol, String newText) implements Edit {
+        @Override
+        public int sortKey() {
+            return line;
+        }
+
+        @Override
+        public void apply(List<String> lines) {
+            if (line < 0 || line >= lines.size()) {
+                return;
+            }
+            String original = lines.get(line);
+            int colon = original.indexOf(':', Math.min(Math.max(keyEndCol, 0), original.length()));
+            if (colon < 0) {
+                throw new ApplicationConfigWriteException(
+                        "Cannot write value: no ':' found on line " + (line + 1) + ": " + original);
+            }
+            int tail = colon + 1;
+            while (tail < original.length()
+                    && (original.charAt(tail) == ' ' || original.charAt(tail) == '\t')) {
+                tail++;
+            }
+            String rest = original.substring(tail);
+            lines.set(line, original.substring(0, colon + 1) + " " + newText
+                    + (rest.isEmpty() ? "" : " " + rest));
         }
     }
 

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/applicationConfig/ApplicationConfigServiceImplTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/applicationConfig/ApplicationConfigServiceImplTest.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -399,6 +401,104 @@ class ApplicationConfigServiceImplTest {
     }
 
     @Test
+    void patchWritesSeparatingSpaceWhenTargetKeyHasNoValueOnDisk(@TempDir Path tempDir) throws IOException {
+        // Regression: the empty scalar's marks collapse to a point right after
+        // the `:`, so the old in-line splice wrote `url:https://…` and the file
+        // stopped parsing. `url: ` (trailing space) is the shipped form.
+        Path target = tempDir.resolve("application.yml");
+        Files.writeString(target, "opencelium:\n"
+                + "  notification:\n"
+                + "    tools:\n"
+                + "      incoming-webhook:\n"
+                + "        url: \n"
+                + "        enabled: true\n", StandardCharsets.UTF_8);
+
+        JsonNode fields = json.readTree("""
+                [ { "path": "opencelium.notification.tools.incoming-webhook.url",
+                    "status": "active", "value": "https://hooks.example.com/abc" } ]
+                """);
+        service(target, tempDir).patch(fields);
+
+        String after = Files.readString(target);
+        assertThat(after).contains("        url: https://hooks.example.com/abc");
+        assertThat(after).doesNotContain("url:https");
+        assertThat(parse(after)).isNotNull();
+    }
+
+    @Test
+    void patchWritesParseableYamlWhenCommentedMailBlockIsActivatedWithCredentials(@TempDir Path tempDir)
+            throws IOException {
+        // The SMTP GUI save flow end to end: uncomment the bundled mail block,
+        // then write username/password into its empty keys.
+        Path target = tempDir.resolve("application.yml");
+        Files.writeString(target, """
+                spring:
+                  application:
+                    name: opencelium
+                #  mail:
+                #    host: smtp.gmail.com
+                #    port: 587
+                #    username:
+                #    password:
+                """, StandardCharsets.UTF_8);
+
+        JsonNode fields = json.readTree("""
+                [ { "path": "spring.mail", "status": "active" },
+                  { "path": "spring.mail.username", "status": "active", "value": "user@example.com" },
+                  { "path": "spring.mail.password", "status": "active", "value": "Test123" } ]
+                """);
+        service(target, tempDir).patch(fields);
+
+        String after = Files.readString(target);
+        assertThat(after).doesNotContain("username:user");
+        assertThat(after).doesNotContain("password:Test123");
+        assertThat(parse(after)).isNotNull();
+        assertThat(leaf(after, "spring", "mail", "username")).isEqualTo("user@example.com");
+        assertThat(leaf(after, "spring", "mail", "password")).isEqualTo("Test123");
+        assertThat(leaf(after, "spring", "mail", "port")).isEqualTo(587);
+        assertThat(leaf(after, "spring", "application", "name")).isEqualTo("opencelium");
+    }
+
+    @Test
+    void patchLeavesFileUntouchedAndThrowsWhenMergeWouldProduceInvalidYaml(@TempDir Path tempDir)
+            throws IOException {
+        // A corrupt application.yml stops the app from booting, which takes the
+        // GUI down with it — so an unparseable merge must never reach disk.
+        Path target = tempDir.resolve("application.yml");
+        String original = """
+                spring:
+                  mail:
+                    host: smtp.gmail.com
+                    username:
+                """;
+        Files.writeString(target, original, StandardCharsets.UTF_8);
+
+        // Exactly what the old splice emitted: no space after the colon, so the
+        // line reads as a bare scalar among sibling keys and the file stops
+        // parsing. The stub stands in for any future splicing defect.
+        YamlConfigWriter corrupting = new YamlConfigWriter() {
+            @Override
+            public String merge(String originalYaml, JsonNode patch) {
+                return "spring:\n  mail:\n    host: smtp.gmail.com\n    username:Test123\n";
+            }
+        };
+        ApplicationConfigServiceImpl service = new ApplicationConfigServiceImpl(
+                new YamlConfigReader(), corrupting,
+                new AtomicFileWriter(tempDir.resolve("backups"), 10), target.toString());
+
+        JsonNode fields = json.readTree("""
+                [ { "path": "spring.mail.username", "status": "active", "value": "Test123" } ]
+                """);
+
+        assertThatThrownBy(() -> service.patch(fields))
+                .isInstanceOf(ApplicationConfigWriteException.class)
+                .hasMessageContaining("Refusing to save")
+                .hasMessageContaining("unchanged");
+
+        assertThat(Files.readString(target)).isEqualTo(original);
+    }
+
+    @Test
     void patchThrowsWhenFieldsIsNotArray(@TempDir Path tempDir) throws IOException {
         Path target = tempDir.resolve("application.yml");
         Files.writeString(target, "key: value\n", StandardCharsets.UTF_8);
@@ -423,5 +523,20 @@ class ApplicationConfigServiceImplTest {
             }
         }
         return null;
+    }
+
+    /** Parses the file the way Spring's config loader would; throws on invalid YAML. */
+    private static Object parse(String yaml) {
+        return new Load(LoadSettings.builder().build()).loadFromString(yaml);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object leaf(String yaml, String... path) {
+        Object current = parse(yaml);
+        for (String segment : path) {
+            assertThat(current).isInstanceOf(java.util.Map.class);
+            current = ((java.util.Map<String, Object>) current).get(segment);
+        }
+        return current;
     }
 }

--- a/src/backend/src/test/java/com/becon/opencelium/backend/unit/applicationConfig/YamlConfigWriterTest.java
+++ b/src/backend/src/test/java/com/becon/opencelium/backend/unit/applicationConfig/YamlConfigWriterTest.java
@@ -14,8 +14,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -381,6 +384,175 @@ class YamlConfigWriterTest {
                 .isInstanceOf(ApplicationConfigWriteException.class);
     }
 
+    // ── Empty-valued keys ────────────────────────────────────────────────────
+    //
+    // A key with no value on disk (`username:`) is where the SMTP GUI save used
+    // to brick the installation: snakeyaml reports the empty scalar's start and
+    // end marks as a single zero-width point immediately after the `:`, so an
+    // in-line splice at that range produced `username:Test123` — no separating
+    // space, no longer valid YAML, and the application would not boot.
+
+    @Test
+    void mergeSeparatesValueFromColonWhenExistingKeyHasNoValue() throws Exception {
+        String original = """
+                spring:
+                  mail:
+                    username:
+                    password:
+                    host: smtp.gmail.com
+                """;
+        JsonNode patch = json.readTree("""
+                { "spring": { "mail": { "username": "Test123", "password": "s3cret" } } }
+                """);
+
+        String merged = writer.merge(original, patch);
+
+        assertThat(merged).contains("    username: Test123");
+        assertThat(merged).contains("    password: s3cret");
+        assertThat(merged).doesNotContain("username:Test123");
+        assertThat(parse(merged)).isNotNull();
+        assertThat(leaf(merged, "spring", "mail", "username")).isEqualTo("Test123");
+        assertThat(leaf(merged, "spring", "mail", "host")).isEqualTo("smtp.gmail.com");
+    }
+
+    @Test
+    void mergeWritesSingleSpaceWhenExistingKeyHasTrailingSpaceAfterColon() throws Exception {
+        // `url: ` (one trailing space) is how the bundled file ships the
+        // incoming-webhook URL — and it is active out of the box.
+        String original = "opencelium:\n"
+                + "  notification:\n"
+                + "    tools:\n"
+                + "      incoming-webhook:\n"
+                + "        url: \n"
+                + "        enabled: true\n";
+        JsonNode patch = json.readTree("""
+                { "opencelium": { "notification": { "tools": {
+                    "incoming-webhook": { "url": "https://hooks.example.com/abc" } } } } }
+                """);
+
+        String merged = writer.merge(original, patch);
+
+        assertThat(merged).contains("        url: https://hooks.example.com/abc\n");
+        assertThat(merged).doesNotContain("url:  ");
+        assertThat(merged).contains("        enabled: true");
+        assertThat(parse(merged)).isNotNull();
+    }
+
+    @Test
+    void mergeCollapsesPaddingWhenExistingKeyHasSeveralSpacesAfterColon() throws Exception {
+        String original = """
+                spring:
+                  mail:
+                    username:
+                """.replace("username:", "username:     ");
+        JsonNode patch = json.readTree("""
+                { "spring": { "mail": { "username": "Test123" } } }
+                """);
+
+        String merged = writer.merge(original, patch);
+
+        assertThat(merged).contains("    username: Test123");
+        assertThat(merged).doesNotContain("username:  ");
+        assertThat(parse(merged)).isNotNull();
+    }
+
+    @Test
+    void mergeKeepsCommentAndSiblingWhenExistingKeyHasInlineCommentAfterColon() throws Exception {
+        // With a trailing comment snakeyaml puts the empty scalar's marks on the
+        // *next* line, so the old line-range fallback deleted the sibling below
+        // it. Both the comment and the sibling must survive.
+        String original = """
+                spring:
+                  mail:
+                    username:   # set me from the GUI
+                    host: smtp.gmail.com
+                """;
+        JsonNode patch = json.readTree("""
+                { "spring": { "mail": { "username": "Test123" } } }
+                """);
+
+        String merged = writer.merge(original, patch);
+
+        assertThat(merged).contains("    username: Test123 # set me from the GUI");
+        assertThat(merged).contains("    host: smtp.gmail.com");
+        assertThat(parse(merged)).isNotNull();
+        assertThat(leaf(merged, "spring", "mail", "host")).isEqualTo("smtp.gmail.com");
+    }
+
+    @Test
+    void mergeWritesNonStringScalarsWhenExistingKeyHasNoValue() throws Exception {
+        String original = """
+                spring:
+                  mail:
+                    port:
+                    debug:
+                """;
+        JsonNode patch = json.readTree("""
+                { "spring": { "mail": { "port": 587, "debug": true } } }
+                """);
+
+        String merged = writer.merge(original, patch);
+
+        assertThat(merged).contains("    port: 587");
+        assertThat(merged).contains("    debug: true");
+        assertThat(parse(merged)).isNotNull();
+    }
+
+    @Test
+    void mergeKeepsSiblingsWhenEmptyKeyIsReplacedByNestedMapping() throws Exception {
+        String original = """
+                spring:
+                  mail:
+                    properties:
+                    host: smtp.gmail.com
+                """;
+        JsonNode patch = json.readTree("""
+                { "spring": { "mail": { "properties": { "smtp": { "auth": true } } } } }
+                """);
+
+        String merged = writer.merge(original, patch);
+
+        assertThat(parse(merged)).isNotNull();
+        assertThat(merged).contains("    host: smtp.gmail.com");
+        assertThat(leaf(merged, "spring", "mail", "properties", "smtp", "auth")).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void mergeProducesParseableYamlWhenUncommentedMailBlockHasEmptyCredentialKeys() throws Exception {
+        // The exact sequence ApplicationConfigServiceImpl.patch() runs for an
+        // SMTP save: activate the bundled (commented) mail block, then merge the
+        // user's credentials into its empty username/password keys.
+        String original = """
+                spring:
+                  application:
+                    name: opencelium
+                #  mail:
+                #    host: smtp.gmail.com
+                #    port: 587
+                #    username:
+                #    password:
+                """;
+
+        String activated = writer.uncomment(original, List.of(
+                "spring.mail", "spring.mail.host", "spring.mail.port",
+                "spring.mail.username", "spring.mail.password"));
+        JsonNode patch = json.readTree("""
+                { "spring": { "mail": { "username": "user@example.com", "password": "Test123" } } }
+                """);
+
+        String merged = writer.merge(activated, patch);
+
+        assertThat(parse(merged)).isNotNull();
+        assertThat(merged).contains("    username: user@example.com");
+        assertThat(merged).contains("    password: Test123");
+        assertThat(merged).doesNotContain("username:user");
+        assertThat(merged).doesNotContain("password:Test123");
+        assertThat(leaf(merged, "spring", "mail", "username")).isEqualTo("user@example.com");
+        assertThat(leaf(merged, "spring", "mail", "password")).isEqualTo("Test123");
+        assertThat(leaf(merged, "spring", "mail", "port")).isEqualTo(587);
+        assertThat(leaf(merged, "spring", "application", "name")).isEqualTo("opencelium");
+    }
+
     @Test
     void commentOutThrowsWhenPathDoesNotExist() {
         String original = """
@@ -390,5 +562,22 @@ class YamlConfigWriterTest {
 
         assertThatThrownBy(() -> writer.commentOut(original, List.of("server.missing")))
                 .isInstanceOf(ApplicationConfigWriteException.class);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /** Parses {@code yaml} the way Spring's config loader would; fails the test on invalid YAML. */
+    private static Object parse(String yaml) {
+        return new Load(LoadSettings.builder().build()).loadFromString(yaml);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object leaf(String yaml, String... path) {
+        Object current = parse(yaml);
+        for (String segment : path) {
+            assertThat(current).isInstanceOf(Map.class);
+            current = ((Map<String, Object>) current).get(segment);
+        }
+        return current;
     }
 }


### PR DESCRIPTION
## What
Fix `YamlConfigWriter.planReplace()` so merging a value into a key that has none on disk (`username:`) emits `key: value` instead of `key:value`. Add a re-parse guard in `ApplicationConfigServiceImpl.patch()` that rejects the patch before
writing if the merged text is not valid YAML.

## Why
Closes OC-1596.

## How to test
```bash
# Writer — empty-value merge, all three empty forms + the SMTP uncomment-then-merge sequence
./gradlew test --tests "*.YamlConfigWriterTest"

# Service — GUI save flow end to end, and the write guard
./gradlew test --tests "*.ApplicationConfigServiceImplTest"
```

## Checklist
- [x] Self-reviewed the diff
- [x] `./gradlew test` passes locally
- [x] Tests added or updated — `YamlConfigWriterTest` (7), `ApplicationConfigServiceImplTest` (3)
- [x] No secrets, debug logs, or commented-out code
- [x] WIP commits squashed